### PR TITLE
chore: enable sql query execution

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -40,6 +40,7 @@ services:
         - ${CACHE_TO:-type=local,dest=/tmp/buildx-cache-new}/tsn-db
       args:
         - CHAIN_ID=${CHAIN_ID:-tsn-local}
+        - ETHEREUM_ADDRESS=${ETHEREUM_ADDRESS:-0x4710A8D8F0D845da110086812a32De6d90d7ff5C}
     environment:
       CONFIG_PATH: /root/.kwild
       # app.pg-db-host

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -17,6 +17,9 @@ FROM alpine:latest
 
 ARG CHAIN_ID=truflation-staging
 
+# Ethereum address taken from 0001's wallet
+ARG ETHEREUM_ADDRESS=0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf
+
 WORKDIR /app
 
 # add postgres client tools
@@ -36,7 +39,7 @@ RUN echo "#!/bin/sh" > /app/config.sh && \
     echo "if [ ! -f /root/.kwild/nodekey.json ]; then" >> /app/config.sh && \
     echo "    echo 'Configuration does not exist';" >> /app/config.sh && \
     echo "    echo 'Creating configuration';" >> /app/config.sh && \
-    echo "    ./kwild setup init --chain-id $CHAIN_ID -r /root/.kwil-new;" >> /app/config.sh && \
+    echo "    ./kwild setup init --chain-id $CHAIN_ID --db-owner $ETHEREUM_ADDRESS -r /root/.kwil-new;" >> /app/config.sh && \
     echo "    mv /root/.kwil-new/* /root/.kwild;" >> /app/config.sh && \
     echo "    rm -rf /root/.kwil-new;" >> /app/config.sh && \
     echo "    echo 'Configuration created';" >> /app/config.sh && \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request introduces changes to the `compose.yaml` and `deployments/Dockerfile` files to include Ethereum address configurations. These changes ensure the Ethereum address is properly set and used during the initialization process.

### Configuration updates:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR43): Added `ETHEREUM_ADDRESS` argument with a default value to the `args` section.
* [`deployments/Dockerfile`](diffhunk://#diff-366193956cffda6b352fede667d47d1b1599483df14700b25589d07095b9e230R20-R22): Introduced `ETHEREUM_ADDRESS` argument with a specific value from a wallet.

### Initialization process:

* [`deployments/Dockerfile`](diffhunk://#diff-366193956cffda6b352fede667d47d1b1599483df14700b25589d07095b9e230L39-R42): Modified the initialization command in the `config.sh` script to include the `--db-owner` parameter with the Ethereum address.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/node/issues/802

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Run `task compose` to run tsn-db in the docker container
2. Try to deploy table
```
kwil-cli exec-sql "CREATE TABLE my_table (id int primary key, name text)" --sync
```