### PR TITLE
chore(kf): query composed contracts more efficiently

### DIFF
--- a/internal/contracts/composed_stream_template.kf
+++ b/internal/contracts/composed_stream_template.kf
@@ -207,9 +207,8 @@ procedure get_record($date_from text, $date_to text, $frozen_at text) public vie
     value int
 ) {
     // here, we sum all of the values that were found by aggregating on the date_valie
-    for $row in SELECT date_value, sum(value) as value FROM get_record_internal($date_from, $date_to, $frozen_at) GROUP BY date_value {
-        return next $row.date_value, $row.value;
-    }
+    return select r.date_value as date_value, sum(r.value)::int as value from get_record_internal($date_from, $date_to, $frozen_at) as r
+    group by r.date_value;
 }
 
 // get_index retrieves the indexes for a specified date range
@@ -218,9 +217,8 @@ procedure get_index($date_from text, $date_to text, $frozen_at text) public view
     value int
 ) {
     // here, we sum all of the indexes that were found by aggregating on the date_valie
-    for $row in SELECT date_value, sum(value) as value FROM get_index_internal($date_from, $date_to, $frozen_at) GROUP BY date_value {
-        return next $row.date_value, $row.value;
-    }
+    return select r.date_value as date_value, sum(r.value)::int as value from get_index_internal($date_from, $date_to, $frozen_at) as r
+    group by r.date_value;
 }
 
 procedure is_initiated() private view returns (result bool) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

Applying the suggestion from Brennan to make the query more efficient despite current kwil limitation.
Notes:
The original suggestion is modified:
```
    return select r.date_value as date_value, sum(r.value) as value from get_record_internal($date_from, $date_to, $frozen_at) as r
    group by r.date_value;
```
into:
```
    for $row in SELECT date_value, sum(value) as value FROM get_index_internal($date_from, $date_to, $frozen_at) GROUP BY date_value {
        return next $row.date_value, $row.value;
    }
```
It will cause errors. It looks like there is a bug on `return select ... group`, since the for statements works
```
error calling action: call action: jsonrpc.Error: code = -300, message = ERROR: structure of query does not match function result type (SQLSTATE 42804), data = null
err code = -300, msg = ERROR: structure of query does not match function result type (SQLSTATE 42804)
```
![image](https://github.com/truflation/tsn/assets/48527109/6068d372-1baf-428a-88b3-01901169adff)


## Related Problem

resolves: #291

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Kwil-cli configure and set private key to `0000000000000000000000000000000000000000000000000000000000000001`
2. Run the test `get records with taxonomy` on composed_stream_contract_test.md file
3. ![image](https://github.com/truflation/tsn/assets/48527109/32be9c31-6d3d-4e90-82a2-cb0623beb5f5)
