### PR TITLE
feat: dynamic created_at with block height for contracts

### DIFF
--- a/internal/contracts/composed_stream_template.kf
+++ b/internal/contracts/composed_stream_template.kf
@@ -96,7 +96,6 @@ procedure get_date_list($date_from text, $date_to text, $frozen_at text) public 
     // get list date
     $date_list text[];
     for $row2 in SELECT * FROM describe_taxonomies(true) {
-        // TODO: need to fix this generate_dbid, for now we're using a fixed value
         $dbid text := generate_dbid($row2.child_data_provider, $row2.child_stream_id);
         for $row3 in SELECT * FROM ext_get_data[$dbid, 'get_record']($date_from, $date_to, $frozen_at) {
             $found bool := false;
@@ -276,8 +275,7 @@ procedure init() public owner {
         error('this contract was already initialized');
     }
 
-    // TODO replace by intrinsic current_block value when kwil supports
-    $current_block int := 1;
+    $current_block int := @height;
 
     // uuid's namespaces are any random generated uuid from https://www.uuidtools.com/v5
     // but each usage should be different to maintain determinism, so we reuse the previous result
@@ -362,8 +360,7 @@ procedure insert_metadata(
     }
 
     $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, @txid);
-    // TODO replace by context value when kwil supports
-    $current_block int := 2;
+    $current_block int := @height;
 
     // insert data
     // TODO add value_f
@@ -440,8 +437,7 @@ procedure get_metadata($key text, $only_latest bool, $ref text) public view retu
 procedure disable_metadata($row_id uuid) public {
     stream_owner_only();
 
-    // TODO when kwil enables current block from context
-    $current_block int := 3;
+    $current_block int := @height;
 
     $found bool := false;
 
@@ -596,8 +592,7 @@ procedure describe_taxonomies($latest_version bool) public view returns table(
 procedure disable_taxonomy($version int) public {
     stream_owner_only();
 
-    // TODO when kwil enables current block from context
-    $current_block int := 4;
+    $current_block int := @height;
 
     $found bool := false;
 

--- a/internal/contracts/primitive_stream_template.kf
+++ b/internal/contracts/primitive_stream_template.kf
@@ -84,8 +84,7 @@ procedure init() public owner {
         error('this contract was already initialized');
     }
 
-    // TODO replace by intrinsic current_block value when kwil supports
-    $current_block int := 1;
+    $current_block int := @height;
 
     // uuid's namespaces are any random generated uuid from https://www.uuidtools.com/v5
     // but each usage should be different to maintain determinism, so we reuse the previous result
@@ -171,8 +170,7 @@ procedure insert_metadata(
     }
 
     $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, @txid);
-    // TODO replace by context value when kwil supports
-    $current_block int := 2;
+    $current_block int := @height;
 
     // insert data
     // TODO add value_f
@@ -250,8 +248,7 @@ procedure get_metadata($key text, $only_latest bool, $ref text) public view retu
 procedure disable_metadata($row_id uuid) public {
     stream_owner_only();
 
-    // TODO when kwil enables current block from context
-    $current_block int := 3;
+    $current_block int := @height;
 
     $found bool := false;
 
@@ -284,8 +281,7 @@ procedure insert_record($date_value text, $value int) public {
         error('contract must be initiated');
     }
 
-    // TODO replace by context value when kwil supports
-    $current_block int := 3;
+    $current_block int := @height;
 
     // insert data
     INSERT INTO primitive_events (date_value, value, created_at)
@@ -324,7 +320,6 @@ procedure get_base_value() private view returns (value int) {
     error('no base value found');
 }
 
-// TODO: frozen_at is not used yet, but it will be used for lookback mechanism
 procedure get_record(
     $date_from text,
     $date_to text,

--- a/internal/contracts/system_contract.kf
+++ b/internal/contracts/system_contract.kf
@@ -60,8 +60,7 @@ procedure accept_stream($data_provider text, $stream_id text) public owner {
         error('this stream is already official');
     }
 
-    // todo replace by real blockheight by kwil
-    $current_blockheight int := 1;
+    $current_blockheight int := @height;
 
     verify_hex($data_provider);
 
@@ -77,7 +76,7 @@ procedure revoke_stream($data_provider text, $stream_id text) public owner {
         error('this stream is not official');
     }
 
-    $current_blockheight int := 1;
+    $current_blockheight int := @height;
 
     UPDATE system_streams SET revoked_at = $current_blockheight WHERE data_provider = $data_provider AND stream_id = $stream_id;
 }


### PR DESCRIPTION
## Description

- Remove resolved TODOs from kuneiform contracts
- Assigned block height into created_at instead of static number

## Related Problem

resolves: https://github.com/truflation/tsn/issues/252

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Run the Primitive test
   1. Deploy
   2. Init
   3. Insert Record
2. Check with any database viewer, that the inserted created_at is now using block height
3. ![image](https://github.com/truflation/tsn/assets/48527109/5cc0264f-cddb-4ef6-8823-e1f5c8157dea)
