### PR TITLE
build: disable cgo on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,25 +30,25 @@ jobs:
 
       - name: Build for Darwin AMD64
         run: |
-          GOOS=darwin GOARCH=amd64 go build -o ./.build/kwild ./cmd/kwild/main.go
+          GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o ./.build/kwild ./cmd/kwild/main.go
           tar -czvf ./.build/tsn_${{ env.VERSION }}_darwin_amd64.tar.gz -C ./.build kwild
           rm -rf ./.build/kwild
 
       - name: Build for Darwin ARM64
         run: |
-          GOOS=darwin GOARCH=arm64 go build -o ./.build/kwild ./cmd/kwild/main.go
+          GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o ./.build/kwild ./cmd/kwild/main.go
           tar -czvf ./.build/tsn_${{ env.VERSION }}_darwin_arm64.tar.gz -C ./.build kwild
           rm -rf ./.build/kwild
 
       - name: Build for Linux AMD64
         run: |
-          GOOS=linux GOARCH=amd64 go build -o ./.build/kwild ./cmd/kwild/main.go
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./.build/kwild ./cmd/kwild/main.go
           tar -czvf ./.build/tsn_${{ env.VERSION }}_linux_amd64.tar.gz -C ./.build kwild
           rm -rf ./.build/kwild
 
       - name: Build for Linux ARM64
         run: |
-          GOOS=linux GOARCH=arm64 go build -o ./.build/kwild ./cmd/kwild/main.go
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o ./.build/kwild ./cmd/kwild/main.go
           tar -czvf ./.build/tsn_${{ env.VERSION }}_linux_arm64.tar.gz -C ./.build kwild
           rm -rf ./.build/kwild
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- disabling cgo on release build

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/613

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced build process for the `kwild` application, allowing for the creation of statically linked binaries for improved portability across various operating systems and architectures. 

- **Bug Fixes**
	- None reported. 

- **Documentation**
	- No updates made. 

- **Refactor**
	- No structural changes to the build logic. 

- **Style**
	- No style changes. 

- **Tests**
	- No test changes. 

- **Chores**
	- Updated build commands for better deployment efficiency. 

- **Revert**
	- None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->