### PR TITLE
fix: return correct number of rows when calling from contract

### DIFF
--- a/internal/contracts/composed_stream_template.kf
+++ b/internal/contracts/composed_stream_template.kf
@@ -363,16 +363,54 @@ procedure get_record($date_from text, $date_to text, $frozen_at text) public vie
     // check if the stream is allowed to compose
     is_stream_allowed_to_compose();
 
+    // TODO: had to use this ugly if else because && is somehow not working
+    // Also, query builder is not supported so yeah, looks ugly
     // here, we sum all of the records that were found by aggregating on the date_valie
-    for $row in
-        SELECT
-            r.date_value AS date_value,
-            SUM(r.value_with_weight)::decimal(21,3) AS total_value_with_weight,
-            SUM(r.weight)::decimal(21,3) AS total_weight
-        FROM get_record_filled($date_from, $date_to, $frozen_at) as r group by r.date_value {
-        // total_weight is not necessarily the sum of all taxonomy weights, because
-        // there might be missing data points for initial dates
-        return next $row.date_value, $row.total_value_with_weight / $row.total_weight;
+    if $date_from != '' {
+        if $date_to != '' {
+            for $row in
+                SELECT
+                    r.date_value AS date_value,
+                    SUM(r.value_with_weight)::decimal(21,3) AS total_value_with_weight,
+                    SUM(r.weight)::decimal(21,3) AS total_weight
+                FROM get_record_filled($date_from, $date_to, $frozen_at) as r
+                WHERE r.date_value >= $date_from AND r.date_value <= $date_to
+                group by r.date_value {
+                // total_weight is not necessarily the sum of all taxonomy weights, because
+                // there might be missing data points for initial dates
+                return next $row.date_value, $row.total_value_with_weight / $row.total_weight;
+            }
+        } else {
+            for $row2 in
+                SELECT
+                    r.date_value AS date_value,
+                    SUM(r.value_with_weight)::decimal(21,3) AS total_value_with_weight,
+                    SUM(r.weight)::decimal(21,3) AS total_weight
+                FROM get_record_filled($date_from, $date_to, $frozen_at) as r
+                WHERE r.date_value >= $date_from
+                group by r.date_value {
+                // total_weight is not necessarily the sum of all taxonomy weights, because
+                // there might be missing data points for initial dates
+                return next $row2.date_value, $row2.total_value_with_weight / $row2.total_weight;
+            }
+        }
+    } else {
+        if $date_to != '' {
+            error('date_from must be provided if date_to is provided');
+        } else {
+            for $row3 in
+                SELECT
+                    r.date_value AS date_value,
+                    SUM(r.value_with_weight)::decimal(21,3) AS total_value_with_weight,
+                    SUM(r.weight)::decimal(21,3) AS total_weight
+                FROM get_record_filled($date_from, $date_to, $frozen_at) as r
+                WHERE r.date_value >= (SELECT MAX(date_value) FROM get_record_filled($date_from, $date_to, $frozen_at))
+                group by r.date_value {
+                // total_weight is not necessarily the sum of all taxonomy weights, because
+                // there might be missing data points for initial dates
+                return next $row3.date_value, $row3.total_value_with_weight / $row3.total_weight;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

1. Querying from composed stream will now return the number rows as expected:
   1. Empty date_from and date_to will return only **ONE** record.
   2. Filled date_from and Empty date_to will return all records to date_from:
   3. Filled both date_from and date_to will limit the selection with both date_from and date_to
   4. Empty date_from and filled date_to will cause an error.

2. The `get_record_filled` is not touched because we need the filled records
3. the filter is on the outer part of the calculation, the get_record part. So you can say it is filtering the already filled record to not go beyond it desired parameters.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/325

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run the complex composed test

![image](https://github.com/truflation/tsn/assets/48527109/20e504dd-0fba-43b1-9d18-aab32a6dc3a9)