### PR TITLE
fix: can't read from private composed stream

### DIFF
--- a/internal/contracts/composed_stream_template.kf
+++ b/internal/contracts/composed_stream_template.kf
@@ -91,6 +91,13 @@ procedure get_raw_record($date_from text, $date_to text, $frozen_at int) private
     value decimal(21,3),
     taxonomy_index int
 ) {
+    // checks are executed at the beginning of the procedure
+    if is_wallet_allowed_to_read(@caller) == false {
+        error('wallet not allowed to read');
+    }
+    // check if the stream is allowed to compose
+    is_stream_allowed_to_compose();
+
     // arrays are 1-indexed, so we match that
     $taxonomy_index int := 0;
     for $row2 in SELECT * FROM describe_taxonomies(true) {
@@ -113,6 +120,13 @@ procedure get_raw_index($date_from text, $date_to text, $frozen_at int) private 
     value decimal(21,3),
     taxonomy_index int
 ) {
+    // checks are executed at the beginning of the procedure
+    if is_wallet_allowed_to_read(@caller) == false {
+        error('wallet not allowed to read');
+    }
+    // check if the stream is allowed to compose
+    is_stream_allowed_to_compose();
+
     // arrays are 1-indexed, so we match that
     $taxonomy_index int := 0;
     for $row2 in SELECT * FROM describe_taxonomies(true) {
@@ -405,9 +419,6 @@ procedure get_record($date_from text, $date_to text, $frozen_at int) public view
     date_value text,
     value decimal(21,3)
 ) {
-    // check if the stream is allowed to compose
-    is_stream_allowed_to_compose();
-
     // here, we sum all of the records that were found by aggregating on the date_valie
     for $row in
         SELECT
@@ -428,9 +439,6 @@ procedure get_index($date_from text, $date_to text, $frozen_at int) public view 
     date_value text,
     value decimal(21,3)
 ) {
-    // check if the stream is allowed to compose
-    is_stream_allowed_to_compose();
-
     // here, we sum all of the index that were found by aggregating on the date_valie
     for $row in
         SELECT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- add compose permission to composed streams
- moves read permission to the first procedure as well

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- Resolves #356 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

during tsn-sdk tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced security checks for wallet permissions and stream composition eligibility added to improve data access control.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->