### PR TITLE
fix: resilient tsn-db docker services

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,7 @@ services:
   kwil-postgres:
     image: "kwildb/postgres:latest"
     hostname: kwil-postgres
+    restart: on-failure
     ports:
       - "5432:5432"
     environment:
@@ -44,6 +45,7 @@ services:
     container_name: tsn-db
     hostname: tsn-db
     image: "tsn-db:local"
+    restart: on-failure
     build:
       context: .
       dockerfile: ./deployments/Dockerfile


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- add restart on failure to compose services

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- should fix #389 (or help mitigate it)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- run the compose
- kill postgres to make tsn-db fail and see it restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic restart on failure for `kwil-postgres` and `tsn-db` services in the app's configuration. This ensures improved stability and reduced downtime for these services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->