### PR TITLE
fix: taskfile to add deps fixed #463

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,11 +46,13 @@ tasks:
       - ./deployments/indexer/kwil-indexer run
 
   compose:
+    deps: [ kwil-binaries ]
     desc: Run docker-compose locally
     cmds:
       - docker compose up
 
   compose-dev:
+    deps: [ kwil-binaries ]
     desc: Run docker-compose locally with dev configuration, 2 nodes, gateway, and indexer services
     cmds:
         - docker compose -f deployments/dev-net/devnet-compose.yaml up -d
@@ -81,6 +83,8 @@ tasks:
   kwil-binaries:
     cmds:
       - ./scripts/download-binaries.sh
+    sources:
+      - ./.build/kwil-admin
 
   # After generating the certs, you need to trust them in your local machine by running the task setup:local-cert
   # leave the fields empty and press enter to use the default values


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
* Fix Taskfile so that kwil binaries are downloaded automatically if not present

## Related Problem
Resolves #463 

## How Has This Been Tested?
Run task compose on clean machine.  Fails before this fix but works afterwards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced task definitions for improved execution flow and dependency management.
	- Added prerequisites for the `compose` and `compose-dev` tasks, ensuring necessary components are available.
- **Improvements**
	- Updated the `kwil-binaries` task to include a new operational context, streamlining task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->