### PR TITLE
test: benchmark new timestamp contracts

### DIFF
--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -29,6 +29,12 @@ From the root of the project, run the following command:
 go test -v ./internal/benchmark
 ```
 
+To run a specific test case, use the `-run` flag:
+```
+go test -run TestBenchUnix ./internal/benchmark -v
+```
+The above command will run the `TestBenchUnix` test case.
+
 ## Results
 
 After running, the benchmark will output performance metrics for each test case, including:

--- a/internal/benchmark/constants.go
+++ b/internal/benchmark/constants.go
@@ -5,8 +5,9 @@ import (
 )
 
 var (
-	readerAddress = MustNewEthereumAddressFromString("0x0000000000000000010000000000000000000001")
-	deployer      = MustNewEthereumAddressFromString("0x0000000000000000000000000000000200000000")
-	fixedDate     = time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
-	maxDepth      = 179 // found empirically
+	readerAddress    = MustNewEthereumAddressFromString("0x0000000000000000010000000000000000000001")
+	deployer         = MustNewEthereumAddressFromString("0x0000000000000000000000000000000200000000")
+	fixedDate        = time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	maxDepth         = 179 // found empirically
+	insertFreqInTime = 1 * time.Minute
 )

--- a/internal/benchmark/load_unix_test.go
+++ b/internal/benchmark/load_unix_test.go
@@ -3,7 +3,6 @@ package benchmark
 import (
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"os/signal"
 	"strconv"
@@ -16,7 +15,7 @@ import (
 )
 
 // Main benchmark test function
-func TestBench(t *testing.T) {
+func TestBenchUnix(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -40,7 +39,7 @@ func TestBench(t *testing.T) {
 	// try get resultPath from env
 	resultPath := os.Getenv("RESULTS_PATH")
 	if resultPath == "" {
-		resultPath = "./benchmark_results.csv"
+		resultPath = "./benchmark_unix_results.csv"
 	}
 
 	// Delete the file if it exists
@@ -62,37 +61,37 @@ func TestBench(t *testing.T) {
 		{1, 1},
 
 		//flat trees = cost of adding a new stream to our composed
-		{50, math.MaxInt},
-		{100, math.MaxInt},
-		{200, math.MaxInt},
-		{400, math.MaxInt},
+		//{50, math.MaxInt},
+		//{100, math.MaxInt},
+		//{200, math.MaxInt},
+		//{400, math.MaxInt},
 		// 800 streams kills t3.small instances for memory starvation. But probably because it stores the whole tree in memory
 		//{800, math.MaxInt},
 		//{1500, math.MaxInt}, // this gives error: Out of shared memory
 
 		// deep trees = cost of adding depth
-		{50, 1},
-		{100, 1},
+		//{50, 1},
+		//{100, 1},
 		//{200, 1}, // we can't go deeper than 180, for call stack size issues
 
 		// to get difference for stream qty on a real world situation
 		{50, 8},
 		{100, 8},
-		{200, 8},
-		{400, 8},
+		//{200, 8},
+		//{400, 8},
 		//{800, 8},
 
 		// to get difference for branching factor
-		{200, 2},
-		{200, 4},
+		//{200, 2},
+		//{200, 4},
 		// {200, 8}, // already tested above
-		{200, 16},
-		{200, 32},
+		//{200, 16},
+		//{200, 32},
 	}
 
 	samples := 3
 
-	days := []int{1, 7, 30, 365}
+	days := []int{1, 7}
 
 	visibilities := []util.VisibilityEnum{util.PublicVisibility, util.PrivateVisibility}
 
@@ -112,12 +111,12 @@ func TestBench(t *testing.T) {
 				Procedures: []ProcedureEnum{
 					ProcedureGetRecord,
 					ProcedureGetIndex,
-					ProcedureGetChangeIndex,
-					ProcedureGetFirstRecord,
+					//ProcedureGetChangeIndex,
+					//ProcedureGetFirstRecord,
 				},
 			},
 				// use pointer, so we can reassign the results channel
-				&resultsCh, false))
+				&resultsCh, true))
 		}
 	}
 
@@ -129,7 +128,7 @@ func TestBench(t *testing.T) {
 
 	for i, groupOfTests := range groupsOfTests {
 		schemaTest := kwilTesting.SchemaTest{
-			Name:          "benchmark_test_" + strconv.Itoa(i),
+			Name:          "benchmark_unix_test_" + strconv.Itoa(i),
 			SchemaFiles:   []string{},
 			FunctionTests: groupOfTests,
 		}
@@ -163,6 +162,7 @@ func TestBench(t *testing.T) {
 					}
 
 					t.Logf("Attempt %d failed: %s", attempt, err)
+					fmt.Println(errors.WithStack(err))
 					if attempt < maxRetries {
 						time.Sleep(time.Second * time.Duration(attempt)) // Exponential backoff
 					}

--- a/internal/contracts/composed_stream_template_unix.kf
+++ b/internal/contracts/composed_stream_template_unix.kf
@@ -1,0 +1,1106 @@
+// This file is the template to be used by Data Providers to deploy their own contracts.
+// A stream must conform to this same interface (read and permissions) to be eligible to officialization from our
+// accepted System Streams.
+
+database composed_stream_db_name;
+
+table taxonomies {
+    taxonomy_id         uuid    primary notnull,
+    child_stream_id     text    notnull,
+    child_data_provider text    notnull,
+    weight              decimal(36,18)   notnull,
+    created_at          int     notnull,    //  block height
+    disabled_at         int,                //  block height
+    version             int     notnull,
+    start_date          int // indicates the start date of when the taxonomy is valid. i.e. when the weight starts to be used
+}
+
+table metadata {
+    row_id      uuid    primary notnull,
+    metadata_key         text    notnull,
+    value_i     int,                 // integer type
+    value_f     decimal(36,18),       // float type
+    value_b     bool,                // boolean type
+    value_s     text,                // string type
+    value_ref   text,                // indexed string type -- lowercase
+    created_at  int     notnull,     // block height
+    disabled_at int,                 // block height
+
+    #key_idx        index(metadata_key),
+    #ref_idx        index(value_ref),
+    #created_idx    index(created_at) // faster sorting
+}
+
+foreign procedure ext_get_record($date_from int, $date_to int, $frozen_at int) returns table(
+    date_value int,
+    value decimal(36,18)
+)
+
+foreign procedure ext_get_index($date_from int, $date_to int, $frozen_at int, $base_date int) returns table(
+    date_value int,
+    value decimal(36,18)
+)
+
+foreign procedure ext_get_first_record($after_date int, $frozen_at int) returns table(
+    date_value int,
+    value decimal(36,18)
+)
+
+procedure stream_exists($data_provider text, $stream_id text) public view returns (result bool) {
+    $dbid text := get_dbid($data_provider, $stream_id);
+
+    for $row in SELECT * FROM get_metadata('type', true, null) {
+        return true;
+    }
+
+    return false;
+}
+
+procedure get_dbid($data_provider text, $stream_id text) private view returns (result text) {
+    $starts_with_0x bool := false;
+    for $row in SELECT $data_provider LIKE '0x%' as a {
+        $starts_with_0x := $row.a;
+    }
+
+    $data_provider_without_0x text;
+
+    if $starts_with_0x == true {
+        $data_provider_without_0x := substring($data_provider, 3);
+    } else {
+        $data_provider_without_0x := $data_provider;
+    }
+
+    return generate_dbid($stream_id, decode($data_provider_without_0x, 'hex'));
+}
+
+
+// It returns every record value for every date as its own
+// row. e.g.:
+// 2020-06-01, 100
+// 2020-06-01, 140
+// 2020-06-02, 103
+// 2020-06-02, 143
+procedure get_raw_record(
+    $date_from int,
+    $date_to int,
+    $frozen_at int,
+    $child_data_providers text[],
+    $child_stream_ids text[]
+) private view returns table(
+    date_value int,
+    value decimal(36,18),
+    taxonomy_index int
+) {
+    // checks are executed at the beginning of the procedure
+    if is_wallet_allowed_to_read(@caller) == false {
+        error('wallet not allowed to read');
+    }
+    // check if the stream is allowed to compose
+    is_stream_allowed_to_compose(@foreign_caller);
+
+    // check if the child_data_providers and child_stream_id are the same length
+    if array_length($child_data_providers) != array_length($child_stream_ids) {
+        error('child_data_providers and child_stream_id must be the same length');
+    }
+
+    if array_length($child_data_providers) > 0 {
+        // arrays are 1-indexed, so we match that
+        for $taxonomy_index in 1..array_length($child_data_providers) {
+            $dbid text := get_dbid($child_data_providers[$taxonomy_index], $child_stream_ids[$taxonomy_index]);
+            for $row3 in SELECT * FROM ext_get_record[$dbid, 'get_record']($date_from, $date_to, $frozen_at) {
+                return next $row3.date_value, $row3.value, $taxonomy_index;
+            }
+        }
+    }
+}
+
+
+// It returns every index value for every date as its own
+// row. e.g.:
+// 2020-06-01, 100
+// 2020-06-01, 140
+// 2020-06-02, 103
+// 2020-06-02, 143
+procedure get_raw_index(
+    $date_from int,
+    $date_to int,
+    $frozen_at int,
+    $child_data_providers text[],
+    $child_stream_ids text[],
+    $base_date int
+) private view returns table(
+    date_value int,
+    value decimal(36,18),
+    taxonomy_index int
+) {
+    // checks are executed at the beginning of the procedure
+    if is_wallet_allowed_to_read(@caller) == false {
+        error('wallet not allowed to read');
+    }
+    // check if the stream is allowed to compose
+    is_stream_allowed_to_compose(@foreign_caller);
+
+    // check if the child_data_providers and child_stream_id are the same length
+    if array_length($child_data_providers) != array_length($child_stream_ids) {
+        error('child_data_providers and child_stream_id must be the same length');
+    }
+
+    if array_length($child_data_providers) > 0 {
+        // arrays are 1-indexed, so we match that
+        for $taxonomy_index in 1..array_length($child_data_providers) {
+            $dbid text := get_dbid($child_data_providers[$taxonomy_index], $child_stream_ids[$taxonomy_index]);
+            for $row in SELECT * FROM ext_get_index[$dbid, 'get_index']($date_from, $date_to, $frozen_at, $base_date) {
+                return next $row.date_value, $row.value, $taxonomy_index;
+            }
+        }
+    }
+}
+
+// get_record_filled retrieves the filled records for a specified date range
+// and fills the gaps with the last known value for each taxonomy
+// if the last known value is not available, it will not emit the record, making it a sparse table
+procedure get_record_filled($date_from int, $date_to int, $frozen_at int) private view returns table(
+    date_value int,
+    value_with_weight decimal(36,18), // value * dynamic weight
+    // we also return the weight, so we can calculate the total weight for a date
+    weight decimal(36,18)
+) {
+    // this will help us reset the arrays
+    $base_taxonomy_list int[];
+
+    // Initialize taxonomy variables
+    $taxonomy_count int := 0;
+    $last_values decimal(36,18)[];
+    $child_data_providers text[];
+    $child_stream_id text[];
+
+    // Fetch taxonomy details
+    for $row in SELECT * FROM describe_taxonomies(true) {
+        $taxonomy_count := $taxonomy_count + 1;
+        $base_taxonomy_list := array_append($base_taxonomy_list, $taxonomy_count);
+        $last_values := array_append($last_values, null::decimal(36,18));
+        $child_data_providers := array_append($child_data_providers, $row.child_data_provider);
+        $child_stream_id := array_append($child_stream_id, $row.child_stream_id);
+    }
+
+    $unemitted_taxonomies_for_date int[] := $base_taxonomy_list;
+    $removed_elements_count int := 0;
+    $prev_date int := 0;
+    $current_date int := 0;
+
+   // what could make this process easier:
+   // - use a map to store the last values, so we can easily check if a value is null
+   // - better manipulation of tables as objects, then we could modify a table to
+   //   fill forward without needing to return immediately on each loop
+
+    // Fetch raw records and emit values with dynamic weights
+    for $row_raw in SELECT * FROM get_raw_record($date_from, $date_to, $frozen_at, $child_data_providers, $child_stream_id) ORDER BY date_value, taxonomy_index {
+        $current_date := $row_raw.date_value;
+
+        // Fetch the dynamic weight based on the current date
+        $dynamic_weight decimal(36,18) := get_dynamic_weight($child_stream_id[$row_raw.taxonomy_index], $current_date);
+
+        // Emit filled values for previous date if date has changed
+        if $current_date != $prev_date {
+            if $prev_date != 0 {
+                for $unemitted_taxonomy in $unemitted_taxonomies_for_date {
+                    // TODO: remove this when we have slices or include if we have just index assignment
+                    // if $unemitted_taxonomy is distinct from null {
+
+                    if $last_values[$unemitted_taxonomy] is distinct from null {
+                        // Use the stored dynamic weight from the previous date
+                        $dynamic_weight_prev := get_dynamic_weight($child_stream_id[$unemitted_taxonomy], $prev_date);
+                        return next $prev_date, $last_values[$unemitted_taxonomy] * $dynamic_weight_prev, $dynamic_weight_prev;
+                    }
+                }
+                // Clear unemitted taxonomies for the new date
+                $unemitted_taxonomies_for_date := $base_taxonomy_list;
+                $removed_elements_count := 0;
+            }
+        }
+
+        // TODO: uncomment when we have index assignment
+        // $last_values[$row_raw.taxonomy_index] := $row_raw.value;
+
+        // Update the last values for the current date
+        $last_values := array_update_element($last_values, $row_raw.taxonomy_index, $row_raw.value);
+
+        // Emit current value with the dynamic weight
+        return next $current_date, $row_raw.value * $dynamic_weight, $dynamic_weight;
+
+        // Remove emitted taxonomy from the unemitted list
+        // we need to subtract the removed_elements_count because the array is shrinking
+        // TODO: we can improve it when we either can remove elements, or with array element assignment
+        $unemitted_taxonomies_for_date := remove_array_element($unemitted_taxonomies_for_date, $row_raw.taxonomy_index - $removed_elements_count);
+        $removed_elements_count := $removed_elements_count + 1;
+        // remove elements is not performant without slices. Then let's make the elements null for now
+        // $unemitted_taxonomies_for_date[$row_raw.taxonomy_index] := null;
+
+        $prev_date := $current_date;
+    }
+
+    // Emit filled values for the last date
+    if $prev_date != 0 {
+        if $taxonomy_count > 0 {
+            for $unemitted_taxonomy2 in $unemitted_taxonomies_for_date {
+                if $last_values[$unemitted_taxonomy2] is distinct from null {
+                    // Fetch the correct dynamic weight for the last date
+                    $dynamic_weight_last := get_dynamic_weight($child_stream_id[$unemitted_taxonomy2], $prev_date);
+                    return next $prev_date, $last_values[$unemitted_taxonomy2] * $dynamic_weight_last, $dynamic_weight_last;
+                }
+            }
+        }
+    }
+}
+
+// get_index_filled retrieves the filled index for a specified date range
+// and fills the gaps with the last known value for each taxonomy
+// if the last known value is not available, it will not emit the index, making it a sparse table
+procedure get_index_filled($date_from int, $date_to int, $frozen_at int, $base_date int) private view returns table(
+    date_value int,
+    value_with_weight decimal(36,18), // value * dynamic weight
+    // we also return the weight, so we can calculate the total weight for a date
+    weight decimal(36,18)             // the dynamic weight for the date
+) {
+    // this will help us reset the arrays
+    $base_taxonomy_list int[];
+
+    // Initialize taxonomy variables
+    $taxonomy_count int := 0;
+    $last_values decimal(36,18)[];
+    $child_data_providers text[];
+    $child_stream_id text[];
+
+    // Fetch taxonomy details
+    for $row in SELECT * FROM describe_taxonomies(true) {
+        $taxonomy_count := $taxonomy_count + 1;
+        $base_taxonomy_list := array_append($base_taxonomy_list, $taxonomy_count);
+        $last_values := array_append($last_values, null::decimal(36,18));
+        $child_data_providers := array_append($child_data_providers, $row.child_data_provider);
+        $child_stream_id := array_append($child_stream_id, $row.child_stream_id);
+    }
+
+    $unemitted_taxonomies_for_date int[] := $base_taxonomy_list;
+    $removed_elements_count int := 0;
+    $prev_date int := 0;
+    $current_date int := 0;
+
+    // what could make this process easier:
+    // - use a map to store the last values, so we can easily check if a value is null
+    // - better manipulation of tables as objects, then we could modify a table to
+    //   fill forward without needing to return immediately on each loop
+
+    for $row_raw in SELECT * FROM get_raw_index($date_from, $date_to, $frozen_at, $child_data_providers, $child_stream_id, $base_date) ORDER BY date_value, taxonomy_index {
+        $current_date := $row_raw.date_value;
+
+        // Fetch the dynamic weight based on the current date
+        $dynamic_weight decimal(36,18) := get_dynamic_weight($child_stream_id[$row_raw.taxonomy_index], $current_date);
+
+        // Emit filled values for the previous date if the date has changed
+        if $current_date != $prev_date {
+            if $prev_date != 0 {
+                for $unemitted_taxonomy in $unemitted_taxonomies_for_date {
+                    if $last_values[$unemitted_taxonomy] is distinct from null {
+                        // TODO: remove this when we have slices or include if we have just index assignment
+                        // if $unemitted_taxonomy is distinct from null {
+
+                        // Use the stored dynamic weight from the previous date
+                        $dynamic_weight_prev := get_dynamic_weight($child_stream_id[$unemitted_taxonomy], $prev_date);
+                        return next $prev_date, $last_values[$unemitted_taxonomy] * $dynamic_weight_prev, $dynamic_weight_prev;
+                    }
+                }
+            }
+            // Clear unemitted taxonomies for the new date
+            $unemitted_taxonomies_for_date := $base_taxonomy_list;
+            $removed_elements_count := 0;
+        }
+
+        // TODO: uncomment when we have index assignment
+        // $last_values[$row_raw.taxonomy_index] := $row_raw.value;
+
+        // Update the last values for the current date
+        $last_values := array_update_element($last_values, $row_raw.taxonomy_index, $row_raw.value);
+
+        // Emit the current value with the dynamic weight
+        return next $current_date, $row_raw.value * $dynamic_weight, $dynamic_weight;
+
+        // Remove emitted taxonomy from the unemitted list
+        // TODO: we can improve it when we either can remove elements, or with array element assignment
+        $unemitted_taxonomies_for_date := remove_array_element($unemitted_taxonomies_for_date, $row_raw.taxonomy_index - $removed_elements_count);
+        $removed_elements_count := $removed_elements_count + 1;
+
+        // remove elements is not performant without slices. Then let's make the elements null for now
+        // $unemitted_taxonomies_for_date[$row_raw.taxonomy_index] := null;
+
+        $prev_date := $current_date;
+    }
+
+    // Emit filled values for the last date
+    if $prev_date != 0 {
+        if $taxonomy_count > 0 {
+            for $unemitted_taxonomy2 in $unemitted_taxonomies_for_date {
+                if $last_values[$unemitted_taxonomy2] is distinct from null {
+                    // Fetch the correct dynamic weight for the last date
+                    $dynamic_weight_last := get_dynamic_weight($child_stream_id[$unemitted_taxonomy2], $prev_date);
+                    return next $prev_date, $last_values[$unemitted_taxonomy2] * $dynamic_weight_last, $dynamic_weight_last;
+                }
+            }
+        }
+    }
+}
+
+// get_record retrieves the records for a specified date range as expected from the stream interface
+// i.e. with filled gaps
+procedure get_record($date_from int, $date_to int, $frozen_at int) public view returns table(
+    date_value int,
+    value decimal(36,18)
+) {
+    $in_range bool := false;
+    $last_date int;
+    $last_value decimal(36,18);
+    // here, we sum all of the records that were found by aggregating on the date_valie
+    for $row in SELECT date_value, total_value_with_weight / total_weight as value FROM
+        (SELECT
+            date_value,
+            SUM(value_with_weight)::decimal(36,18) AS total_value_with_weight,
+            SUM(weight)::decimal(36,18) AS total_weight
+        FROM get_record_filled($date_from, $date_to, $frozen_at) group by date_value) as r {
+        // when we arrive in the range, we start emitting. If there was a previous value, we emit it
+        if $in_range == false {
+            if $row.date_value >= $date_from {
+                $in_range := true;
+                if ($last_date is distinct from null) AND $row.date_value != $date_from {
+                    return next $last_date, $last_value;
+                }
+            }
+
+            $last_date := $row.date_value;
+            $last_value := $row.value;
+        }
+        // we check again, because it might just have entered the range
+        if $in_range == true {
+            return next $row.date_value, $row.value;
+        }
+    }
+
+    // if we finished the loop and we never entered the range, we emit the last value
+    if $in_range == false AND $last_date is distinct from null {
+        return next $last_date, $last_value;
+    }
+}
+
+
+// get_index retrieves the index for a specified date range as expected from the stream interface
+// i.e. with filled gaps
+procedure get_index($date_from int, $date_to int, $frozen_at int, $base_date int) public view returns table(
+    date_value int,
+    value decimal(36,18)
+) {
+    $in_range bool := false;
+    $last_date int;
+    $last_value decimal(36,18);
+    $effective_base_date int := $base_date;
+
+    if $effective_base_date is null OR $effective_base_date == 0 {
+        for $v_row in SELECT * FROM get_metadata('default_base_date', true, null) ORDER BY created_at DESC LIMIT 1 {
+            $effective_base_date := $v_row.value_i;
+        }
+    }
+
+    // here, we sum all of the indexes that were found by aggregating on the date_value
+    for $row in SELECT date_value, total_value_with_weight / total_weight as value FROM
+        (SELECT
+            date_value,
+            SUM(value_with_weight)::decimal(36,18) AS total_value_with_weight,
+            SUM(weight)::decimal(36,18) AS total_weight
+        FROM get_index_filled($date_from, $date_to, $frozen_at, $effective_base_date) group by date_value) as r {
+        // when we arrive in the range, we start emitting. If there was a previous value, we emit it
+        if $in_range == false {
+            if $row.date_value >= $date_from {
+                $in_range := true;
+                if ($last_date is distinct from null) AND $row.date_value != $date_from {
+                    return next $last_date, $last_value;
+                }
+            }
+
+            $last_date := $row.date_value;
+            $last_value := $row.value;
+        }
+        // we check again, because it might just have entered the range
+        if $in_range == true {
+            return next $row.date_value, $row.value;
+        }
+    }
+
+    // if we finished the loop and we never entered the range, we emit the last value
+    if $in_range == false AND $last_date is distinct from null {
+        return next $last_date, $last_value;
+    }
+
+}
+
+// get_first_record returns the first record of the composed stream (optionally after a given date)
+// Note: this operation performs 2 loop queries through the taxonomies (O(2n)).
+// Couldn't optimize to do once because there are edge cases when after_date is provided
+// and the first record is before that date.
+procedure get_first_record($after_date int, $frozen_at int) public view returns table(
+    date_value int,
+    value decimal(36,18)
+) {
+    // check read access
+    if is_wallet_allowed_to_read(@caller) == false {
+        error('wallet not allowed to read');
+    }
+
+    // check compose access
+    is_stream_allowed_to_compose(@foreign_caller);
+
+    // let's coalesce null with ''
+    // then, if it's empty, it will always be the first value
+    if $after_date is null {
+        $after_date := 0;
+    }
+
+    // 1. figure the earliest date possible after the after_date
+   $earliest_date int := 0;
+   for $taxonomy_row in SELECT * FROM describe_taxonomies(true) {
+        $dbid := get_dbid($taxonomy_row.child_data_provider, $taxonomy_row.child_stream_id);
+        for $record_row in SELECT * FROM ext_get_first_record[$dbid, 'get_first_record']($after_date, $frozen_at) {
+            if $earliest_date == 0 OR $record_row.date_value < $earliest_date {
+                $earliest_date := $record_row.date_value;
+            }
+        }
+   }
+
+   // 2. get_record with the earliest date if it exists
+   if $earliest_date != 0 {
+       for $row in SELECT date_value, value FROM get_record($earliest_date, $earliest_date, $frozen_at) {
+            return next $row.date_value, $row.value;
+       }
+   }
+}
+
+procedure is_initiated() private view returns (result bool) {
+    // check if it was already initialized
+    // for that we check if type is already provided
+    for $row in SELECT * FROM metadata WHERE metadata_key = 'type' LIMIT 1 {
+        return true;
+    }
+
+    return false;
+}
+
+procedure is_stream_owner($wallet text) public view returns (result bool) {
+    for $row in SELECT * FROM metadata WHERE metadata_key = 'stream_owner' AND value_ref = LOWER($wallet) LIMIT 1 {
+        return true;
+    }
+    return false;
+}
+
+procedure is_wallet_allowed_to_read($wallet text) public view returns (value bool) {
+
+    // if public, anyone can always read
+    // If there's no visibility metadata, it's public.
+    $visibility int := 0;
+    for $v_row in SELECT * FROM get_metadata('read_visibility', true, null) {
+        $visibility := $v_row.value_i;
+    }
+
+    if $visibility == 0 {
+        return true;
+    }
+
+    // if it's the owner, it's permitted
+    if is_stream_owner($wallet) {
+        return true;
+    }
+
+    // if there's metadata allow_read_wallet -> <wallet>, then its permitted
+    for $row in SELECT * FROM get_metadata('allow_read_wallet', false, $wallet) {
+        return true;
+    }
+
+    return false;
+}
+
+procedure stream_owner_only() private view {
+    if is_stream_owner(@caller) == false  {
+        error('Stream owner only procedure');
+    }
+}
+
+// init method prepares the contract with default values and permanent ones
+procedure init() public owner {
+    if is_initiated() {
+        error('this contract was already initialized');
+    }
+
+    // check if caller is empty
+    // this happens can happen in tests, but we should also protect for that on production
+    if @caller == '' {
+        error('caller is empty');
+    }
+
+    $current_block int := @height;
+
+    // uuid's namespaces are any random generated uuid from https://www.uuidtools.com/v5
+    // but each usage should be different to maintain determinism, so we reuse the previous result
+    $current_uuid uuid := uuid_generate_v5('41fea9f0-179f-11ef-8838-325096b39f47'::uuid, @txid);
+
+    // type = composed
+    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+    INSERT INTO metadata (row_id, metadata_key, value_s, created_at)
+        VALUES ($current_uuid, 'type', 'composed', $current_block);
+
+    // stream_owner = @caller
+    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+    INSERT INTO metadata (row_id, metadata_key, value_ref, created_at)
+        VALUES ($current_uuid, 'stream_owner', LOWER(@caller), 1);
+
+    // compose_visibility = 0 (public)
+    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+    INSERT INTO metadata (row_id, metadata_key, value_i, created_at)
+        VALUES ($current_uuid, 'compose_visibility', 0, $current_block);
+
+    // read_visibility = 0 (public)
+    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+    INSERT INTO metadata (row_id, metadata_key, value_i, created_at)
+        VALUES ($current_uuid, 'read_visibility', 0, $current_block);
+
+    $readonly_keys text[] := [
+        'type',
+        'stream_owner',
+        'readonly_key',
+        'taxonomy_version'
+    ];
+
+    for $key in $readonly_keys {
+        $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+        INSERT INTO metadata (row_id, metadata_key, value_s, created_at)
+            VALUES ($current_uuid, 'readonly_key', $key, $current_block);
+    }
+}
+
+// Note:    We're letting the user be the source of truth for which type a key should have.
+//          To change that, we could initiate `key_type:<key>` key on metadata table, that could be used here
+//          to enforce a type. However, this would force us to know every metadata key before deploying a contract
+procedure insert_metadata(
+    $key text,
+    $value text,
+    $val_type text
+    // TODO: would be better to use value_x from args. However this doesn't work well for nullable inputs
+    //  i.e. if we use a bool type we'll get an conversion error from Nil -> bool. And we don't want to force user to provide
+    //  a value if nil is intended.
+    ) public {
+
+    $value_i int;
+    $value_s text;
+    $value_f decimal(36,18);
+    $value_b bool;
+    $value_ref text;
+
+    if $val_type == 'int' {
+        $value_i := $value::int;
+    } elseif $val_type == 'string' {
+        $value_s := $value;
+    } elseif $val_type == 'bool' {
+        $value_b := $value::bool;
+    } elseif $val_type == 'ref' {
+        $value_ref := $value;
+    } elseif $val_type == 'float' {
+        $value_f := $value::decimal(36,18);
+    } else {
+        error(format('unknown type used "%s". valid types = "float" | "bool" | "int" | "ref" | "string"', $val_type));
+    }
+
+    stream_owner_only();
+
+    if is_initiated() == false {
+        error('contract must be initiated');
+    }
+
+    // check if it's read-only
+    for $row in SELECT * FROM metadata WHERE metadata_key = 'readonly_key' AND value_s = $key LIMIT 1 {
+        error('Cannot insert metadata for read-only key');
+    }
+
+    // we create one deterministic uuid for each metadata record
+    // we can't use just @txid because a single transaction can insert multiple metadata records.
+    // the result will be idempotency here too.
+    $uuid_key := @txid || $key || $value;
+
+    $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, $uuid_key);
+    $current_block int := @height;
+
+    // insert data
+    INSERT INTO metadata (row_id, metadata_key, value_i, value_f, value_s, value_b, value_ref, created_at)
+        VALUES ($uuid, $key, $value_i, $value_f, $value_s, $value_b, LOWER($value_ref), $current_block);
+}
+
+// key: the metadata key to look for
+// only_latest: if true, only return the latest version of the metadata
+// ref: if provided, only return metadata with that ref
+procedure get_metadata($key text, $only_latest bool, $ref text) public view returns table(
+        row_id uuid,
+        value_i int,
+        value_f decimal(36,18),
+        value_b bool,
+        value_s text,
+        value_ref text,
+        created_at int
+        ) {
+
+        if $only_latest == true {
+            if $ref is distinct from null {
+                return SELECT
+                              row_id,
+                              null::int as value_i,
+                              null::decimal(36,18) as value_f,
+                              null::bool as value_b,
+                              null::text as value_s,
+                              value_ref,
+                              created_at
+                FROM metadata
+                WHERE metadata_key = $key AND disabled_at IS NULL AND value_ref = LOWER($ref)
+                ORDER BY created_at DESC
+                LIMIT 1;
+            } else {
+                return SELECT
+                              row_id,
+                              value_i,
+                              value_f,
+                              value_b,
+                              value_s,
+                              value_ref,
+                              created_at
+                FROM metadata
+                WHERE metadata_key = $key AND disabled_at IS NULL
+                ORDER BY created_at DESC
+                LIMIT 1;
+            }
+        } else {
+           // SHOULD BE THE EXACT CODE AS ABOVE, BUT WITHOUT LIMIT
+           if $ref is distinct from null {
+               return SELECT
+                             row_id,
+                             null::int as value_i,
+                             null::decimal(36,18) as value_f,
+                             null::bool as value_b,
+                             null::text as value_s,
+                             value_ref,
+                             created_at
+                FROM metadata
+                WHERE metadata_key = $key AND disabled_at IS NULL AND value_ref = LOWER($ref)
+                ORDER BY created_at DESC;
+           } else {
+               return SELECT
+                             row_id,
+                             value_i,
+                             value_f,
+                             value_b,
+                             value_s,
+                             value_ref,
+                             created_at
+               FROM metadata
+               WHERE metadata_key = $key AND disabled_at IS NULL
+               ORDER BY created_at DESC;
+           }
+        }
+}
+
+procedure disable_metadata($row_id uuid) public {
+    stream_owner_only();
+
+    $current_block int := @height;
+
+    $found bool := false;
+
+    // Check if the metadata is not read-only
+    for $metadata_row in
+    SELECT metadata_key
+    FROM metadata
+    WHERE row_id = $row_id AND disabled_at IS NULL
+    LIMIT 1 {
+        $found := true;
+        $row_key text := $metadata_row.metadata_key;
+
+        for $readonly_row in SELECT row_id FROM metadata WHERE metadata_key = 'readonly_key' AND value_s = $row_key LIMIT 1 {
+            error('Cannot disable read-only metadata');
+        }
+
+        UPDATE metadata SET disabled_at = $current_block
+        WHERE row_id = $row_id;
+    }
+
+    if $found == false {
+        error('metadata record not found');
+    }
+}
+
+procedure transfer_stream_ownership($new_owner text) public {
+    stream_owner_only();
+
+    // fail if not a valid address
+    check_eth_address($new_owner);
+
+    UPDATE metadata SET value_ref = LOWER($new_owner)
+    WHERE metadata_key = 'stream_owner';
+}
+
+procedure check_eth_address($address text) private {
+    // TODO better check when kwil supports regexp and {}[] inside strings
+    // regex: ^0x[0-9a-fA-F]{40}$
+    // for $row in SELECT regexp_match($address, '^0x[0-9a-fA-F]{40}$') {
+    //     return true;
+    // }
+
+    if (length($address) != 42) {
+        error('invalid address length');
+    }
+
+    // check if starts with 0x
+    for $row in SELECT $address LIKE '0x%' as a {
+        if $row.a == false {
+            error('address does not start with 0x');
+        }
+    }
+}
+
+procedure get_current_version($show_disabled bool) private view returns (result int) {
+    if $show_disabled == false {
+         for $row in SELECT version FROM taxonomies WHERE disabled_at IS NULL ORDER BY version DESC LIMIT 1 {
+             return $row.version;
+         }
+    } else {
+        for $row2 in SELECT version FROM taxonomies ORDER BY version DESC LIMIT 1 {
+            return $row2.version;
+        }
+    }
+
+    return 0;
+}
+
+
+// NOTE we won't use this signature jsonb is not supported
+// procedure set_taxonomy($payload text) public {
+//     stream_owner_only();
+//     $next_version int := get_current_version() + 1;
+//     $block_height int := 2;
+//     $current_uuid uuid := uuid_generate_v5('e92064da-19c5-11ef-9bc0-325096b39f47'::uuid, @txid);
+//    for $row in SELECT
+//            elem->>'stream_id' as stream_id,
+//            elem->>'data_provider' as data_provider,
+//            elem->>'weight' as weight
+//        FROM jsonb_array_elements($payload::jsonb) as elem {
+//         $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+//         INSERT INTO taxonomy ( child_stream_id, child_stream_id, weight, created_at, version)
+//             VALUES ($row.stream_id, $row.data_provider, $row.weight::int, $block_height, $next_version);
+//     }
+// }
+
+// set_taxonomy is a batch insert that
+// - gets an array of values for each properties, zipping them as needed
+// - increases the version
+// - adds taxonomy records in batch
+procedure set_taxonomy($data_providers text[], $stream_ids text[], $weights decimal(36,18)[], $start_date int) public {
+    stream_owner_only();
+
+    $next_version int := get_current_version(true) + 1;
+    $block_height int := @height;
+    $current_uuid uuid := uuid_generate_v5('e92064da-19c5-11ef-9bc0-325096b39f47'::uuid, @txid);
+
+    $length int := array_length($data_providers);
+
+    // check lengths
+    if $length != array_length($stream_ids) {
+        error('data_providers and stream_ids must have the same length');
+    }
+    if $length != array_length($weights) {
+        error('data_providers and weights must have the same length');
+    }
+
+    for $i in 1..$length {
+        $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+
+        INSERT INTO taxonomies (taxonomy_id, child_stream_id, child_data_provider, weight, created_at, version, start_date)
+            VALUES ($current_uuid, $stream_ids[$i], $data_providers[$i], $weights[$i], $block_height, $next_version, $start_date);
+    }
+}
+
+procedure describe_taxonomies($latest_version bool) public view returns table(
+        child_stream_id text,
+        child_data_provider text,
+        weight decimal(36,18),
+        created_at int,
+        version int,
+        start_date int
+        ) {
+
+        if $latest_version == true {
+            // just the latest enabled version should be returned
+            return SELECT
+                child_stream_id,
+                child_data_provider,
+                weight,
+                created_at,
+                version,
+                start_date
+            FROM taxonomies
+            WHERE version = get_current_version(false) AND disabled_at IS NULL
+            ORDER BY created_at DESC;
+        } else {
+            return SELECT
+                child_stream_id,
+                child_data_provider,
+                weight,
+                created_at,
+                version,
+                start_date
+            FROM taxonomies
+            WHERE disabled_at IS NULL
+            ORDER BY version DESC;
+        }
+}
+
+// TODO: we should have a way to disable a taxonomy by taxonomy_id
+procedure disable_taxonomy($version int) public {
+    stream_owner_only();
+
+    $current_block int := @height;
+
+    $found bool := false;
+
+    // Check if the taxonomies with the given version exist and disable them
+    for $row in SELECT child_stream_id FROM taxonomies WHERE version = $version AND disabled_at IS NULL {
+        $found := true;
+        UPDATE taxonomies SET disabled_at = $current_block
+        WHERE version = $version AND disabled_at IS NULL;
+    }
+
+    if $found == false {
+        error('No taxonomies found for the given version');
+    }
+}
+
+procedure is_stream_allowed_to_compose($foreign_caller text) public view returns (value bool) {
+    // if foreign_caller is empty, then it's a direct call
+    if $foreign_caller == '' {
+        return true;
+    }
+
+    // if public, anyone can always read
+    // If there's no visibility metadata, it's public.
+    $visibility int := 0;
+    for $v_row in SELECT * FROM get_metadata('compose_visibility', true, null) {
+        $visibility := $v_row.value_i;
+    }
+
+    if $visibility == 0 {
+        return true;
+    }
+
+    // if there's metadata allow_compose_stream -> <foreign_caller>, then its permitted
+    for $row in SELECT * FROM get_metadata('allow_compose_stream', true, $foreign_caller) LIMIT 1 {
+        return true;
+    }
+
+    error('Stream not allowed to compose');
+}
+
+
+procedure get_index_change($date_from int, $date_to int, $frozen_at int, $base_date int, $days_interval int) public view returns table(
+    date_value int,
+    value decimal(36,18)
+) {
+    // the full process is this:
+    // 1. we find the current values for the given date range
+    // | date | value |
+    // | 01-2001 | ... |
+    // | 05-2001 | ... |
+    // | 09-2001 | ... |
+    // | 10-2001 | ... |
+
+    // 2. we get a list of expected previous dates
+    // | current_date | expected_prev_date |
+    // | 01-2001       | 01-2000            |
+    // | 05-2001       | 05-2000            |
+    // | 09-2001       | 09-2000            |
+    // | 10-2001       | 10-2000            |
+
+    // 3. we query the real previous values for the expected previous dates, using earliest and latest dates
+    // they might not match the expected previous dates
+    // | real_prev_date | value |
+    // | 01-2000        | ... |
+    // | 03-2000        | ... |
+    // | 04-2000        | ... |
+    // | 09-2000        | ... |
+
+    // 4. we try to match the expected prev dates with the real prev dates.
+    // see that each expected date should be 1:1 with a result prev date.
+    // | expected_prev_date | real_prev_date | result_prev_date |
+    // | 01-2000            | 01-2000        | 01-2000         |
+    // | -                  | 03-2000        | -               |
+    // | -                  | 04-2000        | -               |
+    // | 05-2000            | -              | 04-2000         |
+    // | 09-2000            | 09-2000        | 09-2000         |
+    // | 10-2000            | -              | 09-2000         |
+
+    // 5. we calculate the index change for the current values and the result prev values
+    // and done.
+
+
+
+    if $frozen_at == null {
+        $frozen_at := 0;
+    }
+
+    if $days_interval == null {
+        error('days_interval is required');
+    }
+
+    $current_values decimal(36,18)[];
+    // example: [01-2001, 05-2001, 09-2001, 10-2001]
+    $current_dates int[];
+    // example: [01-2000, 05-2000, 09-2000, 10-2000]
+    $expected_prev_dates int[];
+
+    for $row_current in SELECT * FROM get_index($date_from, $date_to, $frozen_at, $base_date) {
+        $prev_date := $row_current.date_value - ($days_interval * 86400);
+        $expected_prev_dates := array_append($expected_prev_dates, $prev_date);
+        $current_values := array_append($current_values, $row_current.value);
+        $current_dates := array_append($current_dates, $row_current.date_value);
+    }
+
+    // example: 01-2000]
+    $earliest_prev_date := $expected_prev_dates[1];
+    // example: 09-2000
+    $latest_prev_date := $expected_prev_dates[array_length($expected_prev_dates)];
+
+    // real previous values doesn't match the same length as expected previous dates
+    // because the interval can have much more values than the expected dates
+    $real_prev_values decimal(36,18)[];
+    $real_prev_dates int[];
+
+    // now we query the prev dates
+    for $row_prev in SELECT * FROM get_index($earliest_prev_date, $latest_prev_date, $frozen_at, $base_date) {
+        $real_prev_values := array_append($real_prev_values, $row_prev.value);
+        $real_prev_dates := array_append($real_prev_dates, $row_prev.date_value);
+    }
+
+    // now we calculate the matching dates for the real prev values
+    $result_prev_dates int[];
+    $result_prev_values decimal(36,18)[];
+
+    $real_prev_date_idx int := 1;
+
+    // for each expected prev date, we find the matching real prev date
+    if array_length($expected_prev_dates) > 0 {
+        for $expected_prev_date_idx in 1..array_length($expected_prev_dates) {
+            // we start from the last index of real prev dates. we don't need to check previous values
+            for $selector in $real_prev_date_idx..array_length($real_prev_dates) {
+                // if next real prev date is greater than expected prev date (or null), then we need to use the current real value
+                if $real_prev_dates[$selector + 1] > $expected_prev_dates[$expected_prev_date_idx] OR $real_prev_dates[$selector + 1] IS NULL {
+                    // if the current real prev date is already greater than expected prev date
+                    // we use NULL. We're probably before the first real prev date here
+                    if $real_prev_dates[$selector] > $expected_prev_dates[$expected_prev_date_idx] {
+                        $result_prev_dates := array_append($result_prev_dates, null::int);
+                        $result_prev_values := array_append($result_prev_values, null::decimal(36,18));
+                    } else {
+                    $result_prev_dates := array_append($result_prev_dates, $real_prev_dates[$selector]);
+                    $result_prev_values := array_append($result_prev_values, $real_prev_values[$selector]);
+                    }
+                    // we already appended one for current $real_prev_date_idx, then we need to go to next
+                    $real_prev_date_idx := $selector;
+                    break;
+                }
+            }
+        }
+    }
+
+    // check if we have the same number of values and dates
+    if array_length($current_dates) != array_length($result_prev_dates) {
+        error('we have different number of dates and values');
+    }
+    if array_length($current_values) != array_length($result_prev_values) {
+        error('we have different number of dates and values');
+    }
+
+    // calculate the index change
+    if array_length($result_prev_dates) > 0 {
+        for $row_result in 1..array_length($result_prev_dates) {
+            // if the expected_prev_date is null, then we don't have a real prev date
+            if $result_prev_dates[$row_result] IS DISTINCT FROM NULL {
+                return next $current_dates[$row_result], ($current_values[$row_result] - $result_prev_values[$row_result]) * 100.00::decimal(36,18) / $result_prev_values[$row_result];
+            }
+        }
+    }
+}
+
+// # Miscellaneous helpers
+
+// emit_values_if is a helper function to emit values if a condition is met
+procedure emit_values_if($condition bool, $date_value int, $values decimal(36,18)[], $weights decimal(36,18)[]) private view returns table(
+    date_value int,
+    value decimal(36,18),
+    weight decimal(36,18)
+) {
+    if $condition == true {
+        if array_length($values) > 0 {
+            for $i in 1..array_length($values) {
+                return next $date_value, $values[$i], $weights[$i];
+            }
+        }
+    }
+}
+
+
+procedure remove_array_element($array int[], $index int) private view returns (result int[]) {
+    // todo: this is too inefficient.
+    // we should use slices (i.e. arr[1:3]) when supported
+    $new_array int[];
+    for $i in 1..array_length($array) {
+        if $i != $index {
+            $new_array := array_append($new_array, $array[$i]);
+        }
+    }
+
+    return $new_array;
+}
+
+procedure array_update_element($array decimal(36,18)[], $index int, $value decimal(36,18)) private view returns (result decimal(36,18)[]) {
+    $new_array decimal(36,18)[];
+    for $i in 1..array_length($array) {
+        if $i == $index {
+            $new_array := array_append($new_array, $value);
+        } else {
+            $new_array := array_append($new_array, $array[$i]);
+        }
+    }
+    return $new_array;
+}
+
+// Returns the weight based on the closest start_date before or equal to the given date
+procedure get_dynamic_weight($stream_id text, $date_value int) private view returns (
+    weight decimal(36,18)
+) {
+    // Select the closest weight by stream_id where start_date is before or equal to the current date_value
+    for $row in SELECT weight
+    FROM taxonomies
+    WHERE child_stream_id = $stream_id
+    AND (start_date IS NULL OR start_date = 0 OR start_date <= $date_value)
+    ORDER BY start_date DESC
+    LIMIT 1 {
+        return $row.weight;
+    }
+
+    // If no weight is found, we return the earliest weight available, this to ensure that we always have a weight
+    // for the given date even if it's before the first weight's start_date
+    // Would be better if COALESCE was supported
+    for $row2 in SELECT weight
+    FROM taxonomies
+    WHERE child_stream_id = $stream_id
+    ORDER BY start_date ASC
+    LIMIT 1 {
+        return $row2.weight;
+    }
+}

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -15,3 +15,9 @@ var ComposedStreamContent []byte
 
 //go:embed primitive_stream_template.kf
 var PrimitiveStreamContent []byte
+
+//go:embed composed_stream_template_unix.kf
+var ComposedStreamUnixContent []byte
+
+//go:embed primitive_stream_unix.kf
+var PrimitiveStreamUnixContent []byte

--- a/internal/contracts/primitive_stream_unix.kf
+++ b/internal/contracts/primitive_stream_unix.kf
@@ -1,0 +1,721 @@
+// This file is the template to be used by Data Providers to deploy their own contracts.
+// A stream must conform to this same interface (read and permissions) to be eligible to officialization from our
+// accepted System Streams.
+
+database primitive_stream_db_name;
+
+table primitive_events {
+    date_value int notnull, // unix timestamp
+    value decimal(36,18) notnull,
+    created_at int notnull, // based on blockheight
+
+    #identifier_idx   primary(date_value, created_at)
+}
+
+table metadata {
+    row_id      uuid    primary notnull,
+    metadata_key         text    notnull,
+    value_i     int,                 // integer type
+    value_f     decimal(36,18),
+    value_b     bool,                // boolean type
+    value_s     text,                // string type
+    value_ref   text,                // indexed string type -- lowercase
+    created_at  int     notnull,     // block height
+    disabled_at int,                 // block height
+
+    #key_idx    index(metadata_key),
+    #ref_idx    index(value_ref),
+    #created_idx    index(created_at) // faster sorting
+}
+
+procedure is_initiated() private view returns (result bool) {
+    // check if it was already initialized
+    // for that we check if type is already provided
+    for $row in SELECT * FROM metadata WHERE metadata_key = 'type' LIMIT 1 {
+        return true;
+    }
+
+    return false;
+}
+
+procedure is_stream_owner($wallet text) public view returns (result bool) {
+    for $row in SELECT * FROM metadata WHERE metadata_key = 'stream_owner' AND value_ref = LOWER($wallet) LIMIT 1 {
+        return true;
+    }
+    return false;
+}
+
+procedure is_wallet_allowed_to_write($wallet text) public view returns (value bool) {
+    // if it's the owner, it's permitted
+    if is_stream_owner($wallet) {
+        return true;
+    }
+
+    // if there's metadata allow_write_wallet -> <wallet>, then its permitted
+    for $row in SELECT * FROM get_metadata('allow_write_wallet', false, $wallet) {
+        return true;
+    }
+
+    return false;
+}
+
+procedure is_wallet_allowed_to_read($wallet text) public view returns (value bool) {
+
+    // if public, anyone can always read
+    // If there's no visibility metadata, it's public.
+    $visibility int := 0;
+    for $v_row in SELECT * FROM get_metadata('read_visibility', true, null) {
+        $visibility := $v_row.value_i;
+    }
+
+    if $visibility == 0 {
+        return true;
+    }
+
+    // if it's the owner, it's permitted
+    if is_stream_owner($wallet) {
+        return true;
+    }
+
+    // if there's metadata allow_read_wallet -> <wallet>, then its permitted
+    for $row in SELECT * FROM get_metadata('allow_read_wallet', false, $wallet) {
+        return true;
+    }
+
+    return false;
+}
+
+procedure stream_owner_only() private view {
+    if is_stream_owner(@caller) == false  {
+        error('Stream owner only procedure');
+    }
+}
+
+// init method prepares the contract with default values and permanent ones
+procedure init() public owner {
+    if is_initiated() {
+        error('this contract was already initialized');
+    }
+
+    // check if caller is empty
+    // this happens can happen in tests, but we should also protect for that on production
+    if @caller == '' {
+        error('caller is empty');
+    }
+
+    $current_block int := @height;
+
+    // uuid's namespaces are any random generated uuid from https://www.uuidtools.com/v5
+    // but each usage should be different to maintain determinism, so we reuse the previous result
+    $current_uuid uuid := uuid_generate_v5('111bfa42-17a2-11ef-bf03-325096b39f47'::uuid, @txid);
+
+    // type = primitive
+    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+    INSERT INTO metadata (row_id, metadata_key, value_s, created_at)
+        VALUES ($current_uuid, 'type', 'primitive', $current_block);
+
+    // stream_owner = @caller
+    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+    INSERT INTO metadata (row_id, metadata_key, value_ref, created_at)
+        VALUES ($current_uuid, 'stream_owner', LOWER(@caller), 1);
+
+    // compose_visibility = 0 (public)
+    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+    INSERT INTO metadata (row_id, metadata_key, value_i, created_at)
+        VALUES ($current_uuid, 'compose_visibility', 0, $current_block);
+
+    // read_visibility = 0 (public)
+    $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+    INSERT INTO metadata (row_id, metadata_key, value_i, created_at)
+        VALUES ($current_uuid, 'read_visibility', 0, $current_block);
+
+    $readonly_keys text[] := [
+        'type',
+        'stream_owner',
+        'readonly_key'
+    ];
+
+    for $key in $readonly_keys {
+        $current_uuid :=  uuid_generate_v5($current_uuid, @txid);
+        INSERT INTO metadata (row_id, metadata_key, value_s, created_at)
+            VALUES ($current_uuid, 'readonly_key', $key, $current_block);
+    }
+}
+
+// Note:    We're letting the user be the source of truth for which type a key should have.
+//          To change that, we could initiate `key_type:<key>` key on metadata table, that could be used here
+//          to enforce a type. However, this would force us to know every metadata key before deploying a contract
+procedure insert_metadata(
+    $key text,
+    $value text,
+    $val_type text
+    // TODO: would be better to use value_x from args. However this doesn't work well for nullable inputs
+    //  i.e. if we use a bool type we'll get an conversion error from Nil -> bool. And we don't want to force user to provide
+    //  a value if nil is intended.
+    ) public {
+
+    $value_i int;
+    $value_s text;
+    $value_f decimal(36,18);
+    $value_b bool;
+    $value_ref text;
+
+    if $val_type == 'int' {
+        $value_i := $value::int;
+    } elseif $val_type == 'string' {
+        $value_s := $value;
+    } elseif $val_type == 'bool' {
+        $value_b := $value::bool;
+    } elseif $val_type == 'ref' {
+        $value_ref := $value;
+    } elseif $val_type == 'float' {
+        $value_f := $value::decimal(36,18);
+    } else {
+        error(format('unknown type used "%s". valid types = "float" | "bool" | "int" | "ref" | "string"', $val_type));
+    }
+
+    stream_owner_only();
+
+    if is_initiated() == false {
+        error('contract must be initiated');
+    }
+
+    // check if it's read-only
+    for $row in SELECT * FROM metadata WHERE metadata_key = 'readonly_key' AND value_s = $key LIMIT 1 {
+        error('Cannot insert metadata for read-only key');
+    }
+
+    // we create one deterministic uuid for each metadata record
+    // we can't use just @txid because a single transaction can insert multiple metadata records.
+    // the result will be idempotency here too.
+    $uuid_key := @txid || $key || $value;
+
+    $uuid uuid := uuid_generate_v5('1361df5d-0230-47b3-b2c1-37950cf51fe9'::uuid, $uuid_key);
+    $current_block int := @height;
+
+    // insert data
+    INSERT INTO metadata (row_id, metadata_key, value_i, value_f, value_s, value_b, value_ref, created_at)
+        VALUES ($uuid, $key, $value_i, $value_f, $value_s, $value_b, LOWER($value_ref), $current_block);
+}
+
+// key: the metadata key to look for
+// only_latest: if true, only return the latest version of the metadata
+// ref: if provided, only return metadata with that ref
+procedure get_metadata($key text, $only_latest bool, $ref text) public view returns table(
+        row_id uuid,
+        value_i int,
+        value_f decimal(36,18),
+        value_b bool,
+        value_s text,
+        value_ref text,
+        created_at int
+        ) {
+
+        if $only_latest == true {
+            if $ref is distinct from null {
+                return SELECT
+                              row_id,
+                              null::int as value_i,
+                              null::decimal(36,18) as value_f,
+                              null::bool as value_b,
+                              null::text as value_s,
+                              value_ref,
+                              created_at
+                FROM metadata
+                WHERE metadata_key = $key AND disabled_at IS NULL AND value_ref = LOWER($ref)
+                ORDER BY created_at DESC
+                LIMIT 1;
+            } else {
+                return SELECT
+                              row_id,
+                              value_i,
+                              value_f,
+                              value_b,
+                              value_s,
+                              value_ref,
+                              created_at
+                FROM metadata
+                WHERE metadata_key = $key AND disabled_at IS NULL
+                ORDER BY created_at DESC
+                LIMIT 1;
+            }
+        } else {
+           // SHOULD BE THE EXACT CODE AS ABOVE, BUT WITHOUT LIMIT
+           if $ref is distinct from null {
+               return SELECT
+                             row_id,
+                             null::int as value_i,
+                             null::decimal(36,18) as value_f,
+                             null::bool as value_b,
+                             null::text as value_s,
+                             value_ref,
+                             created_at
+                FROM metadata
+                WHERE metadata_key = $key AND disabled_at IS NULL AND value_ref = LOWER($ref)
+                ORDER BY created_at DESC;
+           } else {
+               return SELECT
+                             row_id,
+                             value_i,
+                             value_f,
+                             value_b,
+                             value_s,
+                             value_ref,
+                             created_at
+               FROM metadata
+               WHERE metadata_key = $key AND disabled_at IS NULL
+               ORDER BY created_at DESC;
+           }
+        }
+}
+
+
+procedure disable_metadata($row_id uuid) public {
+    stream_owner_only();
+
+    $current_block int := @height;
+
+    $found bool := false;
+
+    // Check if the metadata is not read-only
+    for $metadata_row in
+    SELECT metadata_key
+    FROM metadata
+    WHERE row_id = $row_id AND disabled_at IS NULL
+    LIMIT 1 {
+        $found := true;
+        $row_key text := $metadata_row.metadata_key;
+
+        for $readonly_row in SELECT row_id FROM metadata WHERE metadata_key = 'readonly_key' AND value_s = $row_key LIMIT 1 {
+            error('Cannot disable read-only metadata');
+        }
+
+        UPDATE metadata SET disabled_at = $current_block
+        WHERE row_id = $row_id;
+    }
+
+    if $found == false {
+        error('metadata record not found');
+    }
+}
+
+procedure insert_record($date_value int, $value decimal(36,18)) public {
+    if is_wallet_allowed_to_write(@caller) == false {
+        error('wallet not allowed to write');
+    }
+
+    if is_initiated() == false {
+        error('contract must be initiated');
+    }
+
+    $current_block int := @height;
+
+    // insert data
+    INSERT INTO primitive_events (date_value, value, created_at)
+        VALUES ($date_value, $value, $current_block);
+}
+
+// get_index calculation is ((current_primitive/first_primitive)*100).
+// This essentially gives us the same result, but with an extra 3 digits of precision.
+// index := (currentPrimitive * 100) / basePrimitive
+procedure get_index($date_from int, $date_to int, $frozen_at int, $base_date int) public view returns table(
+        date_value int,
+        value decimal(36,18)
+        ) {
+
+    $effective_base_date int := $base_date;
+    if ($effective_base_date == 0 OR $effective_base_date IS NULL) {
+        for $v_row in SELECT * FROM get_metadata('default_base_date', true, null) ORDER BY created_at DESC LIMIT 1 {
+            $effective_base_date := $v_row.value_i;
+        }
+    }
+
+    $baseValue decimal(36,18) := get_base_value($effective_base_date, $frozen_at);
+    if $baseValue == 0::decimal(36,18) {
+        error('base value is 0');
+    }
+
+    return SELECT date_value, (value * 100::decimal(36,18)) / $baseValue as value FROM get_record($date_from, $date_to, $frozen_at);
+}
+
+// get_base_value returns the first nearest value of the primitive stream before the given date
+procedure get_base_value($base_date int, $frozen_at int) private view returns (value decimal(36,18)) {
+    // If $base_date is null or empty, return the first-ever value from the primitive stream.
+    // This ensures that when no valid $base_date is provided, we still return the earliest available data point.
+    if $base_date is null OR $base_date = 0 {
+        for $row in SELECT * FROM primitive_events WHERE (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1 {
+            return $row.value;
+        }
+    }
+
+    for $row2 in SELECT * FROM primitive_events WHERE date_value <= $base_date AND (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value DESC, created_at DESC LIMIT 1 {
+        return $row2.value;
+    }
+
+    // if no value is found, we find the first value after the given date
+    // This will raise a red flag in the system and the data will undergo the usual process for when a new data provider is added.
+    for $row3 in SELECT * FROM primitive_events WHERE date_value > $base_date AND (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1 {
+        return $row3.value;
+    }
+
+    // if no value is found, we return an error
+    error('no base value found');
+}
+
+// get_first_record returns the first record of the primitive stream (optionally after a given date - inclusive)
+procedure get_first_record($after_date int, $frozen_at int) public view returns table(
+    date_value int,
+    value decimal(36,18)
+) {
+    // check read access
+    if is_wallet_allowed_to_read(@caller) == false {
+        error('wallet not allowed to read');
+    }
+
+    // check compose access
+    is_stream_allowed_to_compose(@foreign_caller);
+
+    // let's coalesce after_date with ''
+    // then, if it's empty, it will always be the first value
+    if $after_date is null {
+        $after_date := 0;
+    }
+
+    // coalesce frozen_at with 0
+    if $frozen_at is null {
+        $frozen_at := 0;
+    }
+
+    return SELECT date_value, value FROM primitive_events WHERE date_value >= $after_date AND (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1;
+}
+
+// get_original_record returns the original value of the primitive stream for a given date
+// it does not fill the gaps in the primitive stream
+procedure get_original_record(
+    $date_from int,
+    $date_to int,
+    $frozen_at int
+    ) private view returns table(
+    date_value int,
+    value decimal(36,18)
+    ) {
+
+    // check read access
+    if is_wallet_allowed_to_read(@caller) == false {
+        error('wallet not allowed to read');
+    }
+    // check compose access
+    is_stream_allowed_to_compose(@foreign_caller);
+
+    $frozenValue int := 0;
+    if $frozen_at IS DISTINCT FROM NULL {
+        $frozenValue := $frozen_at::int;
+    }
+
+    // TODO: whereClause here is a placeholder only, not supported yet, but it will make things cleaner if it available
+    //$whereClause text := 'WHERE 1=1 ';
+    //if $date_from != '' {
+    //    $whereClause := $whereClause || 'AND date_value >= $date_from ';
+    //}
+
+    //if $date_to != '' {
+    //    $whereClause := $whereClause || 'AND date_value <= $date_to ';
+    //}
+
+
+    // TODO: Normally we would use the following query to get the latest value of each date
+    // But it's not working for JOIN and MAX() function
+    //for $row in SELECT date_value, value FROM primitive_events JOIN (SELECT date_value, MAX(created_at) as created_at FROM primitive_events GROUP BY date_value) as max_created
+    //ON primitive_events.date_value = max_created.date_value AND primitive_events.created_at = max_created.created_at
+    //$whereClause
+    //ORDER BY date_value DESC {
+    //    return next $row.date_value, $row.value;
+    //}
+
+   // TODO: had to use this workaround because && operator is not working
+   $last_result_date int := 0;
+   if $date_from IS DISTINCT FROM NULL {
+       if $date_to IS DISTINCT FROM NULL {
+           // date_from and date_to are provided
+           // we will fetch all records from date_from to date_to
+           for $row in SELECT date_value, value FROM primitive_events
+               WHERE date_value >= $date_from AND date_value <= $date_to
+               AND (created_at <= $frozenValue OR $frozenValue = 0)
+               AND $last_result_date != date_value
+               ORDER BY date_value DESC, created_at DESC {
+                   if $last_result_date != $row.date_value {
+                        $last_result_date := $row.date_value;
+                       return next $row.date_value, $row.value;
+                   }
+               }
+       } else {
+           // only date_from is provided
+           // we will fetch all records from date_from to the latest
+           for $row2 in SELECT date_value, value FROM primitive_events
+               WHERE date_value >= $date_from
+               AND (created_at <= $frozenValue OR $frozenValue = 0)
+               AND $last_result_date != date_value
+               ORDER BY date_value DESC, created_at DESC {
+                   if $last_result_date != $row2.date_value {
+                        $last_result_date := $row2.date_value;
+                       return next $row2.date_value, $row2.value;
+                   }
+               }
+        }
+   } else {
+       if $date_to IS NOT DISTINCT FROM NULL {
+           // no date_from and date_to provided
+           // we fetch only the latest record
+           return SELECT date_value, value FROM primitive_events
+               WHERE created_at <= $frozenValue OR $frozenValue = 0
+               AND $last_result_date != date_value
+               ORDER BY date_value DESC, created_at DESC LIMIT 1;
+       } else {
+           // date_to is provided but date_from is not
+           error('date_from is required if date_to is provided');
+       }
+   }
+}
+
+// get_record returns the value of the primitive stream for a given date
+// it is able to fill the gaps in the primitive stream by using the last value before the given date
+// in our original implementation, the steps taken was much simpler
+// 1. fetches the original range
+// 2. checks if the original range's first value = start_date
+// 3. if it's not, it tries fetching the last date before it, and prepends result
+// The cause of this added complexity is the lack of support for storing table results in a variable
+procedure get_record(
+    $date_from int,
+    $date_to int,
+    $frozen_at int
+    ) public view returns table(
+    date_value int,
+    value decimal(36,18)
+    ) {
+
+    $is_first_result bool := true;
+
+    for $row in SELECT * FROM get_original_record($date_from, $date_to, $frozen_at) {
+        // we will only fetch the last record before the first result
+        // if the first result is not the same as the start date
+        if $is_first_result == true {
+            $first_result_date int := $row.date_value;
+
+            // if the first result date is not the same as the start date, then we need to fetch the last record before it
+            if $first_result_date != $date_from {
+                for $last_row in SELECT * FROM get_last_record_before_date($first_result_date) {
+                    // Note: although the user requested a date_from, we are returning the previous date here
+                    // e.g., the user used date_from:2021-01-02, and we are returning 2021-01-01 as first value
+                    //
+                    // that happens because the accuracy is guaranteed with this behavior, otherwise the
+                    // user won't be able to know when a data point really exist in our database or not.
+
+                    return next $last_row.date_value, $last_row.value;
+                }
+            }
+
+            $is_first_result := false;
+        }
+
+        return next $row.date_value, $row.value;
+    }
+
+    // it's still the first result? i.e. there were no results
+    // so let's try finding the last record before the start date
+    if $is_first_result == true {
+        for $last_row2 in SELECT * FROM get_last_record_before_date($date_from) {
+            return next $last_row2.date_value, $last_row2.value;
+        }
+    }
+}
+
+// get_last_record_before_date returns the last record before the given date
+procedure get_last_record_before_date(
+    $date_from int
+) public view returns table(
+    date_value int,
+    value decimal(36,18)
+    ) {
+    return SELECT date_value, value FROM primitive_events WHERE date_value < $date_from ORDER BY date_value DESC, created_at DESC LIMIT 1;
+}
+
+procedure transfer_stream_ownership($new_owner text) public {
+    stream_owner_only();
+
+    // fail if not a valid address
+    check_eth_address($new_owner);
+
+    UPDATE metadata SET value_ref = LOWER($new_owner)
+    WHERE metadata_key = 'stream_owner';
+}
+
+procedure check_eth_address($address text) private {
+    // TODO better check when kwil supports regexp and {}[] inside strings
+    // regex: ^0x[0-9a-fA-F]{40}$
+    // for $row in SELECT regexp_match($address, '^0x[0-9a-fA-F]{40}$') {
+    //     return true;
+    // }
+
+    if (length($address) != 42) {
+        error('invalid address length');
+    }
+
+    // check if starts with 0x
+    for $row in SELECT $address LIKE '0x%' as a {
+        if $row.a == false {
+            error('address does not start with 0x');
+        }
+    }
+}
+
+procedure is_stream_allowed_to_compose($foreign_caller text) public view returns (value bool) {
+    // if foreign_caller is empty, then it's a direct call
+    if $foreign_caller == '' {
+        return true;
+    }
+
+    // if public, anyone can always read
+    // If there's no visibility metadata, it's public.
+    $visibility int := 0;
+    for $v_row in SELECT * FROM get_metadata('compose_visibility', true, null) {
+        $visibility := $v_row.value_i;
+    }
+
+    if $visibility == 0 {
+        return true;
+    }
+
+    // if there's metadata allow_compose_stream -> <foreign_caller>, then its permitted
+    for $row in SELECT * FROM get_metadata('allow_compose_stream', true, $foreign_caller) LIMIT 1 {
+        return true;
+    }
+
+    error('stream not allowed to compose');
+}
+
+procedure get_index_change($date_from int, $date_to int, $frozen_at int, $base_date int, $days_interval int) public view returns table(
+    date_value int,
+    value decimal(36,18)
+) {
+    // the full process is this:
+    // 1. we find the current values for the given date range
+    // | date | value |
+    // | 01-2001 | ... |
+    // | 05-2001 | ... |
+    // | 09-2001 | ... |
+    // | 10-2001 | ... |
+
+    // 2. we get a list of expected previous dates
+    // | current_date | expected_prev_date |
+    // | 01-2001       | 01-2000            |
+    // | 05-2001       | 05-2000            |
+    // | 09-2001       | 09-2000            |
+    // | 10-2001       | 10-2000            |
+
+    // 3. we query the real previous values for the expected previous dates, using earliest and latest dates
+    // they might not match the expected previous dates
+    // | real_prev_date | value |
+    // | 01-2000        | ... |
+    // | 03-2000        | ... |
+    // | 04-2000        | ... |
+    // | 09-2000        | ... |
+
+    // 4. we try to match the expected prev dates with the real prev dates.
+    // see that each expected date should be 1:1 with a result prev date.
+    // | expected_prev_date | real_prev_date | result_prev_date |
+    // | 01-2000            | 01-2000        | 01-2000         |
+    // | -                  | 03-2000        | -               |
+    // | -                  | 04-2000        | -               |
+    // | 05-2000            | -              | 04-2000         |
+    // | 09-2000            | 09-2000        | 09-2000         |
+    // | 10-2000            | -              | 09-2000         |
+
+    // 5. we calculate the index change for the current values and the result prev values
+    // and done.
+
+    if $frozen_at == null {
+        $frozen_at := 0;
+    }
+
+    if $days_interval == null {
+        error('days_interval is required');
+    }
+
+    $current_values decimal(36,18)[];
+    // example: [01-2001, 05-2001, 09-2001, 10-2001]
+    $current_dates int[];
+    // example: [01-2000, 05-2000, 09-2000, 10-2000]
+    $expected_prev_dates int[];
+
+    for $row_current in SELECT * FROM get_index($date_from, $date_to, $frozen_at, $base_date) {
+        $prev_date := $row_current.date_value - ($days_interval * 86400);
+        $expected_prev_dates := array_append($expected_prev_dates, $prev_date);
+        $current_values := array_append($current_values, $row_current.value);
+        $current_dates := array_append($current_dates, $row_current.date_value);
+    }
+
+    // example: 01-2000]
+    $earliest_prev_date := $expected_prev_dates[1];
+    // example: 09-2000
+    $latest_prev_date := $expected_prev_dates[array_length($expected_prev_dates)];
+
+    // real previous values doesn't match the same length as expected previous dates
+    // because the interval can have much more values than the expected dates
+    $real_prev_values decimal(36,18)[];
+    $real_prev_dates int[];
+
+    // now we query the prev dates
+    for $row_prev in SELECT * FROM get_index($earliest_prev_date, $latest_prev_date, $frozen_at, $base_date) {
+        $real_prev_values := array_append($real_prev_values, $row_prev.value);
+        $real_prev_dates := array_append($real_prev_dates, $row_prev.date_value);
+    }
+
+    // now we calculate the matching dates for the real prev values
+    $result_prev_dates int[];
+    $result_prev_values decimal(36,18)[];
+
+    $real_prev_date_idx int := 1;
+
+    // for each expected prev date, we find the matching real prev date
+    if array_length($expected_prev_dates) > 0 {
+        for $expected_prev_date_idx in 1..array_length($expected_prev_dates) {
+            // we start from the last index of real prev dates. we don't need to check previous values
+            for $selector in $real_prev_date_idx..array_length($real_prev_dates) {
+                // if next real prev date is greater than expected prev date (or null), then we need to use the current real value
+                if $real_prev_dates[$selector + 1] > $expected_prev_dates[$expected_prev_date_idx]
+                   OR $real_prev_dates[$selector + 1] IS NULL {
+                    // if the current real prev date is already greater than expected prev date
+                    // we use NULL. We're probably before the first real prev date here
+                    if $real_prev_dates[$selector] > $expected_prev_dates[$expected_prev_date_idx] {
+                        $result_prev_dates := array_append($result_prev_dates, null::int);
+                        $result_prev_values := array_append($result_prev_values, null::decimal(36,18));
+                    } else {
+                        $result_prev_dates := array_append($result_prev_dates, $real_prev_dates[$selector]);
+                        $result_prev_values := array_append($result_prev_values, $real_prev_values[$selector]);
+                    }
+                    // we already appended one for current $real_prev_date_idx, then we need to go to next
+                    $real_prev_date_idx := $selector;
+                    break;
+                }
+            }
+        }
+    }
+
+    // check if we have the same number of values and dates
+    if array_length($current_dates) != array_length($result_prev_dates) {
+        error('we have different number of dates and values');
+    }
+    if array_length($current_values) != array_length($result_prev_values) {
+        error('we have different number of dates and values');
+    }
+
+    // calculate the index change
+    if array_length($result_prev_dates) > 0 {
+        for $row_result in 1..array_length($result_prev_dates) {
+            // if the expected_prev_date is null, then we don't have a real prev date
+            if $result_prev_dates[$row_result] IS DISTINCT FROM NULL {
+                return next $current_dates[$row_result], ($current_values[$row_result] - $result_prev_values[$row_result]) * 100.00::decimal(36,18) / $result_prev_values[$row_result];
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Added test for Unix Contract
- Modify some variables because there are changes in kwil's context structure.
- Put a defer function, so when test ends, container got deleted.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/node/issues/770

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

[benchmark_unix_results.csv](https://github.com/user-attachments/files/18324648/benchmark_unix_results.csv)

Tested Hourly with these configurations:
```
	shapePairs := [][]int{
		{1, 1},
		{50, 8},
		{100, 8},
	}
	days := []int{1, 7}
	visibilities := []util.VisibilityEnum{util.PublicVisibility}
```
Looks promising but more rapid (i.e: every 1 minute took very long that I have to cancel it :/