### PR TITLE
feat: batch insert records

### DIFF
--- a/internal/migrations/003-primitive-insertion.sql
+++ b/internal/migrations/003-primitive-insertion.sql
@@ -9,12 +9,12 @@ CREATE OR REPLACE ACTION insert_record(
     $value NUMERIC(36,18)
 ) PUBLIC {
     -- Ensure the wallet is allowed to write
-    if is_wallet_allowed_to_write($data_provider, $stream_id, @caller) == false {
+    if !is_wallet_allowed_to_write($data_provider, $stream_id, @caller) {
         ERROR('wallet not allowed to write');
     }
 
     -- Ensure that the stream/contract is existent
-    if stream_exists($data_provider, $stream_id) == false {
+    if !stream_exists($data_provider, $stream_id) {
         ERROR('stream does not exist');
     }
 
@@ -23,4 +23,43 @@ CREATE OR REPLACE ACTION insert_record(
     -- Insert the new record into the primitive_events table
     INSERT INTO primitive_events (stream_id, data_provider, event_time, value, created_at)
     VALUES ($stream_id, $data_provider, $event_time, $value, $current_block);
+};
+
+
+/**
+ * insert_records: Adds multiple new data points to a primitive stream in batch.
+ * Validates write permissions and stream existence for each record before insertion.
+ */
+CREATE OR REPLACE ACTION insert_records(
+    $data_provider TEXT[],
+    $stream_id TEXT[],
+    $event_time INT8[],
+    $value NUMERIC(36,18)[]
+) PUBLIC {
+    $num_records INT := array_length($data_provider);
+    if $num_records != array_length($stream_id) or $num_records != array_length($event_time) or $num_records != array_length($value) {
+        ERROR('array lengths mismatch');
+    }
+
+    $current_block INT := @height;
+
+    -- Validate each record in the batch
+    FOR $i IN 1..$num_records {
+        if !is_wallet_allowed_to_write($data_provider[$i], $stream_id[$i], @caller) {
+            ERROR('wallet not allowed to write');
+        }
+        if !stream_exists($data_provider[$i], $stream_id[$i]) {
+            ERROR('stream does not exist');
+        }
+    }
+
+    -- Insert all records
+    FOR $i IN 1..$num_records {
+        $stream_id_val TEXT := $stream_id[$i];
+        $data_provider_val TEXT := $data_provider[$i];
+        $event_time_val INT8 := $event_time[$i];
+        $value_val NUMERIC(36,18) := $value[$i];
+        INSERT INTO primitive_events (stream_id, data_provider, event_time, value, created_at)
+        VALUES ($stream_id_val, $data_provider_val, $event_time_val, $value_val, $current_block);
+    }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request includes significant changes to the `internal/migrations/003-primitive-insertion.sql` and `tests/streams/query/query_test.go` files to add batch insertion functionality and improve test coverage. The most important changes include the addition of a new batch insertion action, updates to existing tests to use pointers for time values, and the addition of a new test for batch insertion.

### Batch Insertion Functionality:
* [`internal/migrations/003-primitive-insertion.sql`](diffhunk://#diff-2f44cbadeab352c165403244389d217584b63d9dbbe9180edb5967062e3c8459R27-R65): Added a new action `insert_records` for batch insertion of multiple data points into a primitive stream, including validation of write permissions and stream existence for each record.

### Test Updates:
* [`tests/streams/query/query_test.go`](diffhunk://#diff-b3588b249955797b226816b085f1bfcaa6f085159a80b516b20a6e69362b5d1cL105-R107): Updated several test functions to use pointers for `FromTime` and `ToTime` values, improving the flexibility and accuracy of the tests. [[1]](diffhunk://#diff-b3588b249955797b226816b085f1bfcaa6f085159a80b516b20a6e69362b5d1cL105-R107) [[2]](diffhunk://#diff-b3588b249955797b226816b085f1bfcaa6f085159a80b516b20a6e69362b5d1cL147-R149) [[3]](diffhunk://#diff-b3588b249955797b226816b085f1bfcaa6f085159a80b516b20a6e69362b5d1cL185-R187) [[4]](diffhunk://#diff-b3588b249955797b226816b085f1bfcaa6f085159a80b516b20a6e69362b5d1cL227-R229) [[5]](diffhunk://#diff-b3588b249955797b226816b085f1bfcaa6f085159a80b516b20a6e69362b5d1cL317-R319) [[6]](diffhunk://#diff-b3588b249955797b226816b085f1bfcaa6f085159a80b516b20a6e69362b5d1cL362-R365) [[7]](diffhunk://#diff-b3588b249955797b226816b085f1bfcaa6f085159a80b516b20a6e69362b5d1cL419-R421)
* [`tests/streams/query/query_test.go`](diffhunk://#diff-b3588b249955797b226816b085f1bfcaa6f085159a80b516b20a6e69362b5d1cR525-R585): Added a new test function `testBatchInsertAndQueryRecord` to verify the functionality of the batch insertion action and ensure that the inserted records can be queried correctly.

### Utility Function Updates:
* [`tests/streams/utils/setup/primitive.go`](diffhunk://#diff-0ad46ca5c11ba5acef42d8bf7857619d32b7b16eb40127dcb702e4a34f9473b2L81-R82): Updated the `InsertPrimitiveDataInput` struct and related functions to use consistent naming conventions (`PrimitiveStream` and `Height`). [[1]](diffhunk://#diff-0ad46ca5c11ba5acef42d8bf7857619d32b7b16eb40127dcb702e4a34f9473b2L81-R82) [[2]](diffhunk://#diff-0ad46ca5c11ba5acef42d8bf7857619d32b7b16eb40127dcb702e4a34f9473b2L220-R241) [[3]](diffhunk://#diff-0ad46ca5c11ba5acef42d8bf7857619d32b7b16eb40127dcb702e4a34f9473b2L250-R250) [[4]](diffhunk://#diff-0ad46ca5c11ba5acef42d8bf7857619d32b7b16eb40127dcb702e4a34f9473b2L278-R349)
* [`tests/streams/utils/setup/primitive.go`](diffhunk://#diff-0ad46ca5c11ba5acef42d8bf7857619d32b7b16eb40127dcb702e4a34f9473b2L278-R349): Added a new utility function `InsertPrimitiveDataBatch` to facilitate the batch insertion of primitive data using the new `insert_records` action.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/node/issues/855

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
