### PR TITLE
fix: handle more than one metadata insert per transaction

### DIFF
--- a/internal/contracts/composed_stream_template.kf
+++ b/internal/contracts/composed_stream_template.kf
@@ -586,7 +586,12 @@ procedure insert_metadata(
         error('Cannot insert metadata for read-only key');
     }
 
-    $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, @txid);
+    // we create one deterministic uuid for each metadata record
+    // we can't use just @txid because a single transaction can insert multiple metadata records.
+    // the result will be idempotency here too.
+    $uuid_key := @txid || $key || $value;
+
+    $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, $uuid_key);
     $current_block int := @height;
 
     // insert data

--- a/internal/contracts/primitive_stream_template.kf
+++ b/internal/contracts/primitive_stream_template.kf
@@ -179,7 +179,12 @@ procedure insert_metadata(
         error('Cannot insert metadata for read-only key');
     }
 
-    $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, @txid);
+    // we create one deterministic uuid for each metadata record
+    // we can't use just @txid because a single transaction can insert multiple metadata records.
+    // the result will be idempotency here too.
+    $uuid_key := @txid || $key || $value;
+
+    $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, $uuid_key);
     $current_block int := @height;
 
     // insert data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- create uuid from `txid` + `key` + `value` metadata insertion. So a user can now batch insert using auxiliary contracts (e.g. admin contract) as long as it's not using the same key and value for the same batch.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- Fix #421 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced UUID generation for metadata records, ensuring uniqueness and consistency even when multiple records are inserted in a single transaction.
  
- **Bug Fixes**
	- Improved robustness of metadata handling by preventing potential UUID collisions during metadata insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->