### PR TITLE
chore(docs): add sdk section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ The database for Truflation Stream Network (TSN). It is built on top of the Kwil
 
 Learn more about Truflation at [Truflation.com](https://truflation.com). Check our internal components status [here](https://truflation.grafana.net/public-dashboards/6fe3021962bb4fe1a4aebf5baddecab6).
 
+### SDKs
+
+To interact with TSN, we provide official SDKs in multiple languages:
+
+- **Go SDK** ([tsn-sdk](https://github.com/truflation/tsn-sdk)): A Go library for interacting with TSN, providing tools for publishing, composing, and consuming economic data streams. Supports primitive streams, composed streams, and system streams.
+
+- **TypeScript/JavaScript SDK** ([tsn-sdk-js](https://github.com/truflation/tsn-sdk-js)): A TypeScript/JavaScript library that offers the same capabilities as the Go SDK, with specific implementations for both Node.js and browser environments.
+
+Both SDKs provide high-level abstractions for:
+- Stream deployment and initialization
+- Data insertion and retrieval
+- Stream composition and management
+- Configurable integration with any deployed TSN Node
+
 ## Terminology
 
 See [TERMINOLOGY.md](./TERMINOLOGY.md) for a list of terms used in the TSN project.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

Updated the README to include information on the official SDKs in Go and TypeScript/JavaScript for interacting with TSN. Detailed capabilities and usage instructions for both SDKs are also provided.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix https://github.com/truflation/tsn/issues/696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "SDKs" section in the README, detailing the Go and TypeScript/JavaScript SDKs for the Truflation Stream Network (TSN).
	- Provided descriptions and capabilities for each SDK, including tools for publishing, composing, and consuming economic data streams.
	- Highlighted high-level abstractions for stream management and integration with TSN Nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->