### PR TITLE
basic composed schema gen

### DIFF
--- a/truflation/schema_gen/cli/README.md
+++ b/truflation/schema_gen/cli/README.md
@@ -1,0 +1,19 @@
+# Schema Gen CLI
+
+The schema gen CLI is a toy tool to display generating Kuneiform schemas from a template. It has 3 flags:
+
+- `name`: the name that the schema should be given
+- `import`: the schemas that are being imported and their weights to the "compose_truflation_streams". The name and weight should be separated by colon, and the streams should be separated by column: "xdbid:10,ydbid:25".
+- `out`: the name of the output schema file
+
+To use it, simply run:
+
+```go
+go run ./cli.go -name mydb -import xdbid:10,ydbid:25 -out mydb.json
+```
+
+The outputs are in JSON, which can be deployed to Kwil using the CLI's JSON flag:
+
+```
+kwil-cli database deploy ./mydb.json --type json
+```

--- a/truflation/schema_gen/cli/cli.go
+++ b/truflation/schema_gen/cli/cli.go
@@ -1,0 +1,67 @@
+// package cli contains a command line tool for generating schemas
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	schemagen "github.com/kwilteam/kwil-db/truflation/schema_gen"
+)
+
+func main() {
+	// Define flags
+	nameFlag := flag.String("name", "World", "a name")
+	importFlag := flag.String("import", "", "imports and weights, separated by commas")
+	outFlag := flag.String("out", "output.txt", "output file")
+
+	// Parse flags
+	flag.Parse()
+
+	weightMap := make(map[string]int64)
+
+	// Assuming the importFlag follows the format "import1:weight1,import2:weight2"
+	if *importFlag != "" {
+		importsAndWeights := strings.Split(*importFlag, ",")
+		for _, iw := range importsAndWeights {
+			iwSplit := strings.Split(iw, ":")
+			if len(iwSplit) != 2 {
+				fmt.Println("Invalid import format")
+				return
+			}
+
+			intWeight, err := strconv.ParseInt(iwSplit[1], 10, 64)
+			if err != nil {
+				fmt.Println("Invalid weight: ", err)
+				return
+			}
+
+			weightMap[iwSplit[0]] = intWeight
+		}
+	}
+
+	// Generate schema
+	schema, err := schemagen.GenerateComposedSchema(*nameFlag, weightMap)
+	if err != nil {
+		fmt.Println("Error generating schema: ", err)
+		return
+	}
+
+	// Write schema to file
+	bts, err := json.Marshal(schema)
+	if err != nil {
+		fmt.Println("Error marshalling schema: ", err)
+		return
+	}
+
+	err = os.WriteFile(*outFlag, bts, 0644)
+	if err != nil {
+		fmt.Println("Error writing schema to file: ", err)
+		return
+	}
+
+	fmt.Println("Schema written to ", *outFlag)
+}

--- a/truflation/schema_gen/composed_template.json
+++ b/truflation/schema_gen/composed_template.json
@@ -1,0 +1,40 @@
+{
+    "owner": "",
+    "name": "composed_example",
+    "actions": [
+      {
+        "name": "get_index",
+        "inputs": [
+          "$date",
+          "$date_to"
+        ],
+        "public": true,
+        "mutability": "view",
+        "auxiliaries": null,
+        "statements": [
+          "streams.get_index($date,$date_to);"
+        ]
+      },
+      {
+        "name": "get_value",
+        "inputs": [
+          "$date",
+          "$date_to"
+        ],
+        "public": true,
+        "mutability": "view",
+        "auxiliaries": null,
+        "statements": [
+          "streams.get_value($date,$date_to);"
+        ]
+      }
+    ],
+    "extensions": [
+      {
+        "name": "compose_truflation_streams",
+        "config": [],
+        "alias": "streams"
+      }
+    ]
+  }
+  

--- a/truflation/schema_gen/composed_template.kf
+++ b/truflation/schema_gen/composed_template.kf
@@ -1,0 +1,19 @@
+ // this file exists purely for informational purposes
+ // it is the unparsed version of composed_template.json,
+ // which is a template used to generate schemas from.
+ // schemas can be parsed at https://ide.kwil.com,
+ // and right-clicking the files in the "compiled files"
+ // section of the third tab
+ database composed_example;
+
+ use compose_truflation_streams as streams;
+
+ action get_index($date, $date_to) public view {
+     streams.get_index($date, $date_to);
+     // we ensure no other extension or query is called after this
+ }
+
+ action get_value($date, $date_to) public view {
+     streams.get_value($date, $date_to);
+     // we ensure no other extension or query is called after this
+ }

--- a/truflation/schema_gen/schema.go
+++ b/truflation/schema_gen/schema.go
@@ -1,0 +1,59 @@
+package schemagen
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kwilteam/kwil-db/core/types/transactions"
+)
+
+//go:embed composed_template.json
+var template []byte
+
+// GenerateComposedSchema generates a schema that composes across other streams.
+// It can be given a map[string]int64, which maps the streams it imports to
+// the weight it should be given.
+func GenerateComposedSchema(name string, imports map[string]int64) (*transactions.Schema, error) {
+	var schema transactions.Schema
+	err := json.Unmarshal(template, &schema)
+	if err != nil {
+		return nil, err
+	}
+
+	schema.Name = name
+
+	count := 0
+	found := false
+	for _, ext := range schema.Extensions {
+		// If the extension is a compose_truflation_streams extension, we can
+		// add the imports to it.
+		if ext.Name == "compose_truflation_streams" { // TODO: we should use a global constant string for this once other PR is merged
+			found = true
+			for stream, weight := range imports {
+
+				// as discussed here: https://github.com/truflation/tsn-db/pull/52#discussion_r1506333753
+				// we need to make two entries for id and weight
+
+				ext.Config = append(ext.Config, &transactions.ExtensionConfig{
+					Argument: fmt.Sprintf("stream_%d_id", count),
+					Value:    stream,
+				})
+
+				ext.Config = append(ext.Config, &transactions.ExtensionConfig{
+					Argument: fmt.Sprintf("stream_%d_weight", count),
+					Value:    fmt.Sprint(weight),
+				})
+
+				count++
+			}
+		}
+	}
+
+	// if not found, we need to add it
+	if !found {
+		return nil, fmt.Errorf("compose_truflation_streams extension not found")
+	}
+
+	return &schema, nil
+}


### PR DESCRIPTION
Putting this up as an example, however I am unsure if you guys want to use this, it is just a suggestion.

It contains a very basic schema generator for generating composed schemas with different imports. The intent is to show how this can be done, so more automatic workflows can be set up.

There is also a basic CLI for testing it out. The instructions can be found at `./truflation/schema_gen/cli/README.md`