### PR TITLE
test: insertion behavior

### DIFF
--- a/internal/contracts/contracts_behaviors.md
+++ b/internal/contracts/contracts_behaviors.md
@@ -30,14 +30,14 @@ This document lists the behaviors that must have automated tests to ensure they 
 
 ## Data Insertion
 
-- [x] Authorized wallets can insert new data records (e.g., primitive events) with associated timestamps and values.
+- [PRIMITIVE01][PRIMITIVE02][COMPOSED01][COMPOSED02] Authorized wallets can insert new data records (e.g., primitive events) with associated timestamps and values.
     Note: truf-data-provider primitive has external_created_at field.
-- [x] The stream owner can insert metadata that configures stream behavior. I.e. allow_read_wallet.
-- [x] Some stream metadata are read-only and only set once created (e.g. stream_type, or other properties that are set only on special actions such as ownership transfer)
-- [x] All metadata records are immutable, and can only be disabled but never deleted.
-- [x] Data records are immutable. They can't be disabled or deleted.
-- [x] Taxonomy definitions are immutable. But they can be disabled (only the whole version and not a single child definition)
-- [x] A base date for a stream can be set by the stream owner. If not set, the stream will use the first record date as base date.
+- [COMMON01] The stream owner can insert metadata that configures stream behavior. I.e. allow_read_wallet.
+- [COMMON02][PRIMITIVE03][COMPOSED03] Some stream metadata are read-only and only set once created (e.g. stream_type, or other properties that are set only on special actions such as ownership transfer)
+- [COMMON03] All metadata records are immutable, and can only be disabled but never deleted.
+- [x] Data records are immutable. They can't be disabled or deleted. (records can't be disabled by design, no need to test)
+- [COMPOSED04] Taxonomy definitions are immutable. But they can be disabled (only the whole version and not a single child definition)
+- [PRIMITIVE04] A base date for a stream can be set by parameters. If not set, the stream will use the first record date as base date.
 
 
 ## Composition & Aggregation

--- a/internal/contracts/contracts_behaviors.md
+++ b/internal/contracts/contracts_behaviors.md
@@ -30,14 +30,14 @@ This document lists the behaviors that must have automated tests to ensure they 
 
 ## Data Insertion
 
-- Authorized wallets can insert new data records (e.g., primitive events) with associated timestamps and values.
+- [x] Authorized wallets can insert new data records (e.g., primitive events) with associated timestamps and values.
     Note: truf-data-provider primitive has external_created_at field.
-- The stream owner can insert metadata that configures stream behavior. I.e. allow_read_wallet.
-- Some stream metadata are read-only and only set once created (e.g. stream_type, or other properties that are set only on special actions such as ownership transfer)
-- All metadata records are immutable, and can only be disabled but never deleted.
-- Data records are immutable. They can't be disabled or deleted.
-- Taxonomy definitions are immutable. But they can be disabled (only the whole version and not a single child definition)
-- A base date for a stream can be set by the stream owner. If not set, the stream will use the first record date as base date.
+- [x] The stream owner can insert metadata that configures stream behavior. I.e. allow_read_wallet.
+- [x] Some stream metadata are read-only and only set once created (e.g. stream_type, or other properties that are set only on special actions such as ownership transfer)
+- [x] All metadata records are immutable, and can only be disabled but never deleted.
+- [x] Data records are immutable. They can't be disabled or deleted.
+- [x] Taxonomy definitions are immutable. But they can be disabled (only the whole version and not a single child definition)
+- [x] A base date for a stream can be set by the stream owner. If not set, the stream will use the first record date as base date.
 
 
 ## Composition & Aggregation

--- a/internal/contracts/tests/common_test.go
+++ b/internal/contracts/tests/common_test.go
@@ -112,7 +112,7 @@ func assertMetadataValue(t *testing.T, valType string, expected interface{}, res
 	}
 }
 
