### PR TITLE
fix: fail to deploy more than one nodes

### DIFF
--- a/deployments/infra/config/config.go
+++ b/deployments/infra/config/config.go
@@ -87,8 +87,8 @@ func NumOfNodes(scope constructs.Construct) int {
 	numOfNodes := 1
 
 	ctxValue := scope.Node().TryGetContext(jsii.String("numOfNodes"))
-	if v, err := ctxValue.(int); !err {
-		numOfNodes = v
+	if ctxValue != nil {
+		numOfNodes = int(ctxValue.(float64))
 	}
 
 	return numOfNodes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Discovered the bug during stress test of DEV stack
- Replaced `ok` with just basic `if something != nil`, and convert ctxValue into float64 first before to int

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/409

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Run CDK deploy
set panic to get the result immediate without waiting for the whole deployment,  example:
```
func NumOfNodes(scope constructs.Construct) int {
	numOfNodes := 1

	ctxValue := scope.Node().TryGetContext(jsii.String("numOfNodes"))
	if v, err := ctxValue.(int); !err {
		numOfNodes = v
	}

	fmt.Println("ctxValue: ", ctxValue)
	panic(fmt.Sprintf("numOfNodes: %d", numOfNodes))
	return numOfNodes
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved handling of context value type assertions to ensure more reliable error checking.
	- Enhanced logic in the `NumOfNodes` function to prevent issues when context values are not of the expected type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->