### PR TITLE
fix: prevent duplicate metadata row_id in create_streams

### DIFF
--- a/internal/migrations/001-common-actions.sql
+++ b/internal/migrations/001-common-actions.sql
@@ -165,7 +165,7 @@ CREATE OR REPLACE ACTION create_streams(
     ),
     args AS (
         SELECT 
-            uuid_generate_v5($base_uuid, 'metadata' || arg.row_number::TEXT)::UUID as row_id,
+            uuid_generate_v5($base_uuid, 'metadata' || $data_provider || arg.stream_id || arg.metadata_key || arg.row_number::TEXT)::UUID as row_id,
             $data_provider AS data_provider,
             arg.stream_id,
             arg.metadata_key,


### PR DESCRIPTION
The `create_streams` action was generating duplicate `row_id` values for metadata entries when multiple streams were created in quick succession within the same test context. This was due to the UUID v5 generation relying only on a base UUID derived from `@txid` and a sequential row number, which could lead to collisions across different stream creations if `@txid` was similar and the metadata keys generated in the same order. This commit modifies the `row_id` generation in `create_streams` to include the `stream_id` and `metadata_key` in the "name" portion of the UUID v5, ensuring a unique `row_id` for each distinct metadata entry across all streams created. This resolves the "duplicate key value violates unique constraint `metadata_pkey`" error observed in tests like `TestAUTH04_NestedComposePermissions`.

<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/node/pull/1000#pullrequestreview-2926699844

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
