### PR TITLE
feat: make kwil gateway binary available in ec2 instance

### DIFF
--- a/deployments/infra/cdk_main.go
+++ b/deployments/infra/cdk_main.go
@@ -292,11 +292,10 @@ systemctl start tsn-db-app.service`
 
 	kwilGatewayBinaryScript := `#!/bin/bash
 aws s3 cp s3://kwil-binaries/gateway/kgw_v0.1.2.zip /tmp/kgw_v0.1.2.zip
-unzip /tmp/kgw_v0.1.2.zip -d /tmp
-mkdir -p /kwil-binaries/kgw_v0.1.2/kgw_0.1.2_linux_arm64
-tar -xf /tmp/kgw_v0.1.2/kgw_0.1.2_linux_arm64.tar.gz -C /kwil-binaries/kgw_v0.1.2/kgw_0.1.2_linux_arm64
-chmod +x /kwil-binaries/kgw_v0.1.2/kgw_0.1.2_linux_arm64/kgw
-mv /tmp/kwil-binaries/kgw_v0.1.2/kgw_0.1.2_linux_arm64/kgw /usr/local/bin/kgw
+unzip /tmp/kgw_v0.1.2.zip -d /tmp/
+tar -xf /tmp/kgw_v0.1.2/kgw_0.1.2_linux_amd64.tar.gz -C /tmp/kgw_v0.1.2
+chmod +x /tmp/kgw_v0.1.2/kgw
+mv /tmp/kgw_v0.1.2/kgw /usr/local/bin/kgw
 `
 	instance.AddUserData(&script1Content, &kwilGatewayBinaryScript)
 }


### PR DESCRIPTION
This PR adds a boot up script to ec2 instance to fetch from s3 the kwil gateway binary. It also extracts logic for creating ec2 role into its own function. 

## Related Issue
Resolves #109.

## Motivation and Context
We need to have kwil gateway binary in ec2 instance to be able to execute it. 

## How Has This Been Tested?
Run manually kwilGatewayBinaryScript. The permission grant needs to be tested on staging or at least I don't know another way currently.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (including inline docs)
- [ ] Other (please describe):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If a box does not apply, put `N/A`-->
<!--- For each box that has `N/A`, please explain why in the "Checklist Explanation" section. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Checklist Explanation:
<!--- If any of the above boxes are not checked, please explain why here: -->

## How to Review this PR:
<!--- Please provide instructions on how to review this PR here (e.g. where to start, key design decisions, parts of the code that require special attention): -->

## Additional Information:
<!--- Anything else we should know when reviewing? -->

