### PR TITLE
chore: create local environment that similar to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ task compose
 ```
 It will build and start the TSN-DB in Docker containers, which is already seeded.
 
+Alternatively, you can run the following commands to run TSN-DB in Docker containers with similar setup as our the deployed server.
+It has 2 nodes, gateway, and indexer enabled.
+```shell
+task compose-dev
+```
+Accessing the nodes from gateway will be default to `http://localhost:443` and accessing the indexer will be default to `http://localhost:1337/v0/swagger`.
+
 #### Build and Run the TSN-DB without Docker Compose
 
 Alternatively, you can build and run the TSN-DB without Docker Compose. 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,18 @@ tasks:
     cmds:
       - docker compose up
 
+  compose-dev:
+    desc: Run docker-compose locally with dev configuration, 2 nodes, gateway, and indexer services
+    cmds:
+        - docker compose -f deployments/dev-net/devnet-compose.yaml up -d
+        - docker compose -f deployments/dev-gateway/dev-gateway-compose.yaml up -d
+        - docker compose -f deployments/indexer/dev-indexer-compose.yaml up -d
+    env:
+        BACKENDS: tsn-db-1:8484,tsn-db-2:8484
+        CHAIN_ID: tsn-local
+        NODE_COMETBFT_ENDPOINT: http://tsn-db-1:26657
+        KWIL_PG_CONN: postgresql://kwild@kwil-postgres-1:5432/kwild?sslmode=disable
+
   tools:
     desc: Install tools
     cmds:

--- a/deployments/dev-net/devnet-compose.yaml
+++ b/deployments/dev-net/devnet-compose.yaml
@@ -117,23 +117,6 @@ services:
         source: tsn-conf
         target: /root/.kwild
 
-  indexer:
-    build: ../indexer
-    command: [
-      "./kwil-indexer", "run",
-      "--cometbft-endpoint", "http://tsn-db-1:26657",
-      "--pg-conn", "postgresql://postgres@kwil-postgres-1:5432/postgres?sslmode=disable",
-      "--kwil-pg-conn", "postgresql://kwild@kwil-postgres-1:5432/kwild?sslmode=disable",
-      "--seeds", "nodeID1@tsn-db-1:26657,nodeID2@tsn-db-2:26658"
-    ]
-    ports:
-      - "1337:1337"
-    depends_on:
-      - tsn-db-1
-      - tsn-db-2
-    networks:
-      - tsn-network
-
 networks:
   tsn-network:
     driver: bridge

--- a/deployments/indexer/dev-indexer-compose.yaml
+++ b/deployments/indexer/dev-indexer-compose.yaml
@@ -3,8 +3,8 @@ services:
     image: "caddy:latest"
     hostname: indexer-caddy
     ports:
-      - "80:80"
-      - "443:443"
+      - "81:81"
+      - "444:444"
     volumes:
       - type: bind
         source: ./Caddyfile
@@ -40,8 +40,8 @@ services:
     build:
       dockerfile: indexer.dockerfile
       args:
-        NODE_COMETBFT_ENDPOINT: "http://tsn-db:26657"
-        KWIL_PG_CONN: "postgresql://kwild@kwil-postgres:5432/kwild?sslmode=disable"
+        NODE_COMETBFT_ENDPOINT: ${NODE_COMETBFT_ENDPOINT:-http://tsn-db:26657}
+        KWIL_PG_CONN: ${KWIL_PG_CONN:-postgresql://kwild@kwil-postgres:5432/kwild?sslmode=disable}
         INDEXER_PG_CONN: "postgresql://postgres:postgres@indexer-postgres:5432/indexer?sslmode=disable"
     ports:
       - "1337:1337"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Create a new task inside Taskfile to automatically run 2 nodes, gateway, and indexer all in one command
- Modified some Dockerfile-related configuration.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/401

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Run `task compose-dev`, it will start 2 nodes, gateway, and indexer locally
2. Go to `tsn-data-provider`
3. Set env to match the local gateway
```
TSN_PROVIDER=https://localhost:443
```
4. Try to do migrations and insert record
```
task migrations-apply && task serve
```
5. Insert record by triggering FetchAndPush by curl or Postman
```
curl --location 'http://localhost:8081/tsn-data-provider/dataprovider.DataProviderService/FetchAndPushRecords' \
--header 'Content-Type: application/json' \
--data '{}'
```
6. Try some kwil-cli command
```
kwil-cli database call -a=get_record -n=st1b148397e2ea36889efad820e2315d -o=4710a8d8f0d845da110086812a32de6d90d7ff5c date_from:2024-06-01 date_to:2024-06-17 --private-key 0000000000000000000000000000000000000000000000000000000000000001
```
7. ![image](https://github.com/user-attachments/assets/ae8e1de2-fcbb-434b-862f-b73b3bd43395)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `task compose-dev` command to easily run development environments in Docker with 2 nodes, gateway, and indexer services.

- **Configuration Changes**
  - Adjusted port settings for the `indexer-caddy` service.
  - Updated environment variable usage and replaced hardcoded values for improved flexibility and configuration management.

- **Removals**
  - Removed `indexer` service configuration from `devnet-compose.yaml`.

- **Documentation**
  - Updated README with instructions for the new `task compose-dev` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->