### PR TITLE
feat: from config stack compatible with upgrade

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -186,8 +186,7 @@ tasks:
       - bash ./scripts/migrate.sh
     env:
       PRIVATE_KEY: "0000000000000000000000000000000000000000000000000000000000000001"
-      PROVIDER: https://gateway.dev.infra.truf.network
-      # PROVIDER: http://localhost:8484
+      PROVIDER: http://localhost:8484
 
   action-migrate:
     desc: Run the migration action for all SQL files

--- a/deployments/gateway/gateway-compose.yaml
+++ b/deployments/gateway/gateway-compose.yaml
@@ -16,6 +16,7 @@ services:
       SESSION_SECRET: ${SESSION_SECRET:?}
       DOMAIN: https://${DOMAIN:?}
       CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS}
+      XFF_TRUST_PROXY_COUNT: ${XFF_TRUST_PROXY_COUNT:-}
       EXTRA_ARGS: "--allow-chain-rpcs"
     volumes:
       - type: bind

--- a/deployments/gateway/kgw-config.pkl
+++ b/deployments/gateway/kgw-config.pkl
@@ -31,6 +31,11 @@ tsl_key_file = read?("env:TSL_KEY_FILE")
 // default 30 seconds
 read_timeout = read?("env:READ_TIMEOUT")?.toInt()
 
+// env variable for trusting X-Forwarded-For headers
+// default to null if not provided or not an integer
+hidden xff_trust_proxy_count_raw = read?("env:XFF_TRUST_PROXY_COUNT")
+xff_trust_proxy_count = xff_trust_proxy_count_raw?.toIntOrNull()
+
 // env variable boolean values
 allow_deploy_db = read?("env:ALLOW_DEPLOY_DB") == "true"
 

--- a/deployments/indexer/indexer-compose.yaml
+++ b/deployments/indexer/indexer-compose.yaml
@@ -52,7 +52,6 @@ services:
       context: .
     environment:
       NODE_RPC_ENDPOINT: ${NODE_RPC_ENDPOINT:?NODE_RPC_ENDPOINT is required}
-      KWIL_PG_CONN: ${KWIL_PG_CONN:?KWIL_PG_CONN is required}
       INDEXER_PG_CONN: "postgresql://postgres:postgres@indexer-postgres:5432/indexer?sslmode=disable"
     ports:
       - "1337:1337"

