### PR TITLE
fix: disable gateway syncing to tsn-node-2

### DIFF
--- a/deployments/infra/lib/kwil-gateway/kgw_startup_scripts.go
+++ b/deployments/infra/lib/kwil-gateway/kgw_startup_scripts.go
@@ -22,6 +22,10 @@ func AddKwilGatewayStartupScriptsToInstance(options AddKwilGatewayStartupScripts
 		nodeAddresses = append(nodeAddresses, node.PeerConnection.GetRpcHost())
 	}
 
+	// TODO: Temporary fix for the issue of the gateway keep syncing with the node-2 that is halted
+	// only take the first ([0]) node address
+	nodeAddresses = nodeAddresses[:1]
+
 	// Create the environment variables for the gateway compose file
 	kgwEnvConfig := KGWEnvConfig{
 		CorsAllowOrigins: config.CorsAllowOrigins,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Temporary only assigned node 0 as the backend to listen for gateway

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/618

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've tried:
1. Restarting the app when counting to the instance with `sudo systemctl restart tsn-db-app.service`
2. Restarting the node-2 instance
3. Check KGW for logs. It is still shows:
```
{"level":"warn","ts":1726807338.1601355,"caller":"kgw/schema.go:190","msg":"fetch schema","dbid":"xd23a3f2b50af35dd8a982fe1b41369eace38ef7bbce619ec59db976b","backend":"staging.node-2.tsn.truflation.com:8484","issue":"not found\njsonrpc.Error: code = -301, message = dataset not found, data = null\nerr code = -301, msg = dataset not found"}
{"level":"warn","ts":1726807338.1825209,"caller":"kgw/schema.go:190","msg":"fetch schema","dbid":"xae9b8c6f4d96b30304d0e08165ba3ff5d6174d21aae58a4fa455d8c9","backend":"staging.node-2.tsn.truflation.com:8484","issue":"not found\njsonrpc.Error: code = -301, message = dataset not found, data = null\nerr code = -301, msg = dataset not found"}
{"level":"warn","ts":1726807338.1889584,"caller":"kgw/schema.go:190","msg":"fetch schema","dbid":"x3f7d816527790e1d28571db41539d967e33310e388497fe5cc47673a","backend":"staging.node-2.tsn.truflation.com:8484","issue":"not found\njsonrpc.Error: code = -301, message = dataset not found, data = null\nerr code = -301, msg = dataset not found"}
```
Meaning that our node-2 still unsync

CDK diff: 
![image](https://github.com/user-attachments/assets/9ebfb9fa-d7dc-4498-8e5f-923e52fbc7f2)
So, yeah I set Gateway to not sync to TSN-Node-2 as it is still in trouble

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Implemented a temporary fix to prevent the gateway from syncing with a non-responsive node, improving overall stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->