### PR TITLE
build: restore number of nodes to two

### DIFF
--- a/deployments/infra/cdk.json
+++ b/deployments/infra/cdk.json
@@ -61,7 +61,7 @@
     "stackName": "TSN-DB-Stack",
     "imageRepoName": "tsn-db-repo",
     "deploymentStage": "STAGING",
-    "numOfNodes": 1,
+    "numOfNodes": 2,
     "keyPairName": "tsn-key-pair"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

As there are multiple tests on DEV Stack that are using two nodes and it is not crashing, I think we can restore our number of nodes in Staging back to two, and then, mark the crashing issue as completed.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/403
related: https://github.com/truflation/tsn/issues/198

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've run test on DEV Stack on multiple occasion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the number of nodes for the deployment, enhancing application capacity and availability during the staging phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->