### PR TITLE
chore: introduce TN version command and update build scripts

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,7 +42,7 @@ tasks:
       TARGET: ./.build
     cmds:
       - for: { var: BINARIES }
-        cmd: "SOURCE=./cmd/{{.ITEM}}/main.go ./scripts/build/binary {{.ITEM}}"
+        cmd: "SOURCE=./cmd/{{.ITEM}} ./scripts/build/binary {{.ITEM}}"
 
   build:
     desc: Build all kwil binaries

--- a/app/root.go
+++ b/app/root.go
@@ -1,0 +1,26 @@
+package app
+
+import (
+	"github.com/kwilteam/kwil-db/app"
+	"github.com/spf13/cobra"
+	tnVersion "github.com/trufnetwork/node/cmd/version"
+)
+
+// RootCmd creates a root command that uses TN version instead of kwil-db version
+func RootCmd() *cobra.Command {
+	// Get the original kwil-db root command
+	cmd := app.RootCmd()
+
+	// Find and remove the original version command
+	for _, subcmd := range cmd.Commands() {
+		if subcmd.Name() == "version" {
+			cmd.RemoveCommand(subcmd)
+			break
+		}
+	}
+
+	// Add our custom TN version command
+	cmd.AddCommand(tnVersion.NewVersionCmd())
+
+	return cmd
+}

--- a/cmd/kwild/main.go
+++ b/cmd/kwild/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"github.com/kwilteam/kwil-db/app"
-	"go.uber.org/zap"
 	"os"
+
+	"github.com/trufnetwork/node/app"
+	"go.uber.org/zap"
 )
 
 func main() {

--- a/cmd/version/utils.go
+++ b/cmd/version/utils.go
@@ -1,0 +1,73 @@
+package version
+
+import (
+	"time"
+
+	kwilVersion "github.com/kwilteam/kwil-db/version"
+)
+
+// These variables can be overridden at build time with ldflags
+var (
+	// TN-specific version info that can be set via ldflags
+	TNVersion   string // -X github.com/trufnetwork/node/cmd/version.TNVersion=...
+	TNCommit    string // -X github.com/trufnetwork/node/cmd/version.TNCommit=...
+	TNBuildTime string // -X github.com/trufnetwork/node/cmd/version.TNBuildTime=...
+)
+
+// getVersion returns the TN version if set, otherwise falls back to kwil-db version
+func getVersion() string {
+	if TNVersion != "" {
+		return TNVersion
+	}
+	return kwilVersion.KwilVersion
+}
+
+// getCommit returns the TN commit (short form) if set, otherwise falls back to kwil-db commit
+func getCommit() string {
+	var commit string
+	if TNCommit != "" {
+		commit = TNCommit
+	} else if kwilVersion.Build != nil {
+		commit = kwilVersion.Build.Revision
+	}
+
+	// Return short form (9 chars) for readability
+	const shortHashLength = 9
+	if len(commit) > shortHashLength {
+		return commit[:shortHashLength]
+	}
+	return commit
+}
+
+// getBuildTime returns the TN build time if set, otherwise falls back to kwil-db build time
+func getBuildTime() time.Time {
+	if TNBuildTime != "" {
+		if t, err := time.Parse(time.RFC3339, TNBuildTime); err == nil {
+			return t
+		}
+	}
+	if kwilVersion.Build != nil {
+		return kwilVersion.Build.RevTime
+	}
+	return time.Time{}
+}
+
+// getBuildTimeDisplay returns a formatted build time with context about whether it's commit or build time
+func getBuildTimeDisplay() string {
+	buildTime := getBuildTime()
+	if buildTime.IsZero() {
+		return "unknown"
+	}
+
+	// If we have a custom TN build time, it means we used our logic (commit time if clean, build time if dirty)
+	if TNBuildTime != "" {
+		// Check if workspace was dirty by looking at the version string
+		if TNVersion != "" && len(TNVersion) > 5 && TNVersion[len(TNVersion)-5:] == "dirty" {
+			return buildTime.Format(time.RFC3339) + " (build time)"
+		}
+		return buildTime.Format(time.RFC3339) + " (commit time)"
+	}
+
+	// Fallback to kwil-db build time (always commit time)
+	return buildTime.Format(time.RFC3339) + " (commit time)"
+}

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,96 @@
+package version
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"runtime"
+	"text/template"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kwilteam/kwil-db/app/shared/display"
+)
+
+// Template field labels - centralized to follow no-magic-values rule
+const (
+	VersionLabel   = "Version:"
+	CommitLabel    = "Git commit:"
+	BuiltLabel     = "Built:"
+	GoVersionLabel = "Go version:"
+	OSArchLabel    = "OS/Arch:"
+)
+
+var versionTemplate = `
+ ` + VersionLabel + `	{{.Version}}
+ ` + CommitLabel + `	{{.GitCommit}}
+ ` + BuiltLabel + `		{{.BuildTime}}
+ ` + GoVersionLabel + `	{{.GoVersion}}
+ ` + OSArchLabel + `	{{.Os}}/{{.Arch}}`
+
+type versionInfo struct {
+	// build-time info
+	Version   string `json:"version"`
+	GitCommit string `json:"git_commit"`
+	BuildTime string `json:"build_time"`
+	// client machine info
+	GoVersion string `json:"go_version"`
+	Os        string `json:"os"`
+	Arch      string `json:"arch"`
+}
+
+type respVersionInfo struct {
+	Info *versionInfo
+}
+
+func (v *respVersionInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.Info)
+}
+
+func (v *respVersionInfo) MarshalText() ([]byte, error) {
+	tmpl := template.New("version")
+	// load different template according to the opts.format
+	tmpl, err := tmpl.Parse(versionTemplate)
+	if err != nil {
+		return []byte(""), fmt.Errorf("template parsing error: %w", err)
+	}
+
+	var buf bytes.Buffer
+
+	err = tmpl.Execute(&buf, v.Info)
+	if err != nil {
+		return []byte(""), fmt.Errorf("template executing error: %w", err)
+	}
+
+	bs, err := io.ReadAll(&buf)
+	if err != nil {
+		return []byte(""), err
+	}
+
+	return bs, nil
+}
+
+func NewVersionCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "version",
+		Short: "Display the application version",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp := &respVersionInfo{
+				Info: &versionInfo{
+					Version:   getVersion(),
+					GitCommit: getCommit(),
+					BuildTime: getBuildTimeDisplay(),
+					GoVersion: runtime.Version(),
+					Os:        runtime.GOOS,
+					Arch:      runtime.GOARCH,
+				},
+			}
+
+			return display.PrintCmd(cmd, resp)
+		},
+	}
+
+	return cmd
+}

