### PR TITLE
feat: compose stream authorization

### DIFF
--- a/internal/migrations/000-initial-data.sql
+++ b/internal/migrations/000-initial-data.sql
@@ -79,7 +79,7 @@ ON taxonomies (child_data_provider, child_stream_id);
 
 -- optimizes "get latest taxonomy version"
 CREATE INDEX IF NOT EXISTS tax_latest_version_idx ON taxonomies
-(data_provider, stream_id, start_time DESC, version DESC);
+(data_provider, stream_id, start_time, version);
 
 CREATE TABLE IF NOT EXISTS primitive_events (
     stream_id TEXT NOT NULL,

--- a/internal/migrations/002-authorization.sql
+++ b/internal/migrations/002-authorization.sql
@@ -64,7 +64,7 @@ CREATE OR REPLACE ACTION is_allowed_to_read(
 CREATE OR REPLACE ACTION is_allowed_to_compose(
     $data_provider TEXT,
     $stream_id TEXT,
-    $child_stream_id TEXT,
+    $composing_stream_id TEXT,
     $active_from INT,
     $active_to INT
 ) PUBLIC view returns (is_allowed BOOL) {
@@ -72,7 +72,7 @@ CREATE OR REPLACE ACTION is_allowed_to_compose(
     if !stream_exists($data_provider, $stream_id) {
         ERROR('Stream does not exist: data_provider=' || $data_provider || ' stream_id=' || $stream_id);
     }
-    if !stream_exists($data_provider, $child_stream_id) {
+    if !stream_exists($data_provider, $composing_stream_id) {
         ERROR('Stream does not exist: data_provider=' || $data_provider || ' stream_id=' || $child_stream_id);
     }
     -- Check if the stream is private
@@ -101,7 +101,7 @@ CREATE OR REPLACE ACTION is_allowed_to_compose(
         $data_provider,
         $stream_id,
         'allow_compose_stream',
-        $child_stream_id,
+        $composing_stream_id,
         1,
         0,
         'created_at DESC'

--- a/internal/migrations/002-authorization.sql
+++ b/internal/migrations/002-authorization.sql
@@ -58,6 +58,65 @@ CREATE OR REPLACE ACTION is_allowed_to_read(
 };
 
 /**
+ * is_allowed_to_compose: Checks if a wallet can compose a stream.
+ * Considers compose visibility and explicit compose permissions.
+ */
+CREATE OR REPLACE ACTION is_allowed_to_compose(
+    $data_provider TEXT,
+    $stream_id TEXT,
+    $wallet_address TEXT,
+    $active_from INT,
+    $active_to INT
+) PUBLIC view returns (is_allowed BOOL) {
+    $lowercase_wallet_address TEXT := LOWER($wallet_address);
+    -- Check if the stream exists
+    if !stream_exists($data_provider, $stream_id) {
+        ERROR('Stream does not exist: data_provider=' || $data_provider || ' stream_id=' || $stream_id);
+    }
+    -- Check if the stream is private
+    $is_private BOOL := false;
+    for $row in get_metadata(
+        $data_provider,
+        $stream_id,
+        'compose_visibility',
+        null,
+        1,
+        0,
+        'created_at DESC'
+    ) {
+        if $row.value_i = 1 {
+            $is_private := true;
+        }
+    }
+    if $is_private = false {
+        -- short circuit if the stream is not private
+        return true;
+    }
+
+    -- Check if the wallet is allowed to read the stream
+    $is_allowed BOOL := false;
+    for $row in get_metadata(
+        $data_provider,
+        $stream_id,
+        'allow_compose_stream',
+        $lowercase_wallet_address,
+        1,
+        0,
+        'created_at DESC'
+    ) {
+        $is_allowed := true;
+    }
+
+    if $is_private = true AND $is_allowed = false {
+        return false;
+    }
+
+    NOTICE(FORMAT('is_allowed_to_compose: data_provider=%s stream_id=%s wallet_address=%s is_private=%s is_allowed=%s', $data_provider, $stream_id, $lowercase_wallet_address, $is_private, $is_allowed));
+
+    return true;
+};
+
+/**
  * is_allowed_to_read_all: Checks if a wallet can read a stream and all its substreams.
  * Uses recursive CTE to traverse taxonomy hierarchy and check permissions.
  */
@@ -171,6 +230,124 @@ CREATE OR REPLACE ACTION is_allowed_to_read_all(
         $result := $counts.unauthorized_count = 0;
     }
     
+    -- If we got here (which we shouldn't), return false as a fallback
+    return $result;
+};
+
+/**
+ * is_allowed_to_compose_all: Checks if a wallet can compose a stream and all its substreams.
+ * Uses recursive CTE to traverse taxonomy hierarchy and check permissions.
+ */
+CREATE OR REPLACE ACTION is_allowed_to_compose_all(
+    $data_provider TEXT,
+    $stream_id TEXT,
+    $wallet_address TEXT,
+    $active_from INT,
+    $active_to INT
+) PUBLIC view returns (is_allowed BOOL) {
+    -- Check if the stream exists
+    if !stream_exists($data_provider, $stream_id) {
+        ERROR('Stream does not exist: data_provider=' || $data_provider || ' stream_id=' || $stream_id);
+    }
+
+    $result BOOL := true;
+    -- Check for missing or unauthorized substreams using recursive CTE
+    for $counts in with recursive
+        -- effective_taxonomies holds, for every parent-child link that is active,
+        -- the rows that are considered effective given the time window.
+        effective_taxonomies AS (
+        SELECT
+            t.data_provider,
+            t.stream_id,
+            t.child_data_provider,
+            t.child_stream_id,
+            t.start_time
+        FROM taxonomies t
+        WHERE t.disabled_at IS NULL
+            AND ($active_to IS NULL OR t.start_time <= $active_to)
+            AND (
+            -- (A) For rows before (or at) $active_from: only include the one with the maximum start_time.
+            ($active_from IS NOT NULL
+                AND t.start_time <= $active_from
+                AND t.start_time = (
+                    SELECT max(t2.start_time)
+                    FROM taxonomies t2
+                    WHERE t2.data_provider = t.data_provider
+                        AND t2.stream_id = t.stream_id
+                        AND t2.disabled_at IS NULL
+                        AND ($active_to IS NULL OR t2.start_time <= $active_to)
+                        AND t2.start_time <= $active_from
+                )
+            )
+            -- (B) Also include any rows with start_time greater than $active_from.
+            OR ($active_from IS NULL OR t.start_time > $active_from)
+            )
+        ),
+        -- Now recursively gather all substreams
+        recursive_substreams AS (
+            -- Start with the root stream itself
+            SELECT $data_provider AS data_provider,
+                $stream_id AS stream_id
+            UNION
+            -- Then add all child streams
+            SELECT et.child_data_provider,
+                   et.child_stream_id
+            FROM effective_taxonomies et
+            JOIN recursive_substreams rs
+                ON et.data_provider = rs.data_provider
+                AND et.stream_id = rs.stream_id
+        ),
+        -- Find substreams that don't exist
+        inexisting_substreams as (
+            SELECT rs.data_provider, rs.stream_id
+            FROM recursive_substreams rs
+            LEFT JOIN streams s
+                ON rs.data_provider = s.data_provider
+                AND rs.stream_id = s.stream_id
+            WHERE s.data_provider IS NULL
+        ),
+        -- Find substreams that are private
+        private_substreams as (
+            SELECT rs.data_provider, rs.stream_id
+            FROM recursive_substreams rs
+            WHERE (
+                SELECT value_i
+                FROM metadata m
+                WHERE m.data_provider = rs.data_provider
+                    AND m.stream_id = rs.stream_id
+                    AND m.metadata_key = 'compose_visibility'
+                    AND m.disabled_at IS NULL
+                ORDER BY m.created_at DESC
+                LIMIT 1
+            ) = 1  -- 1 indicates private visibility
+        ),
+        -- Find private streams where the wallet doesn't have access
+        streams_without_permissions as (
+            SELECT p.data_provider, p.stream_id
+            FROM private_substreams p
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM metadata m
+                WHERE m.data_provider = p.data_provider
+                    AND m.stream_id = p.stream_id
+                    AND m.metadata_key = 'allow_compose_stream'
+                    AND LOWER(m.value_ref) = LOWER($wallet_address)
+                    AND m.disabled_at IS NULL
+                LIMIT 1
+            )
+        )
+    SELECT
+        (SELECT COUNT(*) FROM inexisting_substreams) AS missing_count,
+        (SELECT COUNT(*) FROM streams_without_permissions) AS unauthorized_count {
+        -- error out if there's a missing streams
+        if $counts.missing_count > 0 {
+            ERROR('streams missing for stream: data_provider=' || $data_provider || ' stream_id=' || $stream_id || ' missing_count=' || $counts.missing_count::TEXT);
+        }
+
+        -- Return false if there are any unauthorized streams
+        $result := $counts.unauthorized_count = 0;
+    }
+
     -- If we got here (which we shouldn't), return false as a fallback
     return $result;
 };

--- a/internal/migrations/002-authorization.sql
+++ b/internal/migrations/002-authorization.sql
@@ -64,14 +64,16 @@ CREATE OR REPLACE ACTION is_allowed_to_read(
 CREATE OR REPLACE ACTION is_allowed_to_compose(
     $data_provider TEXT,
     $stream_id TEXT,
-    $wallet_address TEXT,
+    $child_stream_id TEXT,
     $active_from INT,
     $active_to INT
 ) PUBLIC view returns (is_allowed BOOL) {
-    $lowercase_wallet_address TEXT := LOWER($wallet_address);
     -- Check if the stream exists
     if !stream_exists($data_provider, $stream_id) {
         ERROR('Stream does not exist: data_provider=' || $data_provider || ' stream_id=' || $stream_id);
+    }
+    if !stream_exists($data_provider, $child_stream_id) {
+        ERROR('Stream does not exist: data_provider=' || $data_provider || ' stream_id=' || $child_stream_id);
     }
     -- Check if the stream is private
     $is_private BOOL := false;
@@ -99,7 +101,7 @@ CREATE OR REPLACE ACTION is_allowed_to_compose(
         $data_provider,
         $stream_id,
         'allow_compose_stream',
-        $lowercase_wallet_address,
+        $child_stream_id,
         1,
         0,
         'created_at DESC'
@@ -241,7 +243,6 @@ CREATE OR REPLACE ACTION is_allowed_to_read_all(
 CREATE OR REPLACE ACTION is_allowed_to_compose_all(
     $data_provider TEXT,
     $stream_id TEXT,
-    $wallet_address TEXT,
     $active_from INT,
     $active_to INT
 ) PUBLIC view returns (is_allowed BOOL) {
@@ -253,95 +254,80 @@ CREATE OR REPLACE ACTION is_allowed_to_compose_all(
     $result BOOL := true;
     -- Check for missing or unauthorized substreams using recursive CTE
     for $counts in with recursive
-        -- effective_taxonomies holds, for every parent-child link that is active,
-        -- the rows that are considered effective given the time window.
-        effective_taxonomies AS (
-        SELECT
-            t.data_provider,
-            t.stream_id,
-            t.child_data_provider,
-            t.child_stream_id,
-            t.start_time
-        FROM taxonomies t
-        WHERE t.disabled_at IS NULL
-            AND ($active_to IS NULL OR t.start_time <= $active_to)
-            AND (
-            -- (A) For rows before (or at) $active_from: only include the one with the maximum start_time.
-            ($active_from IS NOT NULL
-                AND t.start_time <= $active_from
-                AND t.start_time = (
-                    SELECT max(t2.start_time)
-                    FROM taxonomies t2
-                    WHERE t2.data_provider = t.data_provider
-                        AND t2.stream_id = t.stream_id
-                        AND t2.disabled_at IS NULL
-                        AND ($active_to IS NULL OR t2.start_time <= $active_to)
-                        AND t2.start_time <= $active_from
-                )
-            )
-            -- (B) Also include any rows with start_time greater than $active_from.
-            OR ($active_from IS NULL OR t.start_time > $active_from)
-            )
+        -- Build all parent-child edges starting at the given stream.
+        parent_child_edges AS (
+            -- Base: direct children of the root.
+            SELECT
+                t.data_provider AS parent_data_provider,
+                t.stream_id AS parent_stream_id,
+                t.child_data_provider,
+                t.child_stream_id,
+                t.start_time,
+                1 AS level
+            FROM taxonomies t
+            WHERE t.data_provider = $data_provider
+              AND t.stream_id = $stream_id
+              AND t.disabled_at IS NULL
+              AND ($active_to IS NULL OR t.start_time <= $active_to)
+              AND ($active_from IS NULL OR t.start_time > $active_from)
+            UNION ALL
+            -- Recursive: find children of a previously found child.
+            SELECT
+                p.child_data_provider AS parent_data_provider,
+                p.child_stream_id AS parent_stream_id,
+                t.child_data_provider,
+                t.child_stream_id,
+                t.start_time,
+                p.level + 1 AS level
+            FROM parent_child_edges p
+            JOIN taxonomies t
+              ON t.data_provider = p.child_data_provider
+             AND t.stream_id = p.child_stream_id
+            WHERE t.disabled_at IS NULL
+              AND ($active_to IS NULL OR t.start_time <= $active_to)
+              AND ($active_from IS NULL OR t.start_time > $active_from)
         ),
-        -- Now recursively gather all substreams
-        recursive_substreams AS (
-            -- Start with the root stream itself
-            SELECT $data_provider AS data_provider,
-                $stream_id AS stream_id
-            UNION
-            -- Then add all child streams
-            SELECT et.child_data_provider,
-                   et.child_stream_id
-            FROM effective_taxonomies et
-            JOIN recursive_substreams rs
-                ON et.data_provider = rs.data_provider
-                AND et.stream_id = rs.stream_id
-        ),
-        -- Find substreams that don't exist
-        inexisting_substreams as (
-            SELECT rs.data_provider, rs.stream_id
-            FROM recursive_substreams rs
+        -- Check that all child streams exist.
+        inexisting_substreams AS (
+            SELECT DISTINCT p.child_data_provider, p.child_stream_id
+            FROM parent_child_edges p
             LEFT JOIN streams s
-                ON rs.data_provider = s.data_provider
-                AND rs.stream_id = s.stream_id
+              ON p.child_data_provider = s.data_provider
+             AND p.child_stream_id = s.stream_id
             WHERE s.data_provider IS NULL
         ),
-        -- Find substreams that are private
-        private_substreams as (
-            SELECT rs.data_provider, rs.stream_id
-            FROM recursive_substreams rs
+        -- For each edge, if the child is private, check that the child whitelists its parent.
+        unauthorized_edges AS (
+            SELECT p.parent_data_provider, p.parent_stream_id, p.child_data_provider, p.child_stream_id
+            FROM parent_child_edges p
             WHERE (
                 SELECT value_i
                 FROM metadata m
-                WHERE m.data_provider = rs.data_provider
-                    AND m.stream_id = rs.stream_id
-                    AND m.metadata_key = 'compose_visibility'
-                    AND m.disabled_at IS NULL
+                WHERE m.data_provider = p.child_data_provider
+                  AND m.stream_id = p.child_stream_id
+                  AND m.metadata_key = 'compose_visibility'
+                  AND m.disabled_at IS NULL
                 ORDER BY m.created_at DESC
                 LIMIT 1
-            ) = 1  -- 1 indicates private visibility
-        ),
-        -- Find private streams where the wallet doesn't have access
-        streams_without_permissions as (
-            SELECT p.data_provider, p.stream_id
-            FROM private_substreams p
-            WHERE NOT EXISTS (
+            ) = 1
+            AND NOT EXISTS (
                 SELECT 1
-                FROM metadata m
-                WHERE m.data_provider = p.data_provider
-                    AND m.stream_id = p.stream_id
-                    AND m.metadata_key = 'allow_compose_stream'
-                    AND LOWER(m.value_ref) = LOWER($wallet_address)
-                    AND m.disabled_at IS NULL
+                FROM metadata m2
+                WHERE m2.data_provider = p.child_data_provider
+                  AND m2.stream_id = p.child_stream_id
+                  AND m2.metadata_key = 'allow_compose_stream'
+                  AND m2.disabled_at IS NULL
+                  AND m2.value_ref = p.parent_stream_id::text
                 LIMIT 1
             )
         )
     SELECT
         (SELECT COUNT(*) FROM inexisting_substreams) AS missing_count,
-        (SELECT COUNT(*) FROM streams_without_permissions) AS unauthorized_count {
+        (SELECT COUNT(*) FROM unauthorized_edges) AS unauthorized_count {
         -- error out if there's a missing streams
         if $counts.missing_count > 0 {
-            ERROR('streams missing for stream: data_provider=' || $data_provider || ' stream_id=' || $stream_id || ' missing_count=' || $counts.missing_count::TEXT);
+            ERROR('Missing child streams for stream: data_provider=' || $data_provider ||
+                  ' stream_id=' || $stream_id || ' missing_count=' || $counts.missing_count::TEXT);
         }
 
         -- Return false if there are any unauthorized streams

--- a/internal/migrations/006-composed-query.sql
+++ b/internal/migrations/006-composed-query.sql
@@ -32,7 +32,7 @@ RETURNS TABLE(
     }
 
     -- Check compose permissions
-    if !is_allowed_to_compose($data_provider, $stream_id, @caller, $from, $to) {
+    if !is_allowed_to_compose_all($data_provider, $stream_id, $from, $to) {
         ERROR('Not allowed to compose stream');
     }
 

--- a/internal/migrations/006-composed-query.sql
+++ b/internal/migrations/006-composed-query.sql
@@ -31,6 +31,11 @@ RETURNS TABLE(
         ERROR('Not allowed to read stream');
     }
 
+    -- Check compose permissions
+    if !is_allowed_to_compose($data_provider, $stream_id, @caller, $from, $to) {
+        ERROR('Not allowed to compose stream');
+    }
+
     RETURN WITH RECURSIVE
 
     -- Find taxonomy versions that apply to our query window

--- a/tests/streams/auth/auth_test.go
+++ b/tests/streams/auth/auth_test.go
@@ -544,10 +544,10 @@ func testComposePermissionControl(t *testing.T, contractInfo setup.StreamInfo) k
 
 		// Verify foreign stream cannot compose without permission
 		canCompose, err := procedure.CheckComposePermissions(ctx, procedure.CheckComposePermissionsInput{
-			Platform:      platform,
-			Locator:       contractInfo.Locator,
-			ChildStreamId: upperStreamInfo.Locator.StreamId.String(),
-			Height:        0,
+			Platform:          platform,
+			Locator:           contractInfo.Locator,
+			ComposingStreamId: upperStreamInfo.Locator.StreamId.String(),
+			Height:            0,
 		})
 		assert.False(t, canCompose, "Upper stream should not be allowed to compose without permission")
 
@@ -568,10 +568,10 @@ func testComposePermissionControl(t *testing.T, contractInfo setup.StreamInfo) k
 		// Verify upper stream can now compose
 		platform.Deployer = upperStreamInfo.Locator.DataProvider.Bytes()
 		canCompose, err = procedure.CheckComposePermissions(ctx, procedure.CheckComposePermissionsInput{
-			Platform:      platform,
-			Locator:       upperStreamInfo.Locator,
-			ChildStreamId: contractInfo.Locator.StreamId.String(),
-			Height:        0,
+			Platform:          platform,
+			Locator:           upperStreamInfo.Locator,
+			ComposingStreamId: contractInfo.Locator.StreamId.String(),
+			Height:            0,
 		})
 		assert.True(t, canCompose, "Upper stream should be allowed to compose after permission is granted")
 		assert.NoError(t, err, "No error expected when composing with permission")

--- a/tests/streams/utils/procedure/metadata.go
+++ b/tests/streams/utils/procedure/metadata.go
@@ -65,7 +65,6 @@ func CheckReadAllPermissions(ctx context.Context, input CheckReadAllPermissionsI
 type CheckComposeAllPermissionsInput struct {
 	Platform *kwilTesting.Platform
 	Locator  trufTypes.StreamLocator
-	Wallet   string
 	Height   int64
 }
 
@@ -92,7 +91,6 @@ func CheckComposeAllPermissions(ctx context.Context, input CheckComposeAllPermis
 	r, err := input.Platform.Engine.Call(engineContext, input.Platform.DB, "", "is_allowed_to_compose_all", []any{
 		input.Locator.DataProvider.Address(),
 		input.Locator.StreamId.String(),
-		input.Wallet,
 		nil, // active_from, nil means no restriction
 		nil, // active_to, nil means no restriction
 	}, func(row *common.Row) error {
@@ -216,7 +214,7 @@ func CheckWritePermissions(ctx context.Context, input CheckWritePermissionsInput
 type CheckComposePermissionsInput struct {
 	Platform      *kwilTesting.Platform
 	Locator       trufTypes.StreamLocator
-	ForeignCaller string
+	ChildStreamId string
 	Height        int64
 }
 
@@ -243,7 +241,7 @@ func CheckComposePermissions(ctx context.Context, input CheckComposePermissionsI
 	r, err := input.Platform.Engine.Call(engineContext, input.Platform.DB, "", "is_allowed_to_compose", []any{
 		input.Locator.DataProvider.Address(),
 		input.Locator.StreamId.String(),
-		input.ForeignCaller,
+		input.ChildStreamId,
 		nil,
 		nil,
 	}, func(row *common.Row) error {

--- a/tests/streams/utils/procedure/metadata.go
+++ b/tests/streams/utils/procedure/metadata.go
@@ -62,8 +62,15 @@ func CheckReadAllPermissions(ctx context.Context, input CheckReadAllPermissionsI
 	return allowed, nil
 }
 
-// CheckComposeAllPermissions checks if a wallet is allowed to read from all substreams of a stream
-func CheckComposeAllPermissions(ctx context.Context, input CheckReadAllPermissionsInput) (bool, error) {
+type CheckComposeAllPermissionsInput struct {
+	Platform *kwilTesting.Platform
+	Locator  trufTypes.StreamLocator
+	Wallet   string
+	Height   int64
+}
+
+// CheckComposeAllPermissions checks if a wallet is allowed to compose from all substreams of a stream
+func CheckComposeAllPermissions(ctx context.Context, input CheckComposeAllPermissionsInput) (bool, error) {
 	deployer, err := util.NewEthereumAddressFromBytes(input.Platform.Deployer)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to create Ethereum address from deployer bytes")
@@ -82,7 +89,7 @@ func CheckComposeAllPermissions(ctx context.Context, input CheckReadAllPermissio
 	}
 
 	var allowed bool
-	r, err := input.Platform.Engine.Call(engineContext, input.Platform.DB, "", "is_allowed_to_compose", []any{
+	r, err := input.Platform.Engine.Call(engineContext, input.Platform.DB, "", "is_allowed_to_compose_all", []any{
 		input.Locator.DataProvider.Address(),
 		input.Locator.StreamId.String(),
 		input.Wallet,

--- a/tests/streams/utils/procedure/metadata.go
+++ b/tests/streams/utils/procedure/metadata.go
@@ -212,10 +212,10 @@ func CheckWritePermissions(ctx context.Context, input CheckWritePermissionsInput
 }
 
 type CheckComposePermissionsInput struct {
-	Platform      *kwilTesting.Platform
-	Locator       trufTypes.StreamLocator
-	ChildStreamId string
-	Height        int64
+	Platform          *kwilTesting.Platform
+	Locator           trufTypes.StreamLocator
+	ComposingStreamId string
+	Height            int64
 }
 
 // CheckComposePermissions checks if a stream is allowed to compose from another stream
@@ -241,7 +241,7 @@ func CheckComposePermissions(ctx context.Context, input CheckComposePermissionsI
 	r, err := input.Platform.Engine.Call(engineContext, input.Platform.DB, "", "is_allowed_to_compose", []any{
 		input.Locator.DataProvider.Address(),
 		input.Locator.StreamId.String(),
-		input.ChildStreamId,
+		input.ComposingStreamId,
 		nil,
 		nil,
 	}, func(row *common.Row) error {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

Need this PR to be done first: https://github.com/trufnetwork/node/pull/848

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request includes several changes to enhance stream composition permissions and improve the handling of nested stream permissions. The most important changes include adding new actions for checking composition permissions, updating tests to cover these new permissions, and modifying existing procedures to incorporate these checks.

Enhancements to composition permissions:

* [`internal/migrations/002-authorization.sql`](diffhunk://#diff-f5e09011c5dd5a049b04fe6ade00da3f1ca09bb47f857775e67127eca9974e88R60-R118): Added `is_allowed_to_compose` and `is_allowed_to_compose_all` actions to check if a wallet can compose a stream and all its substreams, respectively. [[1]](diffhunk://#diff-f5e09011c5dd5a049b04fe6ade00da3f1ca09bb47f857775e67127eca9974e88R60-R118) [[2]](diffhunk://#diff-f5e09011c5dd5a049b04fe6ade00da3f1ca09bb47f857775e67127eca9974e88R237-R354)
* [`internal/migrations/006-composed-query.sql`](diffhunk://#diff-6a560b5dfa236aed546608bcc8860729d39564c29bb00366532c668f8f966dffR34-R38): Added a check for composition permissions in the composed query logic.

Updates to tests:

* [`tests/streams/auth/auth_test.go`](diffhunk://#diff-7ffa2f7a31ff6873592c58368ff2e987abd9a893e952758428f57e6f9fe68247L498-R754): Re-enabled and updated `TestAUTH04_ComposePermissions` to test composition permissions, and added `TestAUTH04_NestedComposePermissions` to test nested composition permissions.
* [`tests/streams/auth/auth_test.go`](diffhunk://#diff-7ffa2f7a31ff6873592c58368ff2e987abd9a893e952758428f57e6f9fe68247L335-R335): Updated `testNestedReadPermissionControl` to use `nil` for `StartTime` when setting taxonomy for composed streams. [[1]](diffhunk://#diff-7ffa2f7a31ff6873592c58368ff2e987abd9a893e952758428f57e6f9fe68247L335-R335) [[2]](diffhunk://#diff-7ffa2f7a31ff6873592c58368ff2e987abd9a893e952758428f57e6f9fe68247L348-R348)

Procedural modifications:

* [`tests/streams/utils/procedure/metadata.go`](diffhunk://#diff-2f34cd3e6789a4b2e0be41996a2b82d976bd6214386e886d9bc3cdf5eb607e13R65-R115): Added `CheckComposeAllPermissions` function to check if a wallet is allowed to compose from all substreams of a stream.

Index optimization:

* [`internal/migrations/000-initial-data.sql`](diffhunk://#diff-cdae0f913da5e43d2a0a592a6fd6f627a70ae8c7d07a9f176860e14a5196cb36L82-R82): Modified the `tax_latest_version_idx` index to remove `DESC` ordering for `start_time` and `version`.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/node/issues/826

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
