### PR TITLE
chore: add comprehensive cache tests for get_index

### DIFF
--- a/extensions/tn_cache/sync_checker_test.go
+++ b/extensions/tn_cache/sync_checker_test.go
@@ -31,8 +31,12 @@ func TestSyncChecker_CanExecute(t *testing.T) {
 			name:        "syncing blocks execution",
 			maxBlockAge: 3600,
 			health: map[string]any{
-				"syncing":    true,
-				"block_time": time.Now().Unix(),
+				"services": map[string]any{
+					"user": map[string]any{
+						"syncing":    true,
+						"block_time": time.Now().Unix() * 1000, // Convert to milliseconds
+					},
+				},
 			},
 			wantOK:     false,
 			wantReason: "node is syncing",
@@ -41,8 +45,12 @@ func TestSyncChecker_CanExecute(t *testing.T) {
 			name:        "old block blocks execution",
 			maxBlockAge: 3600,
 			health: map[string]any{
-				"syncing":    false,
-				"block_time": time.Now().Unix() - 7200, // 2 hours old
+				"services": map[string]any{
+					"user": map[string]any{
+						"syncing":    false,
+						"block_time": (time.Now().Unix() - 7200) * 1000, // 2 hours old, in milliseconds
+					},
+				},
 			},
 			wantOK:     false,
 			wantReason: "block too old",
@@ -51,8 +59,12 @@ func TestSyncChecker_CanExecute(t *testing.T) {
 			name:        "recent block allows execution",
 			maxBlockAge: 3600,
 			health: map[string]any{
-				"syncing":    false,
-				"block_time": time.Now().Unix() - 1800, // 30 minutes old
+				"services": map[string]any{
+					"user": map[string]any{
+						"syncing":    false,
+						"block_time": (time.Now().Unix() - 1800) * 1000, // 30 minutes old, in milliseconds
+					},
+				},
 			},
 			wantOK:     true,
 			wantReason: "",
@@ -61,8 +73,12 @@ func TestSyncChecker_CanExecute(t *testing.T) {
 			name:        "network halt scenario - synced but old block",
 			maxBlockAge: 3600,
 			health: map[string]any{
-				"syncing":    false, // Not actively syncing
-				"block_time": time.Now().Unix() - 7200, // Old block during halt
+				"services": map[string]any{
+					"user": map[string]any{
+						"syncing":    false, // Not actively syncing
+						"block_time": (time.Now().Unix() - 7200) * 1000, // Old block during halt, in milliseconds
+					},
+				},
 			},
 			wantOK:     false, // Still blocks because block is too old
 			wantReason: "block too old",

--- a/internal/migrations/007-composed-query-derivate.sql
+++ b/internal/migrations/007-composed-query-derivate.sql
@@ -387,6 +387,7 @@ RETURNS TABLE(
     $cache_enabled BOOL := false;
     $use_cache_for_current_value BOOL := false;
     $use_cache_for_base_value BOOL := false;
+    $base_value NUMERIC(36,18); -- Declare base_value in proper scope
     
     -- Check if cache conditions are met
     if $frozen_at IS NULL {
@@ -403,7 +404,6 @@ RETURNS TABLE(
     -- If using cache, get raw data from cache and calculate index
     if $use_cache_for_base_value {
         -- Get base value from cache (need to get data around base_time)
-        $base_value NUMERIC(36,18);
         $found_base_value BOOL := false;
         
         -- try to get the first before base_time
@@ -430,7 +430,7 @@ RETURNS TABLE(
     } else {
         -- only calculate if we really need
         if $use_cache_for_current_value {
-            $base_value := internal_get_base_value($data_provider, $stream_id, $effective_base_time);
+            $base_value := internal_get_base_value($data_provider, $stream_id, $effective_base_time, $effective_frozen_at);
         }
     }
 
@@ -440,6 +440,7 @@ RETURNS TABLE(
             $index_value := ($row.value * 100::NUMERIC(36,18)) / $base_value;
             RETURN NEXT $row.event_time, $index_value;
         }
+        return;
     }
 
     -- Original logic fallback (cache miss or cache disabled)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Add GetIndexWithLogs utility function for test logging
- Add get_index cache tests to integration, observability, and metrics test suites
- Fix critical $base_value variable scoping bug in get_index_composed cache logic
- Add missing $effective_frozen_at parameter to internal_get_base_value call
- Add missing return statement to prevent cache fallthrough
- Verify cache hit/miss functionality works correctly for both get_record and get_index
- Ensure cached index calculations match expected mathematical results

Tests now provide complete coverage for both get_record and get_index cache functionality
with numerical verification of aggregated and indexed values.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/node/issues/1048

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