-func TestOnlyOwnerCanInsertMetadata(t *testing.T) {
+func TestCOMMON01OnlyOwnerCanInsertMetadata(t *testing.T) {
 	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
 		Name: "only_owner_can_insert_metadata",
 		FunctionTests: []kwilTesting.TestFunc{
@@ -141,7 +141,7 @@ func testOnlyOwnerCanInsertMetadata(t *testing.T, contractInfo ContractInfo) kwi
 	}
 }
 
-func TestDisableMetadata(t *testing.T) {
+func TestCOMMON03DisableMetadata(t *testing.T) {
 	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
 		Name: "disable_metadata",
 		FunctionTests: []kwilTesting.TestFunc{
@@ -190,7 +190,7 @@ func testDisableMetadata(t *testing.T, contractInfo ContractInfo) kwilTesting.Te
 	}
 }
 
-func TestReadOnlyMetadataCannotBeModified(t *testing.T) {
+func TestCOMMON02ReadOnlyMetadataCannotBeModified(t *testing.T) {
 	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
 		Name: "readonly_metadata_cannot_be_modified",
 		FunctionTests: []kwilTesting.TestFunc{

--- a/internal/contracts/tests/composed_test.go
+++ b/internal/contracts/tests/composed_test.go
@@ -25,13 +25,13 @@ func TestComposed(t *testing.T) {
 		FunctionTests: []kwilTesting.TestFunc{
 			WithComposedTestSetup(testComposedLastAvailable(t)),
 			WithComposedTestSetup(testComposedNoPastData(t)),
-			WithComposedTestSetup(testSetTaxonomyWithValidData(t)),
-			WithComposedTestSetup(testOnlyOwnerCanSetTaxonomy(t)),
-			WithComposedTestSetup(testDisableTaxonomy(t)),
+			WithComposedTestSetup(testCOMPOSED01SetTaxonomyWithValidData(t)),
+			WithComposedTestSetup(testCOMPOSED02OnlyOwnerCanSetTaxonomy(t)),
+			WithComposedTestSetup(testCOMPOSED04DisableTaxonomy(t)),
 			WithComposedTestSetup(testOnlyOwnerCanDisableTaxonomy(t)),
 			WithComposedTestSetup(testWeightsInComposition(t)),
 			WithComposedTestSetup(testSetTaxonomyWithStartDate(t)),
-			WithComposedTestSetup(testSetReadOnlyMetadataToComposedStream(t)),
+			WithComposedTestSetup(testCOMPOSED03SetReadOnlyMetadataToComposedStream(t)),
 		},
 	})
 }
@@ -139,7 +139,7 @@ func testComposedNoPastData(t *testing.T) func(ctx context.Context, platform *kw
 	}
 }
 
-func testSetTaxonomyWithValidData(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+func testCOMPOSED01SetTaxonomyWithValidData(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		// Initialize contract
 		if err := setupAndInitializeContract(ctx, platform, composedContractInfo); err != nil {
@@ -310,7 +310,7 @@ func testSetTaxonomyWithStartDate(t *testing.T) func(ctx context.Context, platfo
 	}
 }
 
-func testOnlyOwnerCanSetTaxonomy(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+func testCOMPOSED02OnlyOwnerCanSetTaxonomy(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		// Initialize contract
 		if err := setupAndInitializeContract(ctx, platform, composedContractInfo); err != nil {
@@ -336,7 +336,7 @@ func testOnlyOwnerCanSetTaxonomy(t *testing.T) func(ctx context.Context, platfor
 	}
 }
 
-func testDisableTaxonomy(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+func testCOMPOSED04DisableTaxonomy(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		// Initialize contract
 		if err := setupAndInitializeContract(ctx, platform, composedContractInfo); err != nil {
@@ -606,7 +606,7 @@ func disableTaxonomy(ctx context.Context, platform *kwilTesting.Platform, dbid s
 	return nil
 }
 
-func testSetReadOnlyMetadataToComposedStream(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+func testCOMPOSED03SetReadOnlyMetadataToComposedStream(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error { // Change deployer to a non-authorized wallet
 		dbid := utils.GenerateDBID(composedStreamId.String(), platform.Deployer)
 

--- a/internal/contracts/tests/primitive_test.go
+++ b/internal/contracts/tests/primitive_test.go
@@ -35,6 +35,7 @@ func TestPrimitiveStream(t *testing.T) {
 			WithPrimitiveTestSetup(testGetRecordWithBaseDate(t)),
 			WithPrimitiveTestSetup(testFrozenDataRetrieval(t)),
 			WithPrimitiveTestSetup(testUnauthorizedInserts(t)),
+			WithPrimitiveTestSetup(testSetReadOnlyMetadataToPrimitiveStream(t)),
 		},
 	})
 }
@@ -443,6 +444,24 @@ func testUnauthorizedInserts(t *testing.T) func(ctx context.Context, platform *k
 		assert.Error(t, err, "Unauthorized wallet should not be able to insert records")
 		assert.Contains(t, err.Error(), "wallet not allowed to write", "Expected permission error")
 
+		return nil
+	}
+}
+
+func testSetReadOnlyMetadataToPrimitiveStream(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error { // Change deployer to a non-authorized wallet
+		dbid := utils.GenerateDBID(primitiveStreamId.String(), platform.Deployer)
+
+		// Attempt to set metadata
+		err := procedure.SetMetadata(ctx, procedure.SetMetadataInput{
+			Platform: platform,
+			DBID:     dbid,
+			Key:      "type",
+			Value:    "other",
+			ValType:  "string",
+			Height:   0,
+		})
+		assert.Error(t, err, "Cannot insert metadata for read-only key")
 		return nil
 	}
 }

--- a/internal/contracts/tests/primitive_test.go
+++ b/internal/contracts/tests/primitive_test.go
@@ -27,15 +27,15 @@ func TestPrimitiveStream(t *testing.T) {
 	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
 		Name: "primitive_test",
 		FunctionTests: []kwilTesting.TestFunc{
-			WithPrimitiveTestSetup(testInsertAndGetRecord(t)),
+			WithPrimitiveTestSetup(testPRIMITIVE01_InsertAndGetRecord(t)),
+			WithPrimitiveTestSetup(testPRIMITIVE02_UnauthorizedInserts(t)),
 			WithPrimitiveTestSetup(testGetIndex(t)),
 			WithPrimitiveTestSetup(testGetIndexChange(t)),
 			WithPrimitiveTestSetup(testGetFirstRecord(t)),
 			WithPrimitiveTestSetup(testDuplicateDate(t)),
-			WithPrimitiveTestSetup(testGetRecordWithBaseDate(t)),
+			WithPrimitiveTestSetup(testPRIMITIVE04GetRecordWithBaseDate(t)),
 			WithPrimitiveTestSetup(testFrozenDataRetrieval(t)),
-			WithPrimitiveTestSetup(testUnauthorizedInserts(t)),
-			WithPrimitiveTestSetup(testSetReadOnlyMetadataToPrimitiveStream(t)),
+			WithPrimitiveTestSetup(testPRIMITIVE03_SetReadOnlyMetadataToPrimitiveStream(t)),
 		},
 	})
 }
@@ -73,7 +73,7 @@ func WithPrimitiveTestSetup(testFn func(ctx context.Context, platform *kwilTesti
 	}
 }
 
-func testInsertAndGetRecord(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+func testPRIMITIVE01_InsertAndGetRecord(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		dbid := utils.GenerateDBID(primitiveStreamId.String(), platform.Deployer)
 
@@ -285,7 +285,7 @@ func testDuplicateDate(t *testing.T) func(ctx context.Context, platform *kwilTes
 	}
 }
 
-func testGetRecordWithBaseDate(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+func testPRIMITIVE04GetRecordWithBaseDate(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		dbid := utils.GenerateDBID(primitiveStreamId.String(), platform.Deployer)
 
@@ -416,7 +416,7 @@ func testFrozenDataRetrieval(t *testing.T) func(ctx context.Context, platform *k
 	}
 }
 
-func testUnauthorizedInserts(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+func testPRIMITIVE02_UnauthorizedInserts(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		// Change deployer to a non-authorized wallet
 		unauthorizedWallet := util.Unsafe_NewEthereumAddressFromString("0x9999999999999999999999999999999999999999")
@@ -448,7 +448,7 @@ func testUnauthorizedInserts(t *testing.T) func(ctx context.Context, platform *k
 	}
 }
 
-func testSetReadOnlyMetadataToPrimitiveStream(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+func testPRIMITIVE03_SetReadOnlyMetadataToPrimitiveStream(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error { // Change deployer to a non-authorized wallet
 		dbid := utils.GenerateDBID(primitiveStreamId.String(), platform.Deployer)
 

--- a/internal/contracts/tests/utils/procedure/types.go
+++ b/internal/contracts/tests/utils/procedure/types.go
@@ -41,3 +41,12 @@ type GetFirstRecordInput struct {
 	FrozenAt  int64
 	Height    int64
 }
+
+type SetMetadataInput struct {
+	Platform *kwilTesting.Platform
+	DBID     string
+	Key      string
+	Value    string
+	ValType  string
+	Height   int64
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request includes updates to the `internal/contracts` module to enhance metadata handling and testing capabilities. The key changes involve adding new test cases for setting read-only metadata and introducing a new procedure for setting metadata.

### Metadata Handling Enhancements:
* [`internal/contracts/tests/utils/procedure/execute.go`](diffhunk://#diff-68b0a2fe01962c36b6d8c6db3f54954b0f57b240576d46b33b738654e0c6b7beR125-R152): Added a new `SetMetadata` function to handle metadata insertion, ensuring proper error handling for unauthorized attempts.
* [`internal/contracts/tests/utils/procedure/types.go`](diffhunk://#diff-90ffaffea39873594e74cb7d0a3ada1cbc0f66f12febfc3f9bac1d90ff2cd337R44-R52): Introduced a new `SetMetadataInput` struct to encapsulate metadata insertion parameters.

### Test Case Additions:
* [`internal/contracts/tests/composed_test.go`](diffhunk://#diff-382026c91ab411d8a2019cafd528196532ecc5afb06d5a6bc63cf637924fb318R608-R625): Added a new test case `testSetReadOnlyMetadataToComposedStream` to verify that read-only metadata cannot be set by unauthorized wallets.
* [`internal/contracts/tests/primitive_test.go`](diffhunk://#diff-f586f4d766fb1c5f6d5a8d0b3d9828023b61a82884c07a2160749c1abfb3db74R450-R467): Added a new test case `testSetReadOnlyMetadataToPrimitiveStream` to ensure read-only metadata enforcement in primitive streams.

### Documentation Update:
* [`internal/contracts/contracts_behaviors.md`](diffhunk://#diff-9633fa1a28b8de400858fee127011a5684f1f791a12a0128e07b57c354acdde3L33-R40): Updated the documentation to mark metadata-related behaviors as tested.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/node/issues/810

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Every other test has been tested too.