### PR TITLE
chore: separate OR conditional checking with null in SQL

### DIFF
--- a/internal/migrations/001-common-actions.sql
+++ b/internal/migrations/001-common-actions.sql
@@ -1152,13 +1152,19 @@ CREATE OR REPLACE ACTION list_streams(
     if $limit > 5000 {
         ERROR('Limit exceeds maximum allowed value of 5000');
     }
-    if $limit IS NULL OR $limit = 0 {
+    if $limit IS NULL {
         $limit := 5000;
     }
-    if $offset IS NULL OR $offset = 0 {
+    if $limit == 0 {
+        $limit := 5000;
+    }
+    if $offset IS NULL {
         $offset := 0;
     }
-    if $order_by IS NULL OR $order_by = '' {
+    if $order_by IS NULL {
+        $order_by := 'created_at DESC';
+    }
+    if $order_by == '' {
         $order_by := 'created_at DESC';
     }
 

--- a/internal/migrations/004-composed-taxonomy.sql
+++ b/internal/migrations/004-composed-taxonomy.sql
@@ -29,10 +29,11 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     -- Determine the number of child records provided.
     $num_children := array_length($child_stream_ids);
 
+    if $num_children IS NULL {
+       $num_children := 0;
+    }
     -- Validate that all child arrays have the same length.
-    if $num_children IS NULL OR $num_children == 0 OR
-    $num_children != array_length($child_data_providers) OR
-    $num_children != array_length($weights) {
+    if $num_children == 0 OR $num_children != array_length($child_data_providers) OR $num_children != array_length($weights) {
         error('All child arrays must be of the same length');
     }
 

--- a/internal/migrations/010-get-latest-write-activity.sql
+++ b/internal/migrations/010-get-latest-write-activity.sql
@@ -6,7 +6,10 @@ CREATE OR REPLACE ACTION get_last_transactions(
     method     TEXT
 ) {
     $data_provider := LOWER($data_provider);
-    IF $limit_size IS NULL OR $limit_size <= 0 {
+    IF $limit_size IS NULL {
+        $limit_size := 6;
+    }
+    IF $limit_size <= 0 {
         $limit_size := 6;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

separating conditional checking when there is `IS NULL` and `OR` in one condition.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/kwil-db/issues/1507

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Action deployed