### PR TITLE
chore: sync contract and benchmark with dynamic weight

### DIFF
--- a/internal/benchmark/setup.go
+++ b/internal/benchmark/setup.go
@@ -7,6 +7,7 @@ import (
 	mathrand "math/rand"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/google/uuid"
@@ -318,13 +319,22 @@ func setTaxonomyForComposed(ctx context.Context, platform *kwilTesting.Platform,
 	var dataProvidersArg []string
 	var streamIdsArg []string
 	var weightsArg []int
+	var startDateArg string
 
 	for _, t := range taxonomy {
 		dataProvidersArg = append(dataProvidersArg, t.ChildStream.DataProvider.Address())
 		streamIdsArg = append(streamIdsArg, t.ChildStream.StreamId.String())
 		weightsArg = append(weightsArg, int(t.Weight))
 	}
+	startDateArg = randDate(fixedDate.AddDate(0, 0, -input.days), fixedDate).Format(time.DateOnly)
 
 	return executeStreamProcedure(ctx, platform, dbid, "set_taxonomy",
-		[]any{dataProvidersArg, streamIdsArg, weightsArg}, platform.Deployer)
+		[]any{dataProvidersArg, streamIdsArg, weightsArg, startDateArg}, platform.Deployer)
+}
+
+func randDate(minDate, maxDate time.Time) time.Time {
+	delta := maxDate.Unix() - minDate.Unix()
+
+	sec := mathrand.Int63n(delta) + minDate.Unix()
+	return time.Unix(sec, 0)
 }

