### PR TITLE
chore: make node actions backward compatible with fewer argument

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
-	github.com/trufnetwork/kwil-db v0.10.3-0.20250708231942-448241207c3a
-	github.com/trufnetwork/kwil-db/core v0.4.3-0.20250708231942-448241207c3a
+	github.com/trufnetwork/kwil-db v0.10.3-0.20250714152846-a39d164b090c
+	github.com/trufnetwork/kwil-db/core v0.4.3-0.20250714152846-a39d164b090c
 	github.com/trufnetwork/sdk-go v0.3.2-0.20250630062504-841b40cdb709
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa

--- a/go.sum
+++ b/go.sum
@@ -1192,10 +1192,10 @@ github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZ
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPDo=
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250708231942-448241207c3a h1:rj3y5quzaxUZojaFKp5INEH0sR9jh6GV5GWxOsOtlMI=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250708231942-448241207c3a/go.mod h1:xskYWZKkPSQOpSo7yqcqpZzcqIRw06dRgLb9TwIvtAI=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250708231942-448241207c3a h1:rj/m7At0u59HZk5gumKL9V1qlw5JkAqC1BdUfQKSttI=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250708231942-448241207c3a/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
+github.com/trufnetwork/kwil-db v0.10.3-0.20250714152846-a39d164b090c h1:Q5OQimhZ2DsZa4/vXC9BxIB7QQv/d0zi7+NDNFlidBc=
+github.com/trufnetwork/kwil-db v0.10.3-0.20250714152846-a39d164b090c/go.mod h1:xskYWZKkPSQOpSo7yqcqpZzcqIRw06dRgLb9TwIvtAI=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20250714152846-a39d164b090c h1:sQN5KiA93rZdR8YcQliY5ZdoXbnF/XT7fMsKKkvaNZ4=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20250714152846-a39d164b090c/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2 h1:DCq8MzbWH0wZmICNmMVsSzUHUPl+2vqRhluEABjxl88=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2/go.mod h1:Y0MJpPp9QXU5vC6Gpoilql2NkgmGNcbHm9HYC2v2N8s=
 github.com/trufnetwork/sdk-go v0.3.2-0.20250630062504-841b40cdb709 h1:d9EqPXIjbq/atzEncK5dM3Z9oStx1BxCGuL/sjefeCw=

