### PR TITLE
chore: remove unnecessary check_valid_int_or_null procedure

### DIFF
--- a/internal/contracts/primitive_stream_template.kf
+++ b/internal/contracts/primitive_stream_template.kf
@@ -342,7 +342,6 @@ procedure get_original_record(
 
     check_valid_date_or_null($date_from, 'date_from');
     check_valid_date_or_null($date_to, 'date_to');
-    check_valid_int_or_null($frozen_at, 'frozen_at');
 
     // check read access
     if is_wallet_allowed_to_read(@caller) == false {
@@ -561,14 +560,6 @@ procedure check_valid_date_or_null($date text, $name text) private view {
     if $date IS DISTINCT FROM NULL {
         if length($date) != 10 {
             error(format('%s must be in yyyy-mm-dd format or should not be provided: received %s', $name, $date));
-        }
-    }
-}
-
-procedure check_valid_int_or_null($int text, $name text) private view {
-    if $int IS DISTINCT FROM NULL {
-        if $int == '' OR $int::int IS NULL {
-            error(format('%s must be an integer or should not be provided: received %s', $name, $int));
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Removing unnecessary check_valid_int_or_null procedure as it is not needed since the parameter already only accepts int.
- Part of https://github.com/truflation/tsn-data-provider/pull/142

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn-data-provider/issues/141

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
