### PR TITLE
chore: have Taskfile download kgw automatically

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,7 +52,7 @@ tasks:
       - docker compose up
 
   compose-dev:
-    deps: [ kwil-binaries ]
+    deps: [ kwil-binaries-dev ]
     desc: Run docker-compose locally with dev configuration, 2 nodes, gateway, and indexer services
     cmds:
         - docker compose -f deployments/dev-net/devnet-compose.yaml up -d
@@ -63,6 +63,13 @@ tasks:
         CHAIN_ID: tsn-local
         NODE_COMETBFT_ENDPOINT: http://tsn-db-1:26657
         KWIL_PG_CONN: postgresql://kwild@kwil-postgres-1:5432/kwild?sslmode=disable
+
+  compose-dev-down:
+    desc: Shutdown dev 2 nodes, gateway, and indexer services
+    cmds:
+        - docker compose -f deployments/dev-net/devnet-compose.yaml down
+        - docker compose -f deployments/dev-gateway/dev-gateway-compose.yaml down
+        - docker compose -f deployments/indexer/dev-indexer-compose.yaml down
 
   tools:
     desc: Install tools
@@ -85,6 +92,14 @@ tasks:
       - ./scripts/download-binaries.sh
     sources:
       - ./.build/kwil-admin
+
+  kwil-binaries-dev:
+    deps:
+      - kwil-binaries
+    cmds:
+      - ./scripts/download-binaries-dev.sh
+    sources:
+      - ./.build/kgw
 
   # After generating the certs, you need to trust them in your local machine by running the task setup:local-cert
   # leave the fields empty and press enter to use the default values

--- a/scripts/download-binaries-dev.sh
+++ b/scripts/download-binaries-dev.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# go to the script dir
+cd "$(dirname "$0")"
+# go to the root dir
+cd ..
+
+download_binaries() {
+    local ARCH=$(uname -m)
+    local OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+    # Determine the architecture
+    if [[ "$ARCH" == "x86_64" ]]; then
+        ARCH="amd64"
+    elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+        ARCH="arm64"
+    else
+        echo "Unsupported architecture: $ARCH"
+        exit 1
+    fi
+
+    # Determine the operating system
+    if [[ "$OS" == "linux" ]]; then
+        OS="linux"
+    elif [[ "$OS" == "darwin" ]]; then
+        OS="darwin"
+    else
+        echo "Unsupported operating system: $OS"
+        exit 1
+    fi
+
+    # Set the URL for the binary
+    URL="https://www.dropbox.com/scl/fo/gl7ogpaqxs84zaw36nynd/AIfDb7thcS7p6ygm48GnLEI/kgw_0.3.2_${OS}_${ARCH}.tar.gz?rlkey=1cegi9hf50iji0gyra4hakj0u&dl=0"
+
+    echo "Detected platform: ${OS}-${ARCH}"
+    echo "Downloading binary from $URL..."
+
+    wget -O kgw.tar.gz $URL
+
+    if [[ $? -eq 0 ]]; then
+        echo "Binary downloaded successfully"
+
+        tar -xzvf kgw.tar.gz 'kgw'
+        mkdir -p ./.build
+        mv ./kgw .build
+        rm ./kgw.tar.gz
+
+        chmod +x ./.build/kgw
+    else
+        echo "Failed to download binary"
+        exit 1
+    fi
+}
+
+download_binaries


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
- Modify Taskfile to download kgw if not installed
- Add task compose-dev-down target

## Related Problem
Resolves: #468 

## How Has This Been Tested?
Run "task compose-dev" without patch.  no install.  Run "task compose-dev" with patch.  System runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new task to shut down development services (`compose-dev-down`).
	- Added a task to download development-specific binaries (`kwil-binaries-dev`).
	- Launched an automated script to download binaries for specific architectures and operating systems.
  
- **Improvements**
	- Enhanced the task management setup for a more efficient development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->