### PR TITLE
feat: add roles and role-based access control tables

### DIFF
--- a/internal/migrations/012-roles-schema.sql
+++ b/internal/migrations/012-roles-schema.sql
@@ -1,0 +1,43 @@
+/*
+    ROLES AND ROLE-BASED ACCESS CONTROL (RBAC) TABLES
+
+    This migration introduces tables for a role-based access control system.
+    This allows for gating actions and access to resources based on assigned roles.
+
+    Tables:
+    - roles: Defines available roles, which can be system-level or user-defined.
+    - role_members: Maps wallets to roles, establishing membership.
+*/
+
+CREATE TABLE IF NOT EXISTS roles (
+    owner TEXT NOT NULL,
+    role_name TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    role_type TEXT NOT NULL,
+    created_at INT8 NOT NULL,
+
+    PRIMARY KEY (owner, role_name),
+
+    CHECK (role_type IN ('system', 'user')),
+    CHECK (owner = 'system' OR (owner LIKE '0x%' AND LENGTH(owner) = 42)),
+    CHECK (LENGTH(role_name) > 0)
+);
+
+CREATE INDEX IF NOT EXISTS roles_type_idx ON roles (role_type);
+
+CREATE TABLE IF NOT EXISTS role_members (
+    owner TEXT NOT NULL,
+    role_name TEXT NOT NULL,
+    wallet TEXT NOT NULL,
+    granted_at INT8 NOT NULL,
+    granted_by TEXT NOT NULL,
+
+    PRIMARY KEY (owner, role_name, wallet),
+
+    FOREIGN KEY (owner, role_name) REFERENCES roles(owner, role_name) ON DELETE CASCADE,
+
+    CHECK (wallet LIKE '0x%' AND LENGTH(wallet) = 42),
+    CHECK (granted_by = 'system' OR (granted_by LIKE '0x%' AND LENGTH(granted_by) = 42))
+);
+
+CREATE INDEX IF NOT EXISTS role_members_wallet_idx ON role_members (wallet, owner, role_name); 


### PR DESCRIPTION
## Description

This PR introduces the foundational database schema for the new Role-Based Access Control (RBAC) system.

-   Adds two new tables to the database via the `012-roles-schema.sql` migration:
    -   `roles`: Stores role definitions, distinguishing between `system` and `user` types.
    -   `role_members`: Maps wallet addresses to roles to manage memberships.
-   Includes optimized indexes on `roles(role_type)` and `role_members(wallet)` to ensure high performance for common permission checks, such as verifying a user's roles.

## Related Problem

-   Resolves: #972

## How Has This Been Tested?

The SQL migration was successfully applied in a local test environment, confirming that the syntax is valid and the tables are created as expected. No regressions were observed in existing test suites. 