--- a/scripts/build/.go_variables
+++ b/scripts/build/.go_variables
@@ -45,6 +45,26 @@ fi
 export CGO_ENABLED
 
 GO_LDFLAGS="${GO_LDFLAGS:-}"
+
+# Inject TN repo version and VCS info instead of kwil-db version
+TN_VERSION="${TN_VERSION:-$(git describe --match 'v[0-9]*' --dirty --always --tags | sed 's/^v//')}"
+TN_COMMIT="$(git rev-parse HEAD)"
+
+# Use commit time if clean, current time if dirty
+if git diff-index --quiet HEAD --; then
+    # Clean workspace - use commit time
+    TN_BUILD_TIME="$(git log -1 --format=%cI)"
+else
+    # Dirty workspace - use current build time
+    TN_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+fi
+
+# Override version info to show TN repo instead of kwil-db repo
+GO_LDFLAGS="$GO_LDFLAGS -X github.com/trufnetwork/node/cmd/version.TNVersion=${TN_VERSION}"
+GO_LDFLAGS="$GO_LDFLAGS -X github.com/trufnetwork/node/cmd/version.TNCommit=${TN_COMMIT}"
+GO_LDFLAGS="$GO_LDFLAGS -X github.com/trufnetwork/node/cmd/version.TNBuildTime=${TN_BUILD_TIME}"
+
+
 if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ] && [ "$(go env GOOS)" = "linux" ]; then
     GO_LDFLAGS="$GO_LDFLAGS -extldflags=-static"
 fi


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Added a new root command to display the TN version, replacing the original kwil-db version command.
- Introduced versioning utilities to manage TN-specific version information, including version, commit, and build time.
- Updated build scripts to inject TN version and VCS info instead of kwil-db version.
- Modified Taskfile to adjust the source path for building binaries.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #1016 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
kwild version

 Version:       2.0.4-1-ga7c727b9-dirty
 Git commit:    a7c727b9a
 Built:         2025-06-20T13:53:44Z (build time)
 Go version:    go1.24.1
 OS/Arch:       linux/amd64
```

and after commite\ng

```
kwild version

 Version:       2.0.4-2-gb705cbc3
 Git commit:    b705cbc37
 Built:         2025-06-20T10:55:10-03:00 (commit time)
 Go version:    go1.24.1
 OS/Arch:       linux/amd64
```
