### PR TITLE
fix(tn_cache): correct sync checker test API response structure

### DIFF
--- a/extensions/tn_cache/sync_checker_test.go
+++ b/extensions/tn_cache/sync_checker_test.go
@@ -31,8 +31,12 @@ func TestSyncChecker_CanExecute(t *testing.T) {
 			name:        "syncing blocks execution",
 			maxBlockAge: 3600,
 			health: map[string]any{
-				"syncing":    true,
-				"block_time": time.Now().Unix(),
+				"services": map[string]any{
+					"user": map[string]any{
+						"syncing":    true,
+						"block_time": time.Now().Unix() * 1000, // Convert to milliseconds
+					},
+				},
 			},
 			wantOK:     false,
 			wantReason: "node is syncing",
@@ -41,8 +45,12 @@ func TestSyncChecker_CanExecute(t *testing.T) {
 			name:        "old block blocks execution",
 			maxBlockAge: 3600,
 			health: map[string]any{
-				"syncing":    false,
-				"block_time": time.Now().Unix() - 7200, // 2 hours old
+				"services": map[string]any{
+					"user": map[string]any{
+						"syncing":    false,
+						"block_time": (time.Now().Unix() - 7200) * 1000, // 2 hours old, in milliseconds
+					},
+				},
 			},
 			wantOK:     false,
 			wantReason: "block too old",
@@ -51,8 +59,12 @@ func TestSyncChecker_CanExecute(t *testing.T) {
 			name:        "recent block allows execution",
 			maxBlockAge: 3600,
 			health: map[string]any{
-				"syncing":    false,
-				"block_time": time.Now().Unix() - 1800, // 30 minutes old
+				"services": map[string]any{
+					"user": map[string]any{
+						"syncing":    false,
+						"block_time": (time.Now().Unix() - 1800) * 1000, // 30 minutes old, in milliseconds
+					},
+				},
 			},
 			wantOK:     true,
 			wantReason: "",
@@ -61,8 +73,12 @@ func TestSyncChecker_CanExecute(t *testing.T) {
 			name:        "network halt scenario - synced but old block",
 			maxBlockAge: 3600,
 			health: map[string]any{
-				"syncing":    false, // Not actively syncing
-				"block_time": time.Now().Unix() - 7200, // Old block during halt
+				"services": map[string]any{
+					"user": map[string]any{
+						"syncing":    false, // Not actively syncing
+						"block_time": (time.Now().Unix() - 7200) * 1000, // Old block during halt, in milliseconds
+					},
+				},
 			},
 			wantOK:     false, // Still blocks because block is too old
 			wantReason: "block too old",


### PR DESCRIPTION
The sync checker tests were failing because mock health responses used a flat structure instead of the expected nested services.user structure. Also fixed timestamp handling to use milliseconds as expected by the API.

<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/node/pull/1036#issuecomment-3054212948

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to use dynamically generated block timestamps for more realistic scenarios.
  * Modified test data structures and timestamp formats to reflect recent changes, including nesting health data and using millisecond precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->