### PR TITLE
chore: stream storage requirement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.47.0
 	github.com/stretchr/testify v1.9.0
-	github.com/trufnetwork/sdk-go v0.1.1-0.20241126115735-addca8e1da52
+	github.com/trufnetwork/sdk-go v0.1.1-0.20250202003909-f8b63d22a337
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/sync v0.8.0
@@ -67,6 +67,7 @@ require (
 	github.com/ethereum/go-ethereum v1.14.8 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
@@ -74,6 +75,9 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.22.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -102,6 +106,7 @@ require (
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kwilteam/kwil-extensions v0.0.0-20230727040522-1cfd930226b7 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/linxGnu/grocksdb v1.8.14 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
+github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
@@ -180,6 +182,14 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
+github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
+github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
+github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
+github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
+github.com/go-playground/validator/v10 v10.22.0 h1:k6HsTZ0sTnROkhS//R0O+55JgM8C4Bx7ia+JlgcnOao=
+github.com/go-playground/validator/v10 v10.22.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -305,6 +315,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
+github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
+github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
 github.com/lib/pq v1.10.7/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/linxGnu/grocksdb v1.8.14 h1:HTgyYalNwBSG/1qCQUIott44wU5b2Y9Kr3z7SK5OfGQ=
@@ -467,8 +479,10 @@ github.com/tklauser/numcpus v0.8.0 h1:Mx4Wwe/FjZLeQsK/6kt2EOepwwSl7SmJrK5bV/dXYg
 github.com/tklauser/numcpus v0.8.0/go.mod h1:ZJZlAY+dmR4eut8epnzf0u/VwodKmryxR8txiloSqBE=
 github.com/tonistiigi/go-rosetta v0.0.0-20220804170347-3f4430f2d346 h1:TvtdmeYsYEij78hS4oxnwikoiLdIrgav3BA+CbhaDAI=
 github.com/tonistiigi/go-rosetta v0.0.0-20220804170347-3f4430f2d346/go.mod h1:xKQhd7snlzKFuUi1taTGWjpRE8iFTA06DeacYi3CVFQ=
-github.com/trufnetwork/sdk-go v0.1.1-0.20241126115735-addca8e1da52 h1:LNZ99bITHatmYKVHH4YqBhpuAg2bUx8SlP2VHAWR4jE=
-github.com/trufnetwork/sdk-go v0.1.1-0.20241126115735-addca8e1da52/go.mod h1:xfGmTkamZxyAOG331+P2oceLFxR7u/4lIoELyYEeCR4=
+github.com/trufnetwork/sdk-go v0.1.1-0.20250201205045-bfc7285a8282 h1:LTzgVlKoYE+laTizgju24seT2fnIIcNqC+fN2SYYsRM=
+github.com/trufnetwork/sdk-go v0.1.1-0.20250201205045-bfc7285a8282/go.mod h1:XMszfniaEGqyyj+EuFy73S3YUcxLzk0WhQpC3AUwFnE=
+github.com/trufnetwork/sdk-go v0.1.1-0.20250202003909-f8b63d22a337 h1:NlaXTkXnUiKCektYmF0WodsvYN/fCHvB4fuu0DDkpmM=
+github.com/trufnetwork/sdk-go v0.1.1-0.20250202003909-f8b63d22a337/go.mod h1:XMszfniaEGqyyj+EuFy73S3YUcxLzk0WhQpC3AUwFnE=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/tests/integration/storage/config.go
+++ b/tests/integration/storage/config.go
@@ -1,0 +1,15 @@
+package stream_storage_test
+
+// Configuration constants
+const (
+	// Test configuration
+	numStreams = 100
+	workers    = 30
+
+	// Docker configuration
+	networkName = "test-network"
+
+	// SDK configuration
+	TestPrivateKey   = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	TestKwilProvider = "http://localhost:8484"
+)

--- a/tests/integration/storage/stream_manager.go
+++ b/tests/integration/storage/stream_manager.go
@@ -1,0 +1,172 @@
+package stream_storage_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	kwilcrypto "github.com/kwilteam/kwil-db/core/crypto"
+	"github.com/kwilteam/kwil-db/core/crypto/auth"
+	"github.com/kwilteam/kwil-db/core/types/transactions"
+	"github.com/trufnetwork/sdk-go/core/tnclient"
+	"github.com/trufnetwork/sdk-go/core/types"
+	"github.com/trufnetwork/sdk-go/core/util"
+	"golang.org/x/sync/errgroup"
+)
+
+// streamInfo holds information about a deployed stream
+// It assumes the constants TestPrivateKey, TestKwilProvider and workers are defined in the package
+
+type streamInfo struct {
+	name          string
+	streamId      util.StreamId
+	streamLocator types.StreamLocator
+}
+
+// txInfo holds information about a transaction
+
+type txInfo struct {
+	hash     transactions.TxHash
+	streamId string
+}
+
+// streamManager handles stream operations
+
+type streamManager struct {
+	client *tnclient.Client
+	t      *testing.T
+}
+
+// newStreamManager creates a new stream manager using the global TestPrivateKey and TestKwilProvider constants
+func newStreamManager(ctx context.Context, t *testing.T) (*streamManager, error) {
+	pk, err := kwilcrypto.Secp256k1PrivateKeyFromHex(TestPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	client, err := tnclient.NewClient(
+		ctx,
+		TestKwilProvider,
+		tnclient.WithSigner(&auth.EthPersonalSigner{Key: *pk}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TN client: %w", err)
+	}
+
+	return &streamManager{client: client, t: t}, nil
+}
+
+// retryIfNonceError tries the operation up to 5 times if a nonce-related error is detected.
+func (sm *streamManager) retryIfNonceError(ctx context.Context, operation func() (transactions.TxHash, error)) (transactions.TxHash, error) {
+	const maxAttempts = 5
+	var lastErr error
+
+	for attempts := 1; attempts <= maxAttempts; attempts++ {
+		txHash, err := operation()
+		if err == nil {
+			return txHash, nil
+		}
+
+		if strings.Contains(strings.ToLower(err.Error()), "nonce") {
+			lastErr = err
+			sm.t.Logf("Nonce error detected (attempt %d/%d): %v", attempts, maxAttempts, err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		return txHash, err
+	}
+	return transactions.TxHash(""), fmt.Errorf("operation failed after %d attempts. Last error: %w", maxAttempts, lastErr)
+}
+
+// submitAndWaitForTxs is a generic helper to reduce duplication in deploy, initialize, and destroy steps.
+func (sm *streamManager) submitAndWaitForTxs(ctx context.Context, items []string, submitFunc func(string) (transactions.TxHash, error)) error {
+	txInfos := make([]txInfo, 0, len(items))
+
+	for _, item := range items {
+		txHash, err := sm.retryIfNonceError(ctx, func() (transactions.TxHash, error) {
+			return submitFunc(item)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to submit tx for item %s: %w", item, err)
+		}
+		sm.t.Logf("Submitted TX for %s, hash: %s", item, txHash)
+		txInfos = append(txInfos, txInfo{hash: txHash, streamId: item})
+	}
+
+	eg, ctx := errgroup.WithContext(ctx)
+	sem := make(chan struct{}, workers)
+	for _, tx := range txInfos {
+		tx := tx
+		sem <- struct{}{}
+		eg.Go(func() error {
+			defer func() { <-sem }()
+			_, err := sm.client.WaitForTx(ctx, tx.hash, time.Second)
+			if err != nil {
+				return fmt.Errorf("tx %s for %s not mined: %w", tx.hash, tx.streamId, err)
+			}
+			sm.t.Logf("TX mined for %s, hash: %s", tx.streamId, tx.hash)
+			return nil
+		})
+	}
+	return eg.Wait()
+}
+
+// deployStreams deploys streams using the generic submitAndWaitForTxs helper.
+func (sm *streamManager) deployStreams(ctx context.Context, count int) ([]streamInfo, error) {
+	sm.t.Logf("Deploying %d streams", count)
+	streamNames := make([]string, count)
+	for i := 0; i < count; i++ {
+		streamNames[i] = fmt.Sprintf("stream-%d", i)
+	}
+
+	err := sm.submitAndWaitForTxs(ctx, streamNames, func(s string) (transactions.TxHash, error) {
+		streamId := util.GenerateStreamId(s)
+		return sm.client.DeployStream(ctx, streamId, types.StreamTypePrimitiveUnix)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	streams := make([]streamInfo, count)
+	for i, name := range streamNames {
+		sid := util.GenerateStreamId(name)
+		streams[i] = streamInfo{
+			name:          name,
+			streamId:      sid,
+			streamLocator: sm.client.OwnStreamLocator(sid),
+		}
+	}
+	return streams, nil
+}
+
+// initializeStreams initializes streams using the submitAndWaitForTxs helper.
+func (sm *streamManager) initializeStreams(ctx context.Context, streams []streamInfo) error {
+	sm.t.Logf("Initializing %d streams", len(streams))
+	names := make([]string, len(streams))
+	for i, s := range streams {
+		names[i] = s.name
+	}
+	return sm.submitAndWaitForTxs(ctx, names, func(s string) (transactions.TxHash, error) {
+		sid := util.GenerateStreamId(s)
+		stream, err := sm.client.LoadPrimitiveStream(sm.client.OwnStreamLocator(sid))
+		if err != nil {
+			return transactions.TxHash(""), err
+		}
+		return stream.InitializeStream(ctx)
+	})
+}
+
+// destroyStreams destroys streams using the submitAndWaitForTxs helper.
+func (sm *streamManager) destroyStreams(ctx context.Context, count int) error {
+	sm.t.Logf("Destroying %d streams", count)
+	names := make([]string, count)
+	for i := 0; i < count; i++ {
+		names[i] = fmt.Sprintf("stream-%d", i)
+	}
+	return sm.submitAndWaitForTxs(ctx, names, func(s string) (transactions.TxHash, error) {
+		sid := util.GenerateStreamId(s)
+		return sm.client.DestroyStream(ctx, sid)
+	})
+}

--- a/tests/integration/storage/stream_storage_test.go
+++ b/tests/integration/storage/stream_storage_test.go
@@ -1,0 +1,485 @@
+package stream_storage_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	kwilcrypto "github.com/kwilteam/kwil-db/core/crypto"
+	"github.com/kwilteam/kwil-db/core/crypto/auth"
+	"github.com/trufnetwork/sdk-go/core/tnclient"
+	"github.com/trufnetwork/sdk-go/core/util"
+)
+
+/*
+ * Test the stream storage
+
+	1. Start containers for kwil and postgres, isolated from the rest of the system
+	2. measure the current directory size:
+		- postgres: /var/lib/postgresql/data
+		- kwil: /root/.kwildb/
+	3. run the stream storage test:
+		- create 1,000 streams
+		- initialize all streams with 1000 messages each
+	4. measure the directory size of kwil and postgres
+	5. drop all streams
+	6. measure the directory size of kwil and postgres
+	7. log all sizes
+	8. teardown containers
+*/
+
+// containerSpec defines the configuration for a container
+type containerSpec struct {
+	name        string
+	image       string
+	tmpfsPath   string
+	envVars     []string
+	healthCheck func(d *docker) error
+}
+
+// testContainers defines the containers needed for the test
+var containers = struct {
+	postgres containerSpec
+	tsndb    containerSpec
+}{
+	postgres: containerSpec{
+		name:      "test-kwil-postgres",
+		image:     "kwildb/postgres:latest",
+		tmpfsPath: "/var/lib/postgresql/data",
+		envVars:   []string{"POSTGRES_HOST_AUTH_METHOD=trust"},
+		healthCheck: func(d *docker) error {
+			_, err := d.exec("test-kwil-postgres", "pg_isready", "-U", "postgres")
+			return err
+		},
+	},
+	tsndb: containerSpec{
+		name:      "test-tsn-db",
+		image:     "tsn-db:local",
+		tmpfsPath: "/root/.kwild",
+		envVars: []string{
+			"CONFIG_PATH=/root/.kwild",
+			"KWILD_APP_HOSTNAME=test-tsn-db",
+			"KWILD_APP_PG_DB_HOST=test-kwil-postgres",
+			"KWILD_CHAIN_P2P_EXTERNAL_ADDRESS=http://test-tsn-db:26656",
+		},
+		healthCheck: func(d *docker) error {
+			// Wait for the service to be ready
+			time.Sleep(5 * time.Second)
+			_, err := d.exec("test-tsn-db", "ps", "aux")
+			return err
+		},
+	},
+}
+
+// docker provides a simplified interface for docker operations
+type docker struct {
+	t *testing.T
+}
+
+// newDocker creates a new docker helper
+func newDocker(t *testing.T) *docker {
+	return &docker{t: t}
+}
+
+// exec executes a command in a container
+func (d *docker) exec(container string, args ...string) (string, error) {
+	cmdArgs := append([]string{"exec", container}, args...)
+	return d.run(cmdArgs...)
+}
+
+// run executes a docker command
+func (d *docker) run(args ...string) (string, error) {
+	cmd := exec.Command("docker", args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// failWithLogsOnError logs container logs and fails the test if err is non-nil.
+func (d *docker) failWithLogsOnError(err error, containerName string) {
+	if err != nil {
+		if logs, logsErr := d.run("logs", containerName); logsErr == nil {
+			d.t.Logf("Logs for %s:\n%s", containerName, logs)
+		}
+		d.t.Fatal(err)
+	}
+}
+
+// pollUntilTrue polls a condition until it returns true or a timeout is reached.
+func pollUntilTrue(ctx context.Context, timeout time.Duration, check func() bool) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if check() {
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	return errors.New("condition not met within timeout")
+}
+
+// startContainer starts a container with the given spec and waits for it to be healthy.
+func (d *docker) startContainer(spec containerSpec) error {
+	args := []string{"run", "--rm", "--name", spec.name, "--network", networkName, "-d"}
+
+	if spec.tmpfsPath != "" {
+		args = append(args, "--tmpfs", spec.tmpfsPath)
+	}
+
+	for _, env := range spec.envVars {
+		args = append(args, "-e", env)
+	}
+
+	if spec.name == "test-tsn-db" {
+		args = append(args,
+			"-p", "50051:50051",
+			"-p", "50151:50151",
+			"-p", "8080:8080",
+			"-p", "8484:8484",
+			"-p", "26656:26656",
+			"-p", "26657:26657",
+			"--entrypoint", "/app/kwild",
+			spec.image,
+			"--autogen",
+			"--app.pg-db-host", "test-kwil-postgres",
+			"--app.hostname", "test-tsn-db",
+			"--chain.p2p.external-address", "http://test-tsn-db:26656",
+		)
+	} else {
+		args = append(args, spec.image)
+	}
+
+	out, err := d.run(args...)
+	if err != nil {
+		return fmt.Errorf("failed to start container %s: %w\nOutput: %s", spec.name, err, out)
+	}
+
+	if spec.healthCheck != nil {
+		err := pollUntilTrue(context.Background(), 10*time.Second, func() bool {
+			return spec.healthCheck(d) == nil
+		})
+		if err != nil {
+			if logs, logsErr := d.run("logs", spec.name); logsErr == nil {
+				d.t.Logf("Container logs for %s:\n%s", spec.name, logs)
+			}
+			return fmt.Errorf("container %s failed to become healthy: %w", spec.name, err)
+		}
+	}
+
+	if spec.name == "test-tsn-db" {
+		err := pollUntilTrue(context.Background(), 30*time.Second, func() bool {
+			out, err := exec.Command("curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8484/api/v1/health").Output()
+			if err != nil {
+				return false
+			}
+			return strings.TrimSpace(string(out)) == "200"
+		})
+		if err != nil {
+			if logs, logsErr := d.run("logs", spec.name); logsErr == nil {
+				d.t.Logf("Container logs for %s:\n%s", spec.name, logs)
+			}
+			return fmt.Errorf("RPC server in container %s failed to become ready: %w", spec.name, err)
+		}
+	}
+
+	return nil
+}
+
+// stopContainer stops a container
+func (d *docker) stopContainer(name string) error {
+	_, err := d.run("stop", name)
+	if err != nil {
+		return fmt.Errorf("failed to stop container %s: %w", name, err)
+	}
+	d.t.Logf("Stopped container %s", name)
+	return nil
+}
+
+// setupNetwork creates a docker network
+func (d *docker) setupNetwork() error {
+	d.run("network", "rm", networkName)
+	_, err := d.run("network", "create", networkName)
+	return err
+}
+
+// teardownNetwork removes the docker network
+func (d *docker) teardownNetwork() error {
+	_, err := d.run("network", "rm", networkName)
+	return err
+}
+
+// measureSize measures the size of a directory in a container
+func (d *docker) measureSize(container, path string) (int64, error) {
+	out, err := d.exec(container, "du", "-sb", path)
+	if err != nil {
+		return 0, err
+	}
+	return parseDuOutput(out)
+}
+
+// runCommand executes a command and returns its combined output or error.
+func runCommand(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// parseDuOutput parses the output of du command and returns the size in bytes
+func parseDuOutput(output string) (int64, error) {
+	fields := strings.Fields(output)
+	if len(fields) < 1 {
+		return 0, fmt.Errorf("unexpected du output: %s", output)
+	}
+	return strconv.ParseInt(fields[0], 10, 64)
+}
+
+// bytesToMB converts bytes to megabytes with 2 decimal places
+func bytesToMB(bytes int64) float64 {
+	return float64(bytes) / (1024 * 1024)
+}
+
+// cleanup removes all docker resources
+func (d *docker) cleanup() {
+	// Get all container IDs
+	out, err := d.run("ps", "-aq")
+	if err == nil && out != "" {
+		containers := strings.Fields(out)
+		if len(containers) > 0 {
+			killArgs := append([]string{"kill"}, containers...)
+			d.run(killArgs...)
+			rmArgs := append([]string{"rm"}, containers...)
+			d.run(rmArgs...)
+		}
+	}
+	// Remove networks
+	d.run("network", "prune", "-f")
+	// Remove volume
+	d.run("volume", "rm", "tsn-config")
+}
+
+func TestStreamStorage(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup docker helper
+	d := newDocker(t)
+
+	// Clean up any existing resources
+	d.cleanup()
+
+	// Create network
+	if err := d.setupNetwork(); err != nil {
+		t.Fatal(err)
+	}
+	defer d.teardownNetwork()
+
+	// Start postgres first
+	if err := d.startContainer(containers.postgres); err != nil {
+		t.Fatal(err)
+	}
+	defer d.stopContainer(containers.postgres.name)
+
+	// Wait for postgres to be healthy
+	for i := 0; i < 10; i++ {
+		if err := containers.postgres.healthCheck(d); err == nil {
+			break
+		}
+		if i == 9 {
+			t.Fatal("postgres failed to become healthy")
+		}
+		time.Sleep(time.Second)
+	}
+
+	// Start tsn-db with autogen
+	t.Log("Starting tsn-db container...")
+	if err := d.startContainer(containers.tsndb); err != nil {
+		// Get logs before failing
+		if out, err := d.run("logs", containers.tsndb.name); err == nil {
+			t.Logf("TSN-DB container logs:\n%s", out)
+		} else {
+			t.Logf("Failed to get TSN-DB logs: %v", err)
+		}
+		// Get container status
+		if status, err := d.run("inspect", "--format", "{{.State.Status}}", containers.tsndb.name); err == nil {
+			t.Logf("TSN-DB container status: %s", status)
+		}
+		t.Fatalf("Failed to start tsn-db container: %v", err)
+	}
+	t.Log("TSN-DB container started successfully")
+
+	// Wait for node to be fully initialized
+	t.Log("Waiting for node to be fully initialized...")
+	for i := 0; i < 30; i++ { // 30 seconds max wait
+		healthCmd := exec.Command("curl", "-s", TestKwilProvider+"/api/v1/health")
+		healthOut, healthErr := healthCmd.CombinedOutput()
+		if healthErr == nil {
+			t.Logf("Health check response: %s", string(healthOut))
+			if strings.Contains(string(healthOut), `"healthy":true`) &&
+				strings.Contains(string(healthOut), `"block_height":1`) {
+				t.Log("Node is healthy and has produced the first block")
+				break
+			}
+		}
+		if i == 29 {
+			t.Fatal("Node failed to become healthy or produce the first block")
+		}
+		time.Sleep(time.Second)
+	}
+
+	// Get initial container logs
+	if out, err := d.run("logs", containers.tsndb.name); err == nil {
+		t.Logf("Initial TSN-DB container logs:\n%s", out)
+	}
+
+	defer d.stopContainer(containers.tsndb.name)
+
+	// Measure initial sizes
+	pgSizeBefore, err := d.measureSize(containers.postgres.name, containers.postgres.tmpfsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsnSizeBefore, err := d.measureSize(containers.tsndb.name, containers.tsndb.tmpfsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Initial sizes - Postgres: %.2f MB, TSN-DB: %.2f MB", bytesToMB(pgSizeBefore), bytesToMB(tsnSizeBefore))
+
+	// Initialize stream manager
+	t.Log("Creating private key...")
+	pk, err := kwilcrypto.Secp256k1PrivateKeyFromHex(TestPrivateKey)
+	if err != nil {
+		t.Fatalf("Failed to parse private key: %v", err)
+	}
+	t.Log("Successfully created private key")
+
+	t.Log("Creating TN client...")
+	t.Logf("Using provider: %s", TestKwilProvider)
+
+	// Get the Ethereum address from the public key
+	pubKeyBytes := pk.PubKey().Bytes()
+	// Remove the first byte which is the compression flag
+	pubKeyBytes = pubKeyBytes[1:]
+	addr, err := util.NewEthereumAddressFromBytes(crypto.Keccak256(pubKeyBytes)[12:])
+	if err != nil {
+		t.Fatalf("Failed to get address from public key: %v", err)
+	}
+	t.Logf("Using signer with address: %s", addr.Address())
+
+	t.Log("Attempting to create client...")
+	var client *tnclient.Client
+	var lastErr error
+	for i := 0; i < 60; i++ { // 60 seconds max wait
+		t.Logf("Attempt %d/60: Creating client with provider URL %s", i+1, TestKwilProvider)
+
+		// First check if the server is accepting connections
+		cmd := exec.Command("curl", "-s", "-w", "\n%{http_code}", "http://localhost:8484/api/v1/health")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			lastErr = fmt.Errorf("health check command failed: %w", err)
+			t.Logf("Health check command failed: %v", err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		// Split output into response body and status code
+		parts := strings.Split(string(out), "\n")
+		if len(parts) != 2 {
+			lastErr = fmt.Errorf("unexpected health check output format: %s", string(out))
+			t.Logf("Health check output format error: %s", string(out))
+			time.Sleep(time.Second)
+			continue
+		}
+
+		statusCode := strings.TrimSpace(parts[1])
+		t.Logf("Health check response - Status: %s", statusCode)
+
+		if statusCode != "200" {
+			lastErr = fmt.Errorf("health check returned non-200 status: %s", statusCode)
+			t.Logf("Health check failed with status %s", statusCode)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		t.Log("Health check passed, attempting to create client...")
+
+		// Try to create the client now that we know the server is accepting connections
+		client, err = tnclient.NewClient(
+			ctx,
+			TestKwilProvider,
+			tnclient.WithSigner(&auth.EthPersonalSigner{Key: *pk}),
+		)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to create TN client: %w", err)
+			t.Logf("Client creation failed: %v", err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		// Successfully created client
+		t.Log("Client created successfully")
+		break
+	}
+
+	if client == nil {
+		t.Fatalf("Failed to create client after 60 attempts. Last error: %v", lastErr)
+	}
+
+	sm, err := newStreamManager(ctx, t)
+	if err != nil {
+		t.Fatalf("Failed to create stream manager: %v", err)
+	}
+
+	// Deploy streams
+	streams, err := sm.deployStreams(ctx, numStreams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize streams
+	if err := sm.initializeStreams(ctx, streams); err != nil {
+		t.Fatal(err)
+	}
+
+	// Measure sizes after creation
+	pgSizeAfter, err := d.measureSize(containers.postgres.name, containers.postgres.tmpfsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsnSizeAfter, err := d.measureSize(containers.tsndb.name, containers.tsndb.tmpfsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("After creation - Postgres: %.2f MB, TSN-DB: %.2f MB", bytesToMB(pgSizeAfter), bytesToMB(tsnSizeAfter))
+
+	// Destroy streams
+	if err := sm.destroyStreams(ctx, numStreams); err != nil {
+		t.Fatal(err)
+	}
+
+	// Measure final sizes
+	pgSizeFinal, err := d.measureSize(containers.postgres.name, containers.postgres.tmpfsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsnSizeFinal, err := d.measureSize(containers.tsndb.name, containers.tsndb.tmpfsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Log all measurements
+	t.Log("Final measurements:")
+	t.Logf("Postgres (MB): before=%.2f, after=%.2f, final=%.2f",
+		bytesToMB(pgSizeBefore), bytesToMB(pgSizeAfter), bytesToMB(pgSizeFinal))
+	t.Logf("TSN-DB (MB): before=%.2f, after=%.2f, final=%.2f",
+		bytesToMB(tsnSizeBefore), bytesToMB(tsnSizeAfter), bytesToMB(tsnSizeFinal))
+}


### PR DESCRIPTION
## Description

- Add integration tests for stream storage in tests/integration/storage/stream_storage_test.go
- Adjust go.mod and go.sum to include required dependency updates.

## Related Problem

- fix [#786](https://github.com/trufnetwork/node/issues/786)

## How Has This Been Tested?

- Verified that all tests pass and the application runs with no issues. 

## Results

- Tests running locally indicate that we use 250MB per 1,000 deployed and initialized streams.