--- a/deployments/infra/cdk_main.go
+++ b/deployments/infra/cdk_main.go
@@ -22,7 +22,7 @@ func main() {
 	// TN-Auto Stack
 	stacks.TnAutoStack(
 		app,
-		config.WithStackSuffix(app, "TN-DB-Auto"),
+		config.WithStackSuffix(app, "TN-Auto"),
 		&stacks.TnAutoStackProps{
 			StackProps:       awscdk.StackProps{Env: utils.CdkEnv()},
 			CertStackExports: &certExports,

--- a/deployments/infra/config/env_vars.go
+++ b/deployments/infra/config/env_vars.go
@@ -6,21 +6,21 @@ import (
 )
 
 type MainEnvironmentVariables struct {
-	KwildCliPath  string `env:"KWILD_CLI_PATH" required:"true"`
-	CdkDocker     string `env:"CDK_DOCKER" required:"true"`
-	ChainId       string `env:"CHAIN_ID" required:"true"`
-	SessionSecret string `env:"SESSION_SECRET" required:"true"`
+	KwildCliPath    string `env:"KWILD_CLI_PATH" required:"true"`
+	CdkDocker       string `env:"CDK_DOCKER" required:"true"`
+	ChainId         string `env:"CHAIN_ID" required:"true"`
+	SessionSecret   string `env:"SESSION_SECRET" required:"true"`
+	IncludeObserver bool   `env:"INCLUDE_OBSERVER" envDefault:"false"`
 }
 
 type AutoStackEnvironmentVariables struct {
-	// IncludeObserver is true if we want to test metrics setup
-	IncludeObserver bool `env:"INCLUDE_OBSERVER" default:"false"`
+	MainEnvironmentVariables
 	// DB_OWNER must be external, otherwise it will always be unknown
 	DbOwner string `env:"DB_OWNER" required:"true"`
 }
 
 type ConfigStackEnvironmentVariables struct {
-	// comma separated list of private keys for the nodes
+	MainEnvironmentVariables
 	NodePrivateKeys string `env:"NODE_PRIVATE_KEYS" required:"true"`
 	GenesisPath     string `env:"GENESIS_PATH" required:"true"`
 }

--- a/deployments/infra/config/env_vars.go
+++ b/deployments/infra/config/env_vars.go
@@ -6,23 +6,23 @@ import (
 )
 
 type MainEnvironmentVariables struct {
-	KwildCliPath    string `env:"KWILD_CLI_PATH" required:"true"`
-	CdkDocker       string `env:"CDK_DOCKER" required:"true"`
-	ChainId         string `env:"CHAIN_ID" required:"true"`
-	SessionSecret   string `env:"SESSION_SECRET" required:"true"`
+	KwildCliPath    string `env:"KWILD_CLI_PATH,required"`
+	CdkDocker       string `env:"CDK_DOCKER,required"`
+	ChainId         string `env:"CHAIN_ID,required"`
+	SessionSecret   string `env:"SESSION_SECRET,required"`
 	IncludeObserver bool   `env:"INCLUDE_OBSERVER" envDefault:"false"`
 }
 
 type AutoStackEnvironmentVariables struct {
 	MainEnvironmentVariables
 	// DB_OWNER must be external, otherwise it will always be unknown
-	DbOwner string `env:"DB_OWNER" required:"true"`
+	DbOwner string `env:"DB_OWNER,required"`
 }
 
 type ConfigStackEnvironmentVariables struct {
 	MainEnvironmentVariables
-	NodePrivateKeys string `env:"NODE_PRIVATE_KEYS" required:"true"`
-	GenesisPath     string `env:"GENESIS_PATH" required:"true"`
+	NodePrivateKeys string `env:"NODE_PRIVATE_KEYS,required"`
+	GenesisPath     string `env:"GENESIS_PATH,required"`
 }
 
 func GetEnvironmentVariables[T any](scope constructs.Construct) T {

--- a/deployments/infra/lib/constructs/fronting/api_gateway.go
+++ b/deployments/infra/lib/constructs/fronting/api_gateway.go
@@ -75,7 +75,8 @@ func (a *apiGateway) AttachRoutes(scope constructs.Construct, id string, props *
 		&awsapigatewayv2integrations.HttpUrlIntegrationProps{
 			Method: awsapigatewayv2.HttpMethod_ANY,
 			ParameterMapping: awsapigatewayv2.NewParameterMapping().
-				AppendHeader(jsii.String("path"), awsapigatewayv2.MappingValue_ContextVariable(jsii.String("request.path"))),
+				AppendHeader(jsii.String("path"), awsapigatewayv2.MappingValue_ContextVariable(jsii.String("request.path"))).
+				OverwritePath(awsapigatewayv2.MappingValue_RequestPath()),
 		},
 	)
 

--- a/deployments/infra/lib/constructs/kwil_cluster/assets.go
+++ b/deployments/infra/lib/constructs/kwil_cluster/assets.go
@@ -17,6 +17,7 @@ type GatewayAssets struct {
 
 type IndexerAssets struct {
 	DirAsset awss3assets.Asset
+	Binary   utils.S3Object
 }
 
 type KwilAssets struct {
@@ -28,6 +29,7 @@ type KwilAssetOptions struct {
 	RootDir            string // base path for deployments directory
 	BinariesBucketName string
 	KGWBinaryKey       string
+	IndexerBinaryKey   string
 }
 
 // BuildKwilAssets packages gateway and indexer directories and binaries
@@ -38,12 +40,18 @@ func BuildKwilAssets(scope constructs.Construct, opts KwilAssetOptions) KwilAsse
 	ixZip := awss3assets.NewAsset(scope, jsii.String("IndexerDir"), &awss3assets.AssetProps{
 		Path: jsii.String(filepath.Join(opts.RootDir, "deployments/indexer/")),
 	})
-	bin := utils.S3Object{
-		Bucket: awss3.Bucket_FromBucketName(scope, jsii.String("BinaryBucket"), jsii.String(opts.BinariesBucketName)),
+	binBucket := awss3.Bucket_FromBucketName(scope, jsii.String("BinaryBucketImport"), jsii.String(opts.BinariesBucketName))
+
+	kgwBin := utils.S3Object{
+		Bucket: binBucket,
 		Key:    jsii.String(opts.KGWBinaryKey),
 	}
+	ixBin := utils.S3Object{
+		Bucket: binBucket,
+		Key:    jsii.String(opts.IndexerBinaryKey),
+	}
 	return KwilAssets{
-		Gateway: GatewayAssets{DirAsset: gwZip, Binary: bin},
-		Indexer: IndexerAssets{DirAsset: ixZip},
+		Gateway: GatewayAssets{DirAsset: gwZip, Binary: kgwBin},
+		Indexer: IndexerAssets{DirAsset: ixZip, Binary: ixBin},
 	}
 }

--- a/deployments/infra/lib/constructs/kwil_cluster/kwil_cluster.go
+++ b/deployments/infra/lib/constructs/kwil_cluster/kwil_cluster.go
@@ -72,11 +72,12 @@ func NewKwilCluster(scope constructs.Construct, id string, props *KwilClusterPro
 
 	// create Indexer instance
 	idx := kwil_indexer.NewIndexerInstance(node, kwil_indexer.NewIndexerInstanceInput{
-		Vpc:             props.Vpc,
-		TNInstance:      props.Validators[0],
-		IndexerDirAsset: props.Assets.Indexer.DirAsset,
-		HostedDomain:    props.HostedDomain,
-		InitElements:    props.InitElements,
+		Vpc:                props.Vpc,
+		TNInstance:         props.Validators[0],
+		IndexerDirAsset:    props.Assets.Indexer.DirAsset,
+		IndexerBinaryAsset: props.Assets.Indexer.Binary,
+		HostedDomain:       props.HostedDomain,
+		InitElements:       props.InitElements,
 	})
 	kc.Indexer = idx
 	// Apply ingress rules to Indexer SG

--- a/deployments/infra/lib/constructs/kwil_cluster/kwil_cluster.go
+++ b/deployments/infra/lib/constructs/kwil_cluster/kwil_cluster.go
@@ -61,6 +61,8 @@ func NewKwilCluster(scope constructs.Construct, id string, props *KwilClusterPro
 			SessionSecret:    props.SessionSecret,
 			ChainId:          props.ChainId,
 			Nodes:            props.Validators,
+			// default to 1, because it is behind a TLS termination point
+			XffTrustProxyCount: jsii.String("1"),
 		},
 		InitElements: props.InitElements,
 	})

--- a/deployments/infra/lib/kwil-gateway/kgw_instance.go
+++ b/deployments/infra/lib/kwil-gateway/kgw_instance.go
@@ -15,11 +15,12 @@ import (
 )
 
 type KGWConfig struct {
-	CorsAllowOrigins *string
-	Domain           *string
-	SessionSecret    *string
-	ChainId          *string
-	Nodes            []tn.TNInstance
+	CorsAllowOrigins   *string
+	Domain             *string
+	SessionSecret      *string
+	ChainId            *string
+	Nodes              []tn.TNInstance
+	XffTrustProxyCount *string
 }
 
 type NewKGWInstanceInput struct {

--- a/deployments/infra/lib/kwil-gateway/kgw_startup_scripts.go
+++ b/deployments/infra/lib/kwil-gateway/kgw_startup_scripts.go
@@ -26,11 +26,12 @@ func AddKwilGatewayStartupScriptsToInstance(options AddKwilGatewayStartupScripts
 	}
 
 	kgwEnvConfig := KGWEnvConfig{
-		CorsAllowOrigins: config.CorsAllowOrigins,
-		SessionSecret:    config.SessionSecret,
-		Backends:         awscdk.Fn_Join(jsii.String(","), &nodeAddresses), // nodeAddresses now contains http://host:port
-		ChainId:          config.ChainId,
-		Domain:           config.Domain,
+		CorsAllowOrigins:   config.CorsAllowOrigins,
+		SessionSecret:      config.SessionSecret,
+		Backends:           awscdk.Fn_Join(jsii.String(","), &nodeAddresses), // nodeAddresses now contains http://host:port
+		ChainId:            config.ChainId,
+		Domain:             config.Domain,
+		XffTrustProxyCount: config.XffTrustProxyCount,
 	}
 
 	script := "#!/bin/bash\nset -e\nset -x\n\n"
@@ -67,11 +68,12 @@ rm -rf /tmp/kgw-pkg /tmp/kgw-binary
 }
 
 type KGWEnvConfig struct {
-	Domain           *string `env:"DOMAIN"`
-	CorsAllowOrigins *string `env:"CORS_ALLOW_ORIGINS"`
-	SessionSecret    *string `env:"SESSION_SECRET"`
-	Backends         *string `env:"BACKENDS"`
-	ChainId          *string `env:"CHAIN_ID"`
+	Domain             *string `env:"DOMAIN"`
+	CorsAllowOrigins   *string `env:"CORS_ALLOW_ORIGINS"`
+	SessionSecret      *string `env:"SESSION_SECRET"`
+	XffTrustProxyCount *string `env:"XFF_TRUST_PROXY_COUNT"`
+	Backends           *string `env:"BACKENDS"`
+	ChainId            *string `env:"CHAIN_ID"`
 }
 
 // GetDict returns a map of the environment variables and their values

--- a/deployments/infra/lib/kwil-indexer/indexer_startup_scripts.go
+++ b/deployments/infra/lib/kwil-indexer/indexer_startup_scripts.go
@@ -11,17 +11,21 @@ import (
 )
 
 type IndexerEnvConfig struct {
-	NodeRpcEndpoint *string `env:"NODE_RPC_ENDPOINT"`
-	PostgresVolume  *string `env:"POSTGRES_VOLUME"`
+	NodeRpcEndpoint   *string `env:"NODE_RPC_ENDPOINT"`
+	PostgresVolume    *string `env:"POSTGRES_VOLUME"`
+	IndexerBinaryPath *string `env:"INDEXER_BINARY_PATH"`
 }
 
 type AddKwilIndexerStartupScriptsOptions struct {
 	TNInstance           tn.TNInstance
 	indexerZippedDirPath *string
+	indexerBinaryZipPath *string
 }
 
 func AddKwilIndexerStartupScripts(options AddKwilIndexerStartupScriptsOptions) *string {
 	tnInstance := options.TNInstance
+	indexerBinaryDir := "/home/ec2-user/indexer"
+	indexerBinaryPath := fmt.Sprintf("%s/kwil-indexer", indexerBinaryDir)
 
 	// Create the environment variables for the indexer compose file
 	indexerEnvConfig := IndexerEnvConfig{
@@ -32,7 +36,8 @@ func AddKwilIndexerStartupScripts(options AddKwilIndexerStartupScriptsOptions) *
 			*tnInstance.PeerConnection.Address,
 			strconv.Itoa(peer.TnRPCPort),
 		)),
-		PostgresVolume: jsii.String("/data/postgres"),
+		PostgresVolume:    jsii.String("/data/postgres"),
+		IndexerBinaryPath: jsii.String(indexerBinaryPath),
 	}
 
 	script := "#!/bin/bash\nset -e\nset -x\n\n"
@@ -51,6 +56,15 @@ func AddKwilIndexerStartupScripts(options AddKwilIndexerStartupScriptsOptions) *
 	}
 	script += configureScript + "\n"
 	script += utils.UnzipFileScript(*options.indexerZippedDirPath, "/home/ec2-user/indexer") + "\n"
+	// Define the target directory for the binary
+
+	script += fmt.Sprintf("mkdir -p %s\n", indexerBinaryDir)
+	// Unzip the binary zip into the target directory
+	script += utils.UnzipFileScript(*options.indexerBinaryZipPath, indexerBinaryDir) + "\n"
+	// Ensure the binary (assuming name kwil-indexer) is executable
+	script += fmt.Sprintf("chmod +x %s\n", indexerBinaryPath)
+
+	// Assume indexer-compose.yaml will mount indexerBinaryDir/kwil-indexer to the correct path inside the container
 	script += utils.CreateSystemdServiceScript(
 		"kwil-indexer",
 		"Kwil Indexer Compose",

--- a/deployments/infra/lib/kwil-indexer/indexer_startup_scripts.go
+++ b/deployments/infra/lib/kwil-indexer/indexer_startup_scripts.go
@@ -11,8 +11,8 @@ import (
 )
 
 type IndexerEnvConfig struct {
-	NodeCometBftEndpoint *string `env:"NODE_COMETBFT_ENDPOINT"`
-	PostgresVolume       *string `env:"POSTGRES_VOLUME"`
+	NodeRpcEndpoint *string `env:"NODE_RPC_ENDPOINT"`
+	PostgresVolume  *string `env:"POSTGRES_VOLUME"`
 }
 
 type AddKwilIndexerStartupScriptsOptions struct {
@@ -26,7 +26,7 @@ func AddKwilIndexerStartupScripts(options AddKwilIndexerStartupScriptsOptions) *
 	// Create the environment variables for the indexer compose file
 	indexerEnvConfig := IndexerEnvConfig{
 		// note: the tn p2p port (usually 26656) will be automatically crawled by the indexer
-		NodeCometBftEndpoint: jsii.String(fmt.Sprintf(
+		NodeRpcEndpoint: jsii.String(fmt.Sprintf(
 			"http://%s:%s",
 			// public ip so the external elastic ip is used to allow the indexer to connect to the TN node
 			*tnInstance.PeerConnection.Address,

--- a/deployments/infra/lib/utils/attach_init.go
+++ b/deployments/infra/lib/utils/attach_init.go
@@ -30,6 +30,7 @@ func AttachInitDataToLaunchTemplate(input AttachInitDataToLaunchTemplateInput) {
 			InstanceRole: input.Role,
 			UserData:     ud,
 			Platform:     input.Platform,
+			IncludeRole:  jsii.Bool(true),
 		},
 	)
 }

--- a/deployments/infra/stacks/tn_auto_stack.go
+++ b/deployments/infra/stacks/tn_auto_stack.go
@@ -39,12 +39,11 @@ func TnAutoStack(scope constructs.Construct, id string, props *TnAutoStackProps)
 	devPrefix := config.GetDevPrefix(stack)
 	// Retrieve Main environment variables including DbOwner
 	autoEnvVars := config.GetEnvironmentVariables[config.AutoStackEnvironmentVariables](stack)
-	mainEnvVars := config.GetEnvironmentVariables[config.MainEnvironmentVariables](stack)
 
 	initElements := []awsec2.InitElement{} // Base elements only
 	var observerAsset awss3assets.Asset    // Keep asset variable, needed for Attach call
 
-	shouldIncludeObserver := config.GetEnvironmentVariables[config.AutoStackEnvironmentVariables](stack).IncludeObserver
+	shouldIncludeObserver := autoEnvVars.IncludeObserver
 
 	if shouldIncludeObserver {
 		// Only get the asset here, don't generate InitElements
@@ -116,8 +115,8 @@ func TnAutoStack(scope constructs.Construct, id string, props *TnAutoStackProps)
 		HostedDomain:         hd,
 		Cert:                 props.CertStackExports.DomainCert,
 		CorsOrigins:          cdkParams.CorsAllowOrigins.ValueAsString(),
-		SessionSecret:        jsii.String(mainEnvVars.SessionSecret),
-		ChainId:              jsii.String(mainEnvVars.ChainId),
+		SessionSecret:        jsii.String(autoEnvVars.SessionSecret),
+		ChainId:              jsii.String(autoEnvVars.ChainId),
 		Validators:           vs.Nodes,
 		InitElements:         initElements,
 		Assets:               kwilAssets,

--- a/deployments/infra/stacks/tn_auto_stack.go
+++ b/deployments/infra/stacks/tn_auto_stack.go
@@ -106,6 +106,7 @@ func TnAutoStack(scope constructs.Construct, id string, props *TnAutoStackProps)
 		RootDir:            utils.GetProjectRootDir(),
 		BinariesBucketName: "kwil-binaries",
 		KGWBinaryKey:       "gateway/kgw-v0.4.1.zip",
+		IndexerBinaryKey:   "indexer/kwil-indexer_v0.3.0-dev_linux_amd64.zip",
 	})
 
 	// Create KwilCluster

--- a/deployments/infra/stacks/tn_from_config_stack.go
+++ b/deployments/infra/stacks/tn_from_config_stack.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsec2"
+	"github.com/aws/aws-cdk-go/awscdk/v2/awss3assets"
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/aws/jsii-runtime-go"
 	"github.com/trufnetwork/node/infra/config"
@@ -15,6 +16,7 @@ import (
 	"github.com/trufnetwork/node/infra/lib/constructs/validator_set"
 	kwil_network "github.com/trufnetwork/node/infra/lib/kwil-network"
 	"github.com/trufnetwork/node/infra/lib/observer"
+	"github.com/trufnetwork/node/infra/lib/utils"
 )
 
 type TnFromConfigStackProps struct {
@@ -40,10 +42,10 @@ func TnFromConfigStack(
 	// Read environment config for number of nodes
 	cfg := config.GetEnvironmentVariables[config.ConfigStackEnvironmentVariables](stack)
 	privateKeys := strings.Split(cfg.NodePrivateKeys, ",")
+	shouldIncludeObserver := cfg.IncludeObserver // Read the new variable
 
 	// Define CDK params and stage early, and read dev prefix from context
 	cdkParams := config.NewCDKParams(stack)
-	mainEnvVars := config.GetEnvironmentVariables[config.MainEnvironmentVariables](stack)
 	stage := config.GetStage(stack)
 	devPrefix := config.GetDevPrefix(stack)
 
@@ -51,8 +53,11 @@ func TnFromConfigStack(
 	selectedKind := config.GetFrontingKind(stack) // Use context helper
 
 	// Setup observer init elements
-	initElements := []awsec2.InitElement{}                                     // Base elements
-	observerAsset := observer.GetObserverAsset(stack, jsii.String("observer")) // Keep asset var
+	initElements := []awsec2.InitElement{} // Base elements
+	var observerAsset awss3assets.Asset    // Keep asset var, initialize as nil
+	if shouldIncludeObserver {             // Conditionally get the asset
+		observerAsset = observer.GetObserverAsset(stack, jsii.String("observer"))
+	}
 
 	// VPC & domain setup
 	vpc := awsec2.Vpc_FromLookup(stack, jsii.String("VPC"), &awsec2.VpcLookupOptions{IsDefault: jsii.Bool(true)})
@@ -66,16 +71,16 @@ func TnFromConfigStack(
 	})
 
 	// Generate network configs from number of private keys
-	peers, _, genesisAsset := kwil_network.KwilNetworkConfigAssetsFromNumberOfNodes(
+	peers, nodeKeys, genesisAsset := kwil_network.KwilNetworkConfigAssetsFromNumberOfNodes(
 		stack,
 		kwil_network.KwilAutoNetworkConfigAssetInput{
-			NumberOfNodes:   len(privateKeys),
+			PrivateKeys:     privateKeys,
 			GenesisFilePath: cfg.GenesisPath,
 		},
 	)
 
 	// TN assets via helper
-	tnAssets := validator_set.BuildTNAssets(stack, validator_set.TNAssetOptions{RootDir: "compose"})
+	tnAssets := validator_set.BuildTNAssets(stack, validator_set.TNAssetOptions{RootDir: utils.GetProjectRootDir()})
 
 	// Create ValidatorSet
 	vs := validator_set.NewValidatorSet(stack, "ValidatorSet", &validator_set.ValidatorSetProps{
@@ -85,13 +90,14 @@ func TnFromConfigStack(
 		GenesisAsset: genesisAsset,
 		KeyPair:      nil,
 		Assets:       tnAssets,
-		InitElements: initElements, // Only pass base elements
+		InitElements: initElements,
 		CDKParams:    cdkParams,
+		NodeKeys:     nodeKeys,
 	})
 
 	// Kwil Cluster assets via helper
 	kwilAssets := kwil_cluster.BuildKwilAssets(stack, kwil_cluster.KwilAssetOptions{
-		RootDir:            ".", // Assuming stack run from infra root
+		RootDir:            utils.GetProjectRootDir(), // Assuming stack run from infra root
 		BinariesBucketName: "kwil-binaries",
 		KGWBinaryKey:       "gateway/kgw-v0.4.1.zip",
 		IndexerBinaryKey:   "indexer/kwil-indexer_v0.3.0-dev_linux_amd64.zip",
@@ -102,8 +108,8 @@ func TnFromConfigStack(
 		Vpc:                  vpc,
 		HostedDomain:         hd,
 		CorsOrigins:          cdkParams.CorsAllowOrigins.ValueAsString(),
-		SessionSecret:        jsii.String(mainEnvVars.SessionSecret),
-		ChainId:              jsii.String(mainEnvVars.ChainId),
+		SessionSecret:        jsii.String(cfg.SessionSecret),
+		ChainId:              jsii.String(cfg.ChainId),
 		Validators:           vs.Nodes,
 		InitElements:         initElements, // Only pass base elements
 		Assets:               kwilAssets,
@@ -158,16 +164,19 @@ func TnFromConfigStack(
 		panic(fmt.Sprintf("Dual endpoint fronting setup not implemented for type: %s", selectedKind))
 	}
 
-	if observerAsset == nil {
-		panic("Observer asset is nil in tn_from_config_stack") // Should not happen
+	// Conditionally attach observability
+	if shouldIncludeObserver {
+		if observerAsset == nil {
+			panic("Observer asset is nil when observer should be included") // Should not happen
+		}
+		observer.AttachObservability(observer.AttachObservabilityInput{
+			Scope:         stack,
+			ValidatorSet:  vs,
+			KwilCluster:   kc,
+			ObserverAsset: observerAsset,
+			Params:        cdkParams,
+		})
 	}
-	observer.AttachObservability(observer.AttachObservabilityInput{
-		Scope:         stack,
-		ValidatorSet:  vs,
-		KwilCluster:   kc,
-		ObserverAsset: observerAsset,
-		Params:        cdkParams,
-	})
 
 	return stack
 }

--- a/deployments/infra/stacks/tn_from_config_stack.go
+++ b/deployments/infra/stacks/tn_from_config_stack.go
@@ -94,6 +94,7 @@ func TnFromConfigStack(
 		RootDir:            ".", // Assuming stack run from infra root
 		BinariesBucketName: "kwil-binaries",
 		KGWBinaryKey:       "gateway/kgw-v0.4.1.zip",
+		IndexerBinaryKey:   "indexer/kwil-indexer_v0.3.0-dev_linux_amd64.zip",
 	})
 
 	// Create KwilCluster


### PR DESCRIPTION
## Description
- Ensure `TN-From-Config` is compatible with upgraded Kwil version (external node keys, genesis validation).
- Fix gateway XFF_TRUST_PROXY_COUNT to handle X-Forwarded-For headers correctly behind TLS termination proxy.
- Infra refinements: unified CDK env vars, observer feature flag, S3-based indexer binary deployment, updated RPC var, and local dev provider default.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example:

resolves: #112330

-->

- fix #895

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested `TN-From-Config` with a development genesis file in a dev environment; validated cluster deployment, indexer binary execution, and gateway XFF handling. Ready for production rollout.

**Note:** GitHub Actions pipelines will be updated separately.