### PR TITLE
chore: adjust release packages naming with tsn and its version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set Version
+        id: vars
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -24,25 +31,25 @@ jobs:
       - name: Build for Darwin AMD64
         run: |
           GOOS=darwin GOARCH=amd64 go build -o ./.build/kwild ./cmd/kwild/main.go
-          tar -czvf ./.build/kwild_darwin_amd64.tar.gz -C ./.build kwild
+          tar -czvf ./.build/tsn_${{ env.VERSION }}_darwin_amd64.tar.gz -C ./.build kwild
           rm -rf ./.build/kwild
 
       - name: Build for Darwin ARM64
         run: |
           GOOS=darwin GOARCH=arm64 go build -o ./.build/kwild ./cmd/kwild/main.go
-          tar -czvf ./.build/kwild_darwin_arm64.tar.gz -C ./.build kwild
+          tar -czvf ./.build/tsn_${{ env.VERSION }}_arm64.tar.gz -C ./.build kwild
           rm -rf ./.build/kwild
 
       - name: Build for Linux AMD64
         run: |
           GOOS=linux GOARCH=amd64 go build -o ./.build/kwild ./cmd/kwild/main.go
-          tar -czvf ./.build/kwild_linux_amd64.tar.gz -C ./.build kwild
+          tar -czvf ./.build/tsn_${{ env.VERSION }}_linux_amd64.tar.gz -C ./.build kwild
           rm -rf ./.build/kwild
 
       - name: Build for Linux ARM64
         run: |
           GOOS=linux GOARCH=arm64 go build -o ./.build/kwild ./cmd/kwild/main.go
-          tar -czvf ./.build/kwild_linux_arm64.tar.gz -C ./.build kwild
+          tar -czvf ./.build/tsn_${{ env.VERSION }}_linux_arm64.tar.gz -C ./.build kwild
           rm -rf ./.build/kwild
 
       - name: Release
@@ -50,7 +57,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            ./.build/kwild_darwin_amd64.tar.gz
-            ./.build/kwild_darwin_arm64.tar.gz
-            ./.build/kwild_linux_amd64.tar.gz
-            ./.build/kwild_linux_arm64.tar.gz
+            ./.build/tsn_${{ env.VERSION }}_darwin_amd64.tar.gz
+            ./.build/tsn_${{ env.VERSION }}_darwin_arm64.tar.gz
+            ./.build/tsn_${{ env.VERSION }}_linux_amd64.tar.gz
+            ./.build/tsn_${{ env.VERSION }}_linux_arm64.tar.gz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Adjust naming release format into `tsn_{{ version }}_....`

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/475

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on my private repo
![image](https://github.com/user-attachments/assets/57c2e3cd-0a60-4fee-bd6e-596d0945e0d3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced versioning and packaging process for builds, allowing dynamic version extraction from release tags.
	- Standardized naming convention for output files with version prefixes for better clarity and organization of artifacts.

- **Bug Fixes**
	- Updated release artifacts to ensure correct versioned files are uploaded consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->