### PR TITLE
chore: set recommended shm size

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2,6 +2,7 @@ services:
   kwil-postgres:
     image: "kwildb/postgres:latest"
     hostname: kwil-postgres
+    shm_size: 256M
     restart: unless-stopped
     ports:
       - "5432:5432"


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

Added a 256M shared memory size (shm_size) to the kwil-postgres service in the compose.yaml file to optimize its performance. This change ensures that the PostgreSQL database can utilize sufficient shared memory for operations.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves #640 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

no need to deploy, already been changed manually, it's more for self documenting and not losing the recommendation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for the `kwil-postgres` service to enhance performance by allowing specification of shared memory size.
	- Added `shm_size` parameter set to `256M` for improved application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->