### PR TITLE
feat: null params return last record

### DIFF
--- a/internal/migrations/001-common-actions.sql
+++ b/internal/migrations/001-common-actions.sql
@@ -1147,7 +1147,7 @@ CREATE OR REPLACE ACTION list_streams(
     stream_type TEXT,
     created_at INT8
 ) {
-    @data_provider := LOWER($data_provider);
+    $data_provider := LOWER($data_provider);
 
     if $limit > 5000 {
         ERROR('Limit exceeds maximum allowed value of 5000');

--- a/internal/migrations/005-primitive-query.sql
+++ b/internal/migrations/005-primitive-query.sql
@@ -168,6 +168,9 @@ CREATE OR REPLACE ACTION get_index_primitive(
     if !is_allowed_to_read_all($data_provider, $stream_id, @caller, $from, $to) {
         ERROR('Not allowed to read stream');
     }
+
+    $max_int8 INT8 := 9223372036854775000;
+    $effective_frozen_at INT8 := COALESCE($frozen_at, $max_int8);
     
     -- If base_time is not provided, try to get it from metadata
     $effective_base_time INT8 := $base_time;

--- a/internal/migrations/006-composed-query.sql
+++ b/internal/migrations/006-composed-query.sql
@@ -67,6 +67,14 @@ RETURNS TABLE(
         ERROR('Not allowed to compose stream');
     }
 
+        -- for historical consistency, if both from and to are omitted, return the latest record
+    if $from IS NULL AND $to IS NULL {
+        FOR $row IN get_last_record_composed($data_provider, $stream_id, NULL, $effective_frozen_at) {
+            RETURN NEXT $row.event_time, $row.value;
+        }
+        RETURN;
+    }
+
     RETURN WITH RECURSIVE
     /*----------------------------------------------------------------------
      * HIERARCHY CTE: Recursively resolves the dependency tree defined by taxonomies.

--- a/internal/migrations/006-composed-query.sql
+++ b/internal/migrations/006-composed-query.sql
@@ -425,6 +425,8 @@ RETURNS TABLE(
         -- Check the same validity condition as the positive delta
         WHERE GREATEST(pw.group_sequence_start, fvt.first_value_time) <= pw.group_sequence_end
           AND pw.raw_weight != 0::numeric(36,18)
+          -- don't emit closing delta for open interval
+          AND pw.group_sequence_end < ($max_int8 - 1)
     ),
 
     -- Step 7: Combine value and *effective* weight changes into a unified timeline.

--- a/internal/migrations/007-composed-query-derivate.sql
+++ b/internal/migrations/007-composed-query-derivate.sql
@@ -307,6 +307,15 @@ RETURNS TABLE(
         ERROR('Not allowed to compose stream');
     }
 
+    -- for historical consistency, if both from and to are omitted, return the latest record
+    if $from IS NULL AND $to IS NULL {
+        for $row in get_last_record_composed($data_provider, $stream_id, NULL, $effective_frozen_at) {
+            $indexed_value NUMERIC(36,18) := ($row.value * 100::NUMERIC(36,18)) / $base_value;
+            RETURN NEXT $row.event_time, $indexed_value;
+        }
+        RETURN;
+    }
+
 
     -- For detailed explanations of the CTEs below (hierarchy, primitive_weights,
     -- cleaned_event_times, initial_primitive_states, primitive_events_in_interval,

--- a/internal/migrations/007-composed-query-derivate.sql
+++ b/internal/migrations/007-composed-query-derivate.sql
@@ -309,6 +309,7 @@ RETURNS TABLE(
 
     -- for historical consistency, if both from and to are omitted, return the latest record
     if $from IS NULL AND $to IS NULL {
+        $base_value := internal_get_base_value($data_provider, $stream_id, $effective_base_time, $effective_frozen_at);
         for $row in get_last_record_composed($data_provider, $stream_id, NULL, $effective_frozen_at) {
             $indexed_value NUMERIC(36,18) := ($row.value * 100::NUMERIC(36,18)) / $base_value;
             RETURN NEXT $row.event_time, $indexed_value;
@@ -640,8 +641,11 @@ RETURNS TABLE(
         FROM primitive_weights pw
         INNER JOIN first_value_times fvt
             ON pw.data_provider = fvt.data_provider AND pw.stream_id = fvt.stream_id
-        WHERE GREATEST(pw.group_sequence_start, fvt.first_value_time) <= pw.group_sequence_end
-          AND pw.raw_weight != 0::numeric(36,18)
+        WHERE 
+            GREATEST(pw.group_sequence_start, fvt.first_value_time) <= pw.group_sequence_end
+            AND pw.raw_weight != 0::numeric(36,18)
+            -- don't emit closing delta for open interval
+            AND pw.group_sequence_end < ($max_int8 - 1)
     ),
 
     -- Combine indexed value changes and weight changes.
@@ -815,4 +819,59 @@ RETURNS TABLE(
     )
     SELECT event_time, value FROM result
     ORDER BY 1;
+};
+
+
+-- Returns the base value for a composed stream at or around base_time.
+-- This is a helper function for get_record_composed_index readability.
+CREATE OR REPLACE ACTION internal_get_base_value(
+    $data_provider TEXT,
+    $stream_id     TEXT,
+    $effective_base_time     INT8,   -- already pre-resolved “effective base time”
+    $effective_frozen_at     INT8    -- created_at cutoff (can be NULL ⇢ infinity)
+) PRIVATE VIEW RETURNS (NUMERIC(36,18)) {
+    -- doesn't check for access control, as it's private and not responsible for
+    -- any access control checks
+
+    -- Try to find an exact match at base_time
+    $found_exact := FALSE;
+    $exact_value NUMERIC(36,18);
+    for $row in get_record_composed($data_provider, $stream_id, $effective_base_time, $effective_base_time, $effective_frozen_at) {
+        $exact_value := $row.value;
+        $found_exact := TRUE;
+        break;
+    }
+    
+    if $found_exact {
+        return $exact_value;
+    }
+    
+    -- If no exact match, try to find the closest value before base_time
+    $found_before := FALSE;
+    $before_value NUMERIC(36,18);
+    for $row in get_last_record_composed($data_provider, $stream_id, $effective_base_time, $effective_frozen_at) {
+        $before_value := $row.value;
+        $found_before := TRUE;
+        break;
+    }
+    
+    if $found_before {
+        return $before_value;
+    }
+    
+    -- If no value before, try to find the closest value after base_time
+    $found_after := FALSE;
+    $after_value NUMERIC(36,18);
+    for $row in get_first_record_composed($data_provider, $stream_id, $effective_base_time, $effective_frozen_at) {
+        $after_value := $row.value;
+        $found_after := TRUE;
+        break;
+    }
+    
+    if $found_after {
+        return $after_value;
+    }
+    
+    -- If no value is found at all, return an error
+    ERROR('no base value found');
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->
## Description
This PR adjusts the behavior of stream query actions (`get_record_primitive`, `get_index_primitive`, `get_record_composed`, `get_record_composed_index`) to return only the latest record/index when both the `from` and `to` time parameters are omitted. This aligns the behavior with historical expectations. It also includes improvements to composed query logic and enhances test coverage and debugging for query functions.

- **SQL Migrations:**
    - Modified `get_record_primitive`, `get_index_primitive`, `get_record_composed`, and `get_record_composed_index` to return the latest entry if `from` and `to` are NULL.
    - Refactored base value retrieval in `get_record_composed_index` into a new private helper action `internal_get_base_value`.
    - Fixed variable usage (`@data_provider` to `$data_provider`) in `list_streams`.
    - Prevented emission of closing weight deltas for open-ended intervals in composed queries.
- **Go Tests (`query_test.go`):**
    - Added new test cases (`test_GetLatestRecord`, `test_GetLatestIndex`, `test_GetLatestIndexChange`, `test_GetRecordFromSpecificTime`, `test_GetRecordUntilSpecificTime`, `test_GetIndexFromSpecificTime`, `test_GetIndexUntilSpecificTime`, `test_GetIndexChangeFromSpecificTime`, `test_GetIndexChangeUntilSpecificTime`) to cover scenarios where `from_time` and/or `to_time` are omitted in query procedures.
    - Improved `validateTableResult` to output the actual result table in case of test failure, facilitating easier debugging.
    - Added helper `FormatResultRows`.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example:

resolves: #112330

-->

- fix #917 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Added comprehensive Go unit tests in `tests/streams/query/query_test.go` to cover the new logic for handling omitted time ranges in query procedures (`get_record`, `get_index`, `get_index_change`).
- Existing tests for primitive and composed queries were run to ensure no regressions.