### PR TITLE
fix: wrong output value in date_from

### DIFF
--- a/internal/contracts/composed_stream_template.kf
+++ b/internal/contracts/composed_stream_template.kf
@@ -860,7 +860,7 @@ procedure emit_values_if($condition bool, $date_value text, $values decimal(21,3
 ) {
     if $condition == true {
         for $i in 1..array_length($values) {
-            return next $date_value, $values[$i] * $weights[$i], $weights[$i];
+            return next $date_value, $values[$i], $weights[$i];
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->
- Fixing bug on "date_from" parameter which always gives data 1 day before, if they are not finding any data that match between "date_value" and "date_from" in Primitive Stream and Composed Stream.  

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->
- Fix https://github.com/truflation/tsn/issues/338
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
First, I checked whether the Primitive Stream and Composed Stream have the same bug. Then, I found that both have the same bug, but it has a little difference. Primitive Stream shows data that have been created, but Composite Stream can show data that has never been created before by giving the empty value ''. 
Here are the example:
<h3>Record on Primitive Stream or Composed Stream</h3><table>
  <tr>
    <th>Date</th>
    <th>Value</th>
  </tr>
  <tr>
    <td>2021-01-02</td>
    <td>2</td>
  </tr>
  <tr>
    <td>2021-02-05</td>
    <td>5</td>
  </tr>
</table>
<h3>Get Record</h3><table>
  <tr>
    <th>Column</th>
    <th>Value</th>
  </tr>
  <tr>
    <td>date_from</td>
    <td>2021-01-03</td>
  </tr>
  <tr>
    <td>date_to</td>
    <td>2021-02-05</td>
  </tr>
</table>
<h3>Primitive Stream Output</h3><table>
  <tr>
    <th>Date</th>
    <th>Value</th>
  </tr>
  <tr>
    <td>2021-01-02</td>
    <td>2</td>
  </tr>
  <tr>
    <td>2021-02-05</td>
    <td>5</td>
  </tr>
</table>
<h3>Composed Stream Output</h3><table>
  <tr>
    <th>Date</th>
    <th>Value</th>
  </tr>
  <tr>
    <td></td>
    <td>nil</td>
  </tr>
  <tr>
    <td>2021-02-05</td>
    <td>5</td>
  </tr>
</table>
<p><b>Primitive Stream</b>: I check in the get_record procedure. Then, I found that it is getting data from "get_original_record" procedure. However, "get_record" procedure has a logic to add 1 day before if "date_from" parameter doesn't found out any data that has the same date as the "date_from" parameter. Then, I replace "get_record" procedure with the "get_original_record" and delete unnecessary code. Here is the result:</p>

![primitive get record](https://github.com/truflation/tsn/assets/60654908/9c2e00c4-7542-4711-b971-a7d4253e6dcc)

<p><b>Composed Stream</b>: I check in the get_record procedure. Then, I found the data come from "get_record_filled" procedure. After that, I checked which one that put the '' value. I found that "$prev_loop_date" variable is set to '' as the initial value so I read all of the code that connected with this variable. When I read the code, it shows that "emit_value_if" procedure is the one that sets the value to '' to our data, so I delete it and all of the code that return "$prev_loop_date" variable. Here is the result: </p>

![composed_check_stream2](https://github.com/truflation/tsn/assets/60654908/cb91c016-144f-460e-a546-5d66682ec4a3)
