### PR TITLE
fix: add missing darwin name package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Build for Darwin ARM64
         run: |
           GOOS=darwin GOARCH=arm64 go build -o ./.build/kwild ./cmd/kwild/main.go
-          tar -czvf ./.build/tsn_${{ env.VERSION }}_arm64.tar.gz -C ./.build kwild
+          tar -czvf ./.build/tsn_${{ env.VERSION }}_darwin_arm64.tar.gz -C ./.build kwild
           rm -rf ./.build/kwild
 
       - name: Build for Linux AMD64


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- I forget to add the word `darwin` on `Build for Darwin ARM64` CI's step

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

Resolves: https://github.com/truflation/tsn/issues/475

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the naming convention for the output tarball of the Darwin ARM64 build to enhance clarity regarding the target operating system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->