--- a/internal/migrations/006-composed-query.sql
+++ b/internal/migrations/006-composed-query.sql
@@ -41,7 +41,7 @@ CREATE OR REPLACE ACTION get_record_composed(
     $from INT8,           -- Start of requested time range (inclusive)
     $to INT8,             -- End of requested time range (inclusive)
     $frozen_at INT8,      -- Created-at cutoff: only consider events created before this
-    $use_cache BOOL       -- Whether to use cache (default: false)
+    $use_cache BOOL DEFAULT false  -- Whether to use cache (default: false)
 ) PRIVATE VIEW
 RETURNS TABLE(
     event_time INT8,
@@ -85,7 +85,7 @@ RETURNS TABLE(
 
     -- for historical consistency, if both from and to are omitted, return the latest record
     if $from IS NULL AND $to IS NULL {
-        FOR $row IN get_last_record_composed($data_provider, $stream_id, NULL, $effective_frozen_at, $use_cache) {
+        FOR $row IN get_last_record_composed($data_provider, $stream_id, NULL, $effective_frozen_at, $effective_use_cache) {
             RETURN NEXT $row.event_time, $row.value;
         }
         RETURN;

--- a/internal/migrations/007-composed-query-derivate.sql
+++ b/internal/migrations/007-composed-query-derivate.sql
@@ -7,7 +7,7 @@ CREATE OR REPLACE ACTION get_last_record_composed(
     $stream_id TEXT,
     $before INT8,       -- Upper bound for event_time
     $frozen_at INT8,    -- Only consider events created on or before this
-    $use_cache BOOL     -- Whether to use cache (default: false)
+    $use_cache BOOL DEFAULT false     -- Whether to use cache (default: false)
 ) PRIVATE VIEW
 RETURNS TABLE(
     event_time INT8,
@@ -182,7 +182,7 @@ CREATE OR REPLACE ACTION get_first_record_composed(
     $stream_id TEXT,
     $after INT8,       -- Lower bound for event_time
     $frozen_at INT8,   -- Only consider events created on or before this
-    $use_cache BOOL    -- Whether to use cache (default: false)
+    $use_cache BOOL DEFAULT false    -- Whether to use cache (default: false)
 ) PRIVATE VIEW
 RETURNS TABLE(
     event_time INT8,
@@ -353,7 +353,7 @@ CREATE OR REPLACE ACTION get_index_composed(
     $to INT8,
     $frozen_at INT8,
     $base_time INT8,
-    $use_cache BOOL     -- Whether to use cache (default: false)
+    $use_cache BOOL DEFAULT false     -- Whether to use cache (default: false)
 ) PRIVATE VIEW
 RETURNS TABLE(
     event_time INT8,

--- a/internal/migrations/008-public-query.sql
+++ b/internal/migrations/008-public-query.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE ACTION get_record(
     $from INT8,
     $to INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns table(
     event_time INT8,
     value NUMERIC(36,18)
@@ -39,7 +39,7 @@ CREATE OR REPLACE ACTION get_last_record(
     $stream_id TEXT,
     $before INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns table(
     event_time INT8,
     value NUMERIC(36,18)
@@ -72,7 +72,7 @@ CREATE OR REPLACE ACTION get_first_record(
     $stream_id TEXT,
     $after INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns table(
     event_time INT8,
     value NUMERIC(36,18)
@@ -103,7 +103,7 @@ CREATE OR REPLACE ACTION get_base_value(
     $stream_id TEXT,
     $base_time INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns (value NUMERIC(36,18)) {
     $data_provider  := LOWER($data_provider);
     $lower_caller TEXT := LOWER(@caller);
@@ -208,7 +208,7 @@ CREATE OR REPLACE ACTION get_index(
     $to INT8,
     $frozen_at INT8,
     $base_time INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns table(
     event_time INT8,
     value NUMERIC(36,18)
@@ -238,7 +238,7 @@ CREATE OR REPLACE ACTION get_index_change(
     $frozen_at INT8,
     $base_time INT8,
     $time_interval INT,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC VIEW
 RETURNS TABLE (
     event_time INT8,

--- a/internal/migrations/009-truflation-query.sql
+++ b/internal/migrations/009-truflation-query.sql
@@ -349,7 +349,7 @@ CREATE OR REPLACE ACTION truflation_get_index(
     $to INT8,
     $frozen_at INT8,
     $base_time INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns table(
     event_time INT8,
     value NUMERIC(36,18)
@@ -448,7 +448,7 @@ CREATE OR REPLACE ACTION truflation_get_record(
     $from INT8,
     $to INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns table(
     event_time INT8,
     value NUMERIC(36,18)
@@ -479,7 +479,7 @@ CREATE OR REPLACE ACTION truflation_get_last_record(
     $stream_id TEXT,
     $before INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns table(
     event_time INT8,
     value NUMERIC(36,18)
@@ -512,7 +512,7 @@ CREATE OR REPLACE ACTION truflation_get_first_record(
     $stream_id TEXT,
     $after INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns table(
     event_time INT8,
     value NUMERIC(36,18)
@@ -543,7 +543,7 @@ CREATE OR REPLACE ACTION truflation_get_base_value(
     $stream_id TEXT,
     $base_time INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PUBLIC view returns (value NUMERIC(36,18)) {
     $data_provider  := LOWER($data_provider);
     $lower_caller TEXT := LOWER(@caller);
@@ -643,7 +643,7 @@ CREATE OR REPLACE ACTION truflation_get_record_composed(
     $from INT8,         
     $to INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 )  PUBLIC VIEW
 RETURNS TABLE(
     event_time INT8,
@@ -1201,7 +1201,7 @@ CREATE OR REPLACE ACTION truflation_last_rc_composed(
     $stream_id TEXT,
     $before INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PRIVATE VIEW
 RETURNS TABLE(
     event_time INT8,
@@ -1387,7 +1387,7 @@ CREATE OR REPLACE ACTION truflation_first_rc_composed(
     $stream_id TEXT,
     $after INT8,
     $frozen_at INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PRIVATE VIEW
 RETURNS TABLE(
     event_time INT8,
@@ -1565,7 +1565,7 @@ CREATE OR REPLACE ACTION truflation_get_index_composed(
     $to INT8,
     $frozen_at INT8,
     $base_time INT8,
-    $use_cache BOOL
+    $use_cache BOOL DEFAULT false
 ) PRIVATE VIEW
 RETURNS TABLE(
     event_time INT8,

--- a/tests/streams/backward_compatibility_test.go
+++ b/tests/streams/backward_compatibility_test.go
@@ -1,0 +1,96 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/trufnetwork/kwil-db/common"
+	kwiltesting "github.com/trufnetwork/kwil-db/testing"
+	"github.com/trufnetwork/node/internal/migrations"
+	testutils "github.com/trufnetwork/node/tests/streams/utils"
+	"github.com/trufnetwork/sdk-go/core/util"
+)
+
+func TestBackwardCompatibility(t *testing.T) {
+	kwiltesting.RunSchemaTest(t, kwiltesting.SchemaTest{
+		Name:        "backward_compatibility_test",
+		SeedScripts: migrations.GetSeedScriptPaths(),
+		FunctionTests: []kwiltesting.TestFunc{
+			testBackwardCompatibilityFunc(t),
+		},
+	}, testutils.GetTestOptions())
+}
+
+func testBackwardCompatibilityFunc(t *testing.T) kwiltesting.TestFunc {
+	return func(ctx context.Context, platform *kwiltesting.Platform) error {
+		// Initialize platform deployer with a valid address to prevent the default kwil "deployer" string issue
+		defaultDeployer := util.Unsafe_NewEthereumAddressFromString("0x0000000000000000000000000000000000000000")
+		platform.Deployer = defaultDeployer.Bytes()
+
+		// Test calling get_record with 5 arguments (without use_cache)
+		t.Run("get_record_with_5_args", func(t *testing.T) {
+			testBackwardCompatibilityCall(t, platform, "get_record", []any{
+				defaultDeployer.Address(),
+				"test_stream",
+				nil, // from
+				nil, // to
+				nil, // frozen_at
+				// useCache parameter is omitted - should default to false
+			})
+		})
+
+		// Test calling get_record with 6 arguments (with use_cache)
+		t.Run("get_record_with_6_args", func(t *testing.T) {
+			testBackwardCompatibilityCall(t, platform, "get_record", []any{
+				defaultDeployer.Address(),
+				"test_stream",
+				nil,  // from
+				nil,  // to
+				nil,  // frozen_at
+				true, // useCache
+			})
+		})
+
+		return nil
+	}
+}
+
+func testBackwardCompatibilityCall(t *testing.T, platform *kwiltesting.Platform, actionName string, args []any) {
+	deployer, err := util.NewEthereumAddressFromBytes(platform.Deployer)
+	if err != nil {
+		t.Fatalf("Failed to create deployer address: %v", err)
+	}
+
+	txContext := &common.TxContext{
+		Ctx: context.Background(),
+		BlockContext: &common.BlockContext{
+			Height: 1,
+		},
+		TxID:   platform.Txid(),
+		Signer: platform.Deployer,
+		Caller: deployer.Address(),
+	}
+
+	engineContext := &common.EngineContext{
+		TxContext: txContext,
+	}
+
+	// This should not panic or fail due to argument count mismatch
+	result, err := platform.Engine.Call(engineContext, platform.DB, "", actionName, args, func(row *common.Row) error {
+		return nil
+	})
+
+	// We expect this to fail with a permission error, not an argument count error
+	if err != nil {
+		fmt.Printf("Expected error (permission/stream not found): %v\n", err)
+		return
+	}
+
+	if result.Error != nil {
+		fmt.Printf("Expected result error (permission/stream not found): %v\n", result.Error)
+		return
+	}
+
+	fmt.Printf("Call to %s with %d args succeeded\n", actionName, len(args))
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/node/issues/1056
related: https://github.com/trufnetwork/kwil-db/pull/1545

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test are passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added default values for the `use_cache` parameter in multiple public and private query actions, making this parameter optional.
  * Introduced tests to verify backward compatibility for query actions called with or without the `use_cache` parameter.

* **Bug Fixes**
  * Ensured consistent behavior and identical results when the `use_cache` parameter is omitted versus explicitly set to false.

* **Chores**
  * Updated dependencies to newer versions for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->