### PR TITLE
ci: disable automatic staging deployment

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -2,9 +2,6 @@ name: Deploy Staging Environment
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   #  tests:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

Disabling Automatic CI Deploment from Github Action Workflow. It is still be able to run via `workflow_dispatch`, which means only manual deployment will do. It is needed because for every deployment to staging, the tsn server reseted.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
