### PR TITLE
fix: gateway listening to non working nodes

### DIFF
--- a/deployments/infra/lib/kwil-gateway/kgw_startup_scripts.go
+++ b/deployments/infra/lib/kwil-gateway/kgw_startup_scripts.go
@@ -22,10 +22,6 @@ func AddKwilGatewayStartupScriptsToInstance(options AddKwilGatewayStartupScripts
 		nodeAddresses = append(nodeAddresses, node.PeerConnection.GetRpcHost())
 	}
 
-	// TODO: Temporary fix for the issue of the gateway keep syncing with the node-2 that is halted
-	// only take the first ([0]) node address
-	nodeAddresses = nodeAddresses[:1]
-
 	// Create the environment variables for the gateway compose file
 	kgwEnvConfig := KGWEnvConfig{
 		CorsAllowOrigins: config.CorsAllowOrigins,

--- a/deployments/infra/stacks/tsn_stack.go
+++ b/deployments/infra/stacks/tsn_stack.go
@@ -80,7 +80,7 @@ func TsnStack(stack awscdk.Stack, props *TsnStackProps) awscdk.Stack {
 			jsii.String("KwilGatewayBucket"),
 			jsii.String("kwil-binaries"),
 		),
-		Key: jsii.String("gateway/kgw-v0.3.1.zip"),
+		Key: jsii.String("gateway/kgw-v0.3.3.zip"),
 	}
 
 	// ## Instances & Permissions

--- a/scripts/download-binaries-dev.sh
+++ b/scripts/download-binaries-dev.sh
@@ -30,7 +30,7 @@ download_binaries() {
     fi
 
     # Set the URL for the binary
-    URL="https://www.dropbox.com/scl/fo/gl7ogpaqxs84zaw36nynd/AIfDb7thcS7p6ygm48GnLEI/kgw_0.3.2_${OS}_${ARCH}.tar.gz?rlkey=1cegi9hf50iji0gyra4hakj0u&dl=0"
+    URL="https://www.dropbox.com/scl/fi/pseq2piergab1l2eg5xfi/kgw_0.3.3_${OS}_${ARCH}.tar.gz?rlkey=kytxxyeepoxi4zz7eancmjj43&st=klxh3rdh&dl=0"
 
     echo "Detected platform: ${OS}-${ARCH}"
     echo "Downloading binary from $URL..."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Uploaded the newest KGW files on AWS E2
- Undoing the previous temporary fix on https://github.com/truflation/tsn/pull/619
- Confirmed with `cdk diff` that the changes are around KGW instance

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/618

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Tested locally, deploying with `task compose-dev` and tried some kwil-cli commands including migrations
2. Tested with `cdk diff`
3. ![image](https://github.com/user-attachments/assets/6ed38141-a309-4e18-9a71-0dd96776f21a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced gateway functionality by allowing the use of all available node addresses for improved synchronization.
	- Updated gateway binaries to version 0.3.3 for better performance and features.

- **Bug Fixes**
	- Resolved an issue with the gateway syncing with a halted node.

- **Chores**
	- Updated download scripts to fetch the latest binary version (0.3.3).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->