### PR TITLE
build: open comet bft rpc port enabling snapshot

### DIFF
--- a/deployments/infra/lib/kwil-indexer/kwil_indexer_instance.go
+++ b/deployments/infra/lib/kwil-indexer/kwil_indexer_instance.go
@@ -66,7 +66,6 @@ func NewIndexerInstance(scope constructs.Construct, input NewIndexerInstanceInpu
 		name string
 	}{
 		{peer.TSNPostgresPort, "TSN Postgres port"},
-		{peer.TsnCometBFTRPCPort, "TSN Comet BFT RPC port"},
 	}
 
 	// allow communication from indexer to TSN node

--- a/deployments/infra/lib/tsn/security_group.go
+++ b/deployments/infra/lib/tsn/security_group.go
@@ -30,6 +30,7 @@ func NewTSNSecurityGroup(scope constructs.Construct, input NewTSNSecurityGroupIn
 		{peer.TsnRPCPort, "TSN RPC port"},
 		{peer.TsnIndexerPort, "TSN Indexer port"},
 		{peer.TsnP2pPort, "TSN P2P port"},
+		{peer.TsnCometBFTRPCPort, "TSN Comet BFT RPC port"},
 		{22, "SSH port"},
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/610

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the TSN Comet BFT RPC port in the security group configuration, enhancing network communication capabilities.
  
- **Bug Fixes**
	- Removed the deprecated TSN Comet BFT RPC port from the indexer instance configuration, simplifying the setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->