### PR TITLE
ci: release tsn binaries on github's release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,11 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: true
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Taskfile
-        uses: arduino/setup-task@v2
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -25,12 +21,36 @@ jobs:
           go-version: '1.22.x'
           check-latest: true
 
-      - name: Build
-        run: task build:kwild
+      - name: Build for Darwin AMD64
+        run: |
+          GOOS=darwin GOARCH=amd64 go build -o ./.build/kwild ./cmd/kwild/main.go
+          tar -czvf ./.build/kwild_darwin_amd64.tar.gz -C ./.build kwild
+          rm -rf ./.build/kwild
+
+      - name: Build for Darwin ARM64
+        run: |
+          GOOS=darwin GOARCH=arm64 go build -o ./.build/kwild ./cmd/kwild/main.go
+          tar -czvf ./.build/kwild_darwin_arm64.tar.gz -C ./.build kwild
+          rm -rf ./.build/kwild
+
+      - name: Build for Linux AMD64
+        run: |
+          GOOS=linux GOARCH=amd64 go build -o ./.build/kwild ./cmd/kwild/main.go
+          tar -czvf ./.build/kwild_linux_amd64.tar.gz -C ./.build kwild
+          rm -rf ./.build/kwild
+
+      - name: Build for Linux ARM64
+        run: |
+          GOOS=linux GOARCH=arm64 go build -o ./.build/kwild ./cmd/kwild/main.go
+          tar -czvf ./.build/kwild_linux_arm64.tar.gz -C ./.build kwild
+          rm -rf ./.build/kwild
 
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ./.build/kwild
+            ./.build/kwild_darwin_amd64.tar.gz
+            ./.build/kwild_darwin_arm64.tar.gz
+            ./.build/kwild_linux_amd64.tar.gz
+            ./.build/kwild_linux_arm64.tar.gz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Create a simple workflow with release action.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/455

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Tested with my forked tsn repository on my GitHub
2. ![image](https://github.com/user-attachments/assets/2acf3d96-c43e-4bc5-ba73-bb624778b1c8)
3. It will have multiple binary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined CI/CD workflow focusing on building and releasing the application.
	- Introduced a new `Release` step for handling versioned releases.
- **Improvements**
	- Upgraded dependencies for actions and tools, enhancing compatibility and performance.
	- Simplified workflow by removing unnecessary steps related to dependency installation and Docker image building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->