### PR TITLE
ci: exclude markdown on ci test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
     types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_dispatch:
   push:
+    paths-ignore:
+      - '**.md'
+      - '**.kf'
     branches:
       - main
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

Two things I exclude:
1. `.md` files, markdown excluded
2. `.kf` kuneiform is also excluded since it is not part of CI

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/287

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. CI is not run when md files changed (I tested by pushing a test commit, it is reverted)
2. ![image](https://github.com/truflation/tsn/assets/48527109/ed772dcf-c854-4678-b732-4c45e7e33268)
3. ![image](https://github.com/truflation/tsn/assets/48527109/25ec44b5-0ca4-419a-9d65-a3bc6728e6a3)
4. CI run because there is changes to yaml file (including ci.yaml)