--- a/internal/contracts/composed_stream_template.kf
+++ b/internal/contracts/composed_stream_template.kf
@@ -250,16 +250,15 @@ procedure get_record_filled($date_from text, $date_to text, $frozen_at int) priv
 // if the last known value is not available, it will not emit the index, making it a sparse table
 procedure get_index_filled($date_from text, $date_to text, $frozen_at int, $base_date text) private view returns table(
     date_value text,
-    value_with_weight decimal(36,18), // value * weight
+    value_with_weight decimal(36,18), // value * dynamic weight
     // we also return the weight, so we can calculate the total weight for a date
-    weight decimal(36,18)
+    weight decimal(36,18)             // the dynamic weight for the date
 ) {
     // this will help us reset the arrays
     $base_taxonomy_list int[];
 
     // Initialize taxonomy variables
     $taxonomy_count int := 0;
-    $taxonomy_weight_list decimal(36,18)[];
     $last_values decimal(36,18)[];
     $child_data_providers text[];
     $child_stream_id text[];
@@ -268,7 +267,6 @@ procedure get_index_filled($date_from text, $date_to text, $frozen_at int, $base
     for $row in SELECT * FROM describe_taxonomies(true) {
         $taxonomy_count := $taxonomy_count + 1;
         $base_taxonomy_list := array_append($base_taxonomy_list, $taxonomy_count);
-        $taxonomy_weight_list := array_append($taxonomy_weight_list, $row.weight);
         $last_values := array_append($last_values, null::decimal(36,18));
         $child_data_providers := array_append($child_data_providers, $row.child_data_provider);
         $child_stream_id := array_append($child_stream_id, $row.child_stream_id);
@@ -279,43 +277,50 @@ procedure get_index_filled($date_from text, $date_to text, $frozen_at int, $base
     $prev_date text := '';
     $current_date text := '';
 
-       // what could make this process easier:
-   // - use a map to store the last values, so we can easily check if a value is null
-   // - better manipulation of tables as objects, then we could modify a table to
-   //   fill forward without needing to return immediately on each loop
+    // what could make this process easier:
+    // - use a map to store the last values, so we can easily check if a value is null
+    // - better manipulation of tables as objects, then we could modify a table to
+    //   fill forward without needing to return immediately on each loop
 
     for $row_raw in SELECT * FROM get_raw_index($date_from, $date_to, $frozen_at, $child_data_providers, $child_stream_id, $base_date) ORDER BY date_value, taxonomy_index {
         $current_date := $row_raw.date_value;
 
-        // Emit filled values for previous date if date has changed
+        // Fetch the dynamic weight based on the current date
+        $dynamic_weight decimal(36,18) := get_dynamic_weight($child_stream_id[$row_raw.taxonomy_index], $current_date);
+
+        // Emit filled values for the previous date if the date has changed
         if $current_date != $prev_date {
             if $prev_date is distinct from '' {
                 for $unemitted_taxonomy in $unemitted_taxonomies_for_date {
-                    // TODO: remove this when we have slices or include if we have just index assignment
-                    // if $unemitted_taxonomy is distinct from null {
-                        if $last_values[$unemitted_taxonomy] is distinct from null {
-                            return next $prev_date, $last_values[$unemitted_taxonomy] * $taxonomy_weight_list[$unemitted_taxonomy], $taxonomy_weight_list[$unemitted_taxonomy];
-                        }
-                    // }
+                    if $last_values[$unemitted_taxonomy] is distinct from null {
+                        // TODO: remove this when we have slices or include if we have just index assignment
+                        // if $unemitted_taxonomy is distinct from null {
+
+                        // Use the stored dynamic weight from the previous date
+                        $dynamic_weight_prev := get_dynamic_weight($child_stream_id[$unemitted_taxonomy], $prev_date);
+                        return next $prev_date, $last_values[$unemitted_taxonomy] * $dynamic_weight_prev, $dynamic_weight_prev;
+                    }
                 }
-                // we're moving to a new date, let's clear the unemitted_taxonomies_for_date list and the removed_elements_count
-                $unemitted_taxonomies_for_date := $base_taxonomy_list;
-                $removed_elements_count := 0;
             }
+            // Clear unemitted taxonomies for the new date
+            $unemitted_taxonomies_for_date := $base_taxonomy_list;
+            $removed_elements_count := 0;
         }
 
         // TODO: uncomment when we have index assignment
         // $last_values[$row_raw.taxonomy_index] := $row_raw.value;
+
+        // Update the last values for the current date
         $last_values := array_update_element($last_values, $row_raw.taxonomy_index, $row_raw.value);
 
-        // Emit current value
-        return next $current_date, $row_raw.value * $taxonomy_weight_list[$row_raw.taxonomy_index], $taxonomy_weight_list[$row_raw.taxonomy_index];
+        // Emit the current value with the dynamic weight
+        return next $current_date, $row_raw.value * $dynamic_weight, $dynamic_weight;
 
-        // let's remove the emitted taxonomy from the unemitted_taxonomies_for_date list
-        // we need to subtract the removed_elements_count because the array is shrinking
+        // Remove emitted taxonomy from the unemitted list
         // TODO: we can improve it when we either can remove elements, or with array element assignment
         $unemitted_taxonomies_for_date := remove_array_element($unemitted_taxonomies_for_date, $row_raw.taxonomy_index - $removed_elements_count);
         $removed_elements_count := $removed_elements_count + 1;
+
         // remove elements is not performant without slices. Then let's make the elements null for now
         // $unemitted_taxonomies_for_date[$row_raw.taxonomy_index] := null;
 
@@ -327,7 +332,9 @@ procedure get_index_filled($date_from text, $date_to text, $frozen_at int, $base
         if $taxonomy_count > 0 {
             for $unemitted_taxonomy2 in $unemitted_taxonomies_for_date {
                 if $last_values[$unemitted_taxonomy2] is distinct from null {
-                    return next $prev_date, $last_values[$unemitted_taxonomy2] * $taxonomy_weight_list[$unemitted_taxonomy2], $taxonomy_weight_list[$unemitted_taxonomy2];
+                    // Fetch the correct dynamic weight for the last date
+                    $dynamic_weight_last := get_dynamic_weight($child_stream_id[$unemitted_taxonomy2], $prev_date);
+                    return next $prev_date, $last_values[$unemitted_taxonomy2] * $dynamic_weight_last, $dynamic_weight_last;
                 }
             }
         }
@@ -1054,4 +1061,19 @@ procedure array_update_element($array decimal(36,18)[], $index int, $value decim
         }
     }
     return $new_array;
+}
+
+// Returns the weight based on the closest start_date before or equal to the given date
+procedure get_dynamic_weight($stream_id text, $date_value text) private view returns (
+    weight decimal(36,18)
+) {
+    // Select the closest weight by stream_id where start_date is before or equal to the current date_value
+    for $row in SELECT weight
+    FROM taxonomies
+    WHERE child_stream_id = $stream_id
+    AND (start_date IS NULL OR start_date = '' OR start_date <= $date_value)
+    ORDER BY start_date DESC
+    LIMIT 1 {
+        return $row.weight;
+    }
 }

--- a/internal/contracts/primitive_stream_template.kf
+++ b/internal/contracts/primitive_stream_template.kf
@@ -331,12 +331,27 @@ procedure get_index($date_from text, $date_to text, $frozen_at int, $base_date t
     return SELECT date_value, (value * 100::decimal(36,18)) / $baseValue as value FROM get_record($date_from, $date_to, $frozen_at);
 }
 
-// get_base_value returns the first value of the primitive stream after the given date
+// get_base_value returns the first nearest value of the primitive stream before the given date
 procedure get_base_value($base_date text, $frozen_at int) private view returns (value decimal(36,18)) {
-    for $row in SELECT * FROM get_first_record($base_date, $frozen_at) {
-        return $row.value;
+    // If $base_date is null or empty, return the first-ever value from the primitive stream.
+    // This ensures that when no valid $base_date is provided, we still return the earliest available data point.
+    if $base_date is null OR $base_date = '' {
+        for $row in SELECT * FROM primitive_events WHERE (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1 {
+            return $row.value;
+        }
     }
 
+    for $row2 in SELECT * FROM primitive_events WHERE date_value <= $base_date AND (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value DESC, created_at DESC LIMIT 1 {
+        return $row2.value;
+    }
+
+    // if no value is found, we find the first value after the given date
+    // This will raise a red flag in the system and the data will undergo the usual process for when a new data provider is added.
+    for $row3 in SELECT * FROM primitive_events WHERE date_value > $base_date AND (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1 {
+        return $row3.value;
+    }
+
+    // if no value is found, we return an error
     error('no base value found');
 }
 
@@ -364,7 +379,7 @@ procedure get_first_record($after_date text, $frozen_at int) public view returns
         $frozen_at := 0;
     }
 
-    return SELECT date_value, value FROM primitive_events WHERE date_value >= $after_date AND (created_at <= $frozen_at OR $frozen_at = 0) ORDER BY date_value ASC, created_at DESC LIMIT 1;
+    return SELECT date_value, value FROM primitive_events WHERE date_value >= $after_date AND (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1;
 }
 
 // get_original_record returns the original value of the primitive stream for a given date
@@ -457,9 +472,6 @@ procedure get_original_record(
        }
    }
 }
-
-
-
 
 // get_record returns the value of the primitive stream for a given date
 // it is able to fill the gaps in the primitive stream by using the last value before the given date
@@ -616,8 +628,6 @@ procedure get_index_change($date_from text, $date_to text, $frozen_at int, $base
 
     // 5. we calculate the index change for the current values and the result prev values
     // and done.
-
-
 
     if $frozen_at == null {
         $frozen_at := 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

sync contract and benchmark with the latest dynamic weight adjustment

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

related to https://github.com/truflation/tsn-sdk/pull/48#discussion_r1806691514

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new random date generation feature to enhance taxonomy setup.
	- Added a dynamic weight mechanism for improved data retrieval in taxonomy calculations.

- **Bug Fixes**
	- Improved error handling and clarity in data retrieval procedures.

- **Documentation**
	- Enhanced comments for clarity in procedures related to taxonomies and weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->