### PR TITLE
chore: make taxonomy insertion not a view function

### DIFF
--- a/internal/migrations/004-composed-taxonomy.sql
+++ b/internal/migrations/004-composed-taxonomy.sql
@@ -9,7 +9,7 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     $child_stream_ids TEXT[],       -- The stream IDs of the child streams.
     $weights NUMERIC(36,18)[],      -- The weights of the child streams.
     $start_date INT                 -- The start date of the taxonomy.
-) PUBLIC view returns (result bool) {
+) PUBLIC {
     -- ensure it's a composed stream
     if is_primitive_stream($data_provider, $stream_id) == true {
         ERROR('stream is not a composed stream');
@@ -74,7 +74,6 @@ CREATE OR REPLACE ACTION insert_taxonomy(
             $start_date          -- Start date of the taxonomy.
         );
     }
-    return true;
 };
 
 /**

--- a/internal/migrations/006-composed-query.sql
+++ b/internal/migrations/006-composed-query.sql
@@ -22,14 +22,14 @@ RETURNS TABLE(
     }
 
     -- -- Check permissions; raises error if unauthorized
-    -- IF !is_allowed_to_read_all($data_provider, $stream_id, @caller, $from, $to) {
-    --     ERROR('Not allowed to read stream');
-    -- }
+    IF !is_allowed_to_read_all($data_provider, $stream_id, @caller, $from, $to) {
+        ERROR('Not allowed to read stream');
+    }
 
-    -- -- Check compose permissions
-    -- if !is_allowed_to_compose_all($data_provider, $stream_id, $from, $to) {
-    --     ERROR('Not allowed to compose stream');
-    -- }
+    -- Check compose permissions
+    if !is_allowed_to_compose_all($data_provider, $stream_id, $from, $to) {
+        ERROR('Not allowed to compose stream');
+    }
 
     RETURN WITH RECURSIVE
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This pull request includes changes to the SQL migration files to improve the handling of permissions and streamline the `insert_taxonomy` action.

### Improvements to `insert_taxonomy` action:

* [`internal/migrations/004-composed-taxonomy.sql`](diffhunk://#diff-6ac43eedbca3bd192af8acbe4abf69eef3dd3cf6c497bb6a057a2226080ef45dL12-R12): Removed the return statement and modified the function signature to remove the `returns (result bool)` clause. [[1]](diffhunk://#diff-6ac43eedbca3bd192af8acbe4abf69eef3dd3cf6c497bb6a057a2226080ef45dL12-R12) [[2]](diffhunk://#diff-6ac43eedbca3bd192af8acbe4abf69eef3dd3cf6c497bb6a057a2226080ef45dL77)

### Permissions handling:

* [`internal/migrations/006-composed-query.sql`](diffhunk://#diff-6a560b5dfa236aed546608bcc8860729d39564c29bb00366532c668f8f966dffL25-R32): Uncommented and re-enabled permission checks for reading and composing streams to ensure proper authorization.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/sdk-js/issues/55

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
