### PR TITLE
fix: increase timeout to prevent database timeout

### DIFF
--- a/deployments/tsn-entrypoint.sh
+++ b/deployments/tsn-entrypoint.sh
@@ -7,5 +7,6 @@
 exec /app/kwild --root-dir $CONFIG_PATH \
        --app.http-listen-addr "0.0.0.0:8080"\
        --app.jsonrpc-listen-addr "0.0.0.0:8484"\
+       --app.db-read-timeout "60s"\
        --chain.p2p.listen-addr "tcp://0.0.0.0:26656"\
        --chain.rpc.listen-addr "tcp://0.0.0.0:26657"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- increase read db timeout to 60s

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/439

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line argument for improved database read timeout management.
	- Enhanced application configuration for better performance and reliability during database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->