### PR TITLE
chore: add blockchain height tracking to cache extension

### DIFF
--- a/extensions/tn_cache/internal/db_ops.go
+++ b/extensions/tn_cache/internal/db_ops.go
@@ -44,11 +44,12 @@ func (c *CacheDB) SetTx(tx sql.DB) {
 
 // StreamCacheConfig represents a stream's caching configuration
 type StreamCacheConfig struct {
-	DataProvider  string
-	StreamID      string
-	FromTimestamp int64
-	LastRefreshed int64
-	CronSchedule  string
+	DataProvider              string
+	StreamID                  string
+	FromTimestamp             int64
+	CacheRefreshedAtTimestamp int64 // Internal use: when cache was refreshed
+	CacheHeight               int64 // User-facing: blockchain height during refresh
+	CronSchedule              string
 }
 
 // CachedEvent represents a cached event from a stream
@@ -67,6 +68,34 @@ func NewCacheDB(db sql.DB, logger log.Logger) *CacheDB {
 	}
 }
 
+// GetCurrentBlockHeight queries the blockchain state directly from kwild_chain.chain
+func (c *CacheDB) GetCurrentBlockHeight(ctx context.Context) (int64, error) {
+	results, err := c.db.Execute(ctx, `
+		SELECT height 
+		FROM kwild_chain.chain 
+		ORDER BY height DESC 
+		LIMIT 1
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("query blockchain height: %w", err)
+	}
+
+	if len(results.Rows) == 0 {
+		return 0, fmt.Errorf("no blockchain state found in kwild_chain.chain")
+	}
+
+	height, ok := results.Rows[0][0].(int64)
+	if !ok {
+		return 0, fmt.Errorf("failed to convert height to int64")
+	}
+
+	if height <= 0 {
+		return 0, fmt.Errorf("invalid blockchain height: %d", height)
+	}
+
+	return height, nil
+}
+
 // AddStreamConfig adds or updates a stream's cache configuration
 func (c *CacheDB) AddStreamConfig(ctx context.Context, config StreamCacheConfig) error {
 
@@ -79,15 +108,16 @@ func (c *CacheDB) AddStreamConfig(ctx context.Context, config StreamCacheConfig)
 	// Insert or update the stream config using UPSERT
 	_, err = tx.Execute(ctx, `
 		INSERT INTO `+constants.CacheSchemaName+`.cached_streams 
-			(data_provider, stream_id, from_timestamp, last_refreshed, cron_schedule)
+			(data_provider, stream_id, from_timestamp, cache_refreshed_at_timestamp, cache_height, cron_schedule)
 		VALUES 
-			($1, $2, $3, $4, $5)
+			($1, $2, $3, $4, $5, $6)
 		ON CONFLICT (data_provider, stream_id) 
 		DO UPDATE SET
 			from_timestamp = EXCLUDED.from_timestamp,
-			last_refreshed = EXCLUDED.last_refreshed,
+			cache_refreshed_at_timestamp = EXCLUDED.cache_refreshed_at_timestamp,
+			cache_height = EXCLUDED.cache_height,
 			cron_schedule = EXCLUDED.cron_schedule
-	`, config.DataProvider, config.StreamID, config.FromTimestamp, config.LastRefreshed, config.CronSchedule)
+	`, config.DataProvider, config.StreamID, config.FromTimestamp, config.CacheRefreshedAtTimestamp, config.CacheHeight, config.CronSchedule)
 
 	if err != nil {
 		return fmt.Errorf("upsert stream config: %w", err)
@@ -120,27 +150,29 @@ func (c *CacheDB) AddStreamConfigs(ctx context.Context, configs []StreamCacheCon
 
 	// Build arrays for batch insert using UNNEST for efficiency
 	var dataProviders, streamIDs, cronSchedules []string
-	var fromTimestamps, lastRefresheds []int64
+	var fromTimestamps, cacheRefreshedAtTimestamps, cacheHeights []int64
 
 	for _, config := range configs {
 		dataProviders = append(dataProviders, config.DataProvider)
 		streamIDs = append(streamIDs, config.StreamID)
 		fromTimestamps = append(fromTimestamps, config.FromTimestamp)
-		lastRefresheds = append(lastRefresheds, config.LastRefreshed)
+		cacheRefreshedAtTimestamps = append(cacheRefreshedAtTimestamps, config.CacheRefreshedAtTimestamp)
+		cacheHeights = append(cacheHeights, config.CacheHeight)
 		cronSchedules = append(cronSchedules, config.CronSchedule)
 	}
 
 	// Execute the batch insert with UPSERT logic
 	_, err = tx.Execute(ctx, `
 		INSERT INTO `+constants.CacheSchemaName+`.cached_streams 
-			(data_provider, stream_id, from_timestamp, last_refreshed, cron_schedule)
-		SELECT * FROM UNNEST($1::TEXT[], $2::TEXT[], $3::INT8[], $4::INT8[], $5::TEXT[])
+			(data_provider, stream_id, from_timestamp, cache_refreshed_at_timestamp, cache_height, cron_schedule)
+		SELECT * FROM UNNEST($1::TEXT[], $2::TEXT[], $3::INT8[], $4::INT8[], $5::INT8[], $6::TEXT[])
 		ON CONFLICT (data_provider, stream_id) 
 		DO UPDATE SET
 			from_timestamp = EXCLUDED.from_timestamp,
-			last_refreshed = EXCLUDED.last_refreshed,
+			cache_refreshed_at_timestamp = EXCLUDED.cache_refreshed_at_timestamp,
+			cache_height = EXCLUDED.cache_height,
 			cron_schedule = EXCLUDED.cron_schedule
-	`, dataProviders, streamIDs, fromTimestamps, lastRefresheds, cronSchedules)
+	`, dataProviders, streamIDs, fromTimestamps, cacheRefreshedAtTimestamps, cacheHeights, cronSchedules)
 
 	if err != nil {
 		return fmt.Errorf("batch upsert stream configs: %w", err)
@@ -165,7 +197,7 @@ func (c *CacheDB) ListStreamConfigs(ctx context.Context) ([]StreamCacheConfig, e
 	c.logger.Debug("listing all stream cache configs")
 
 	results, err := c.db.Execute(ctx, `
-		SELECT data_provider, stream_id, from_timestamp, last_refreshed, cron_schedule
+		SELECT data_provider, stream_id, from_timestamp, cache_refreshed_at_timestamp, cache_height, cron_schedule
 		FROM `+constants.CacheSchemaName+`.cached_streams
 		ORDER BY data_provider, stream_id
 	`)
@@ -175,8 +207,8 @@ func (c *CacheDB) ListStreamConfigs(ctx context.Context) ([]StreamCacheConfig, e
 
 	var configs []StreamCacheConfig
 	for _, row := range results.Rows {
-		if len(row) != 5 {
-			return nil, fmt.Errorf("expected 5 columns, got %d", len(row))
+		if len(row) != 6 {
+			return nil, fmt.Errorf("expected 6 columns, got %d", len(row))
 		}
 
 		dataProvider, ok := row[0].(string)
@@ -194,22 +226,28 @@ func (c *CacheDB) ListStreamConfigs(ctx context.Context) ([]StreamCacheConfig, e
 			return nil, fmt.Errorf("failed to convert from_timestamp to int64")
 		}
 
-		lastRefreshed, ok := row[3].(int64)
+		cacheRefreshedAtTimestamp, ok := row[3].(int64)
 		if !ok {
-			return nil, fmt.Errorf("failed to convert last_refreshed to int64")
+			return nil, fmt.Errorf("failed to convert cache_refreshed_at_timestamp to int64")
 		}
 
-		cronSchedule, ok := row[4].(string)
+		cacheHeight, ok := row[4].(int64)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert cache_height to int64")
+		}
+
+		cronSchedule, ok := row[5].(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to convert cron_schedule to string")
 		}
 
 		config := StreamCacheConfig{
-			DataProvider:  dataProvider,
-			StreamID:      streamID,
-			FromTimestamp: fromTimestamp,
-			LastRefreshed: lastRefreshed,
-			CronSchedule:  cronSchedule,
+			DataProvider:              dataProvider,
+			StreamID:                  streamID,
+			FromTimestamp:             fromTimestamp,
+			CacheRefreshedAtTimestamp: cacheRefreshedAtTimestamp,
+			CacheHeight:               cacheHeight,
+			CronSchedule:              cronSchedule,
 		}
 		configs = append(configs, config)
 	}
@@ -283,18 +321,25 @@ func (c *CacheDB) CacheEvents(ctx context.Context, events []CachedEvent) error {
 				}
 			}
 
-			// Finally, update the last refreshed timestamp for the stream
+			// Finally, update the refresh timestamp and blockchain height for the stream
 			if len(events) > 0 {
 				event := events[0]
+
+				// Get current blockchain height
+				currentHeight, err := c.GetCurrentBlockHeight(traceCtx)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get current blockchain height: %w", err)
+				}
+
 				now := time.Now().Unix()
 				_, err = tx.Execute(traceCtx, `
 					UPDATE `+constants.CacheSchemaName+`.cached_streams
-					SET last_refreshed = $3
+					SET cache_refreshed_at_timestamp = $3, cache_height = $4
 					WHERE data_provider = $1 AND stream_id = $2
-				`, event.DataProvider, event.StreamID, now)
+				`, event.DataProvider, event.StreamID, now, currentHeight)
 
 				if err != nil {
-					return nil, fmt.Errorf("update last refreshed: %w", err)
+					return nil, fmt.Errorf("update refresh timestamp and height: %w", err)
 				}
 			}
 
@@ -347,32 +392,32 @@ func (c *CacheDB) CacheEventsWithIndex(ctx context.Context, events []CachedEvent
 				}
 			}()
 
-	// Cache raw events if provided
-	if len(events) > 0 {
-		// Insert events in batches using UNNEST for efficiency
-		batchSize := 10000
-		for i := 0; i < len(events); i += batchSize {
-			end := i + batchSize
-			if end > len(events) {
-				end = len(events)
-			}
+			// Cache raw events if provided
+			if len(events) > 0 {
+				// Insert events in batches using UNNEST for efficiency
+				batchSize := 10000
+				for i := 0; i < len(events); i += batchSize {
+					end := i + batchSize
+					if end > len(events) {
+						end = len(events)
+					}
 
-			batch := events[i:end]
+					batch := events[i:end]
 
-			// Build arrays for UNNEST
-			var dataProviders, streamIDs []string
-			var eventTimes []int64
-			var values []*types.Decimal
+					// Build arrays for UNNEST
+					var dataProviders, streamIDs []string
+					var eventTimes []int64
+					var values []*types.Decimal
 
-			for _, event := range batch {
-				dataProviders = append(dataProviders, event.DataProvider)
-				streamIDs = append(streamIDs, event.StreamID)
-				eventTimes = append(eventTimes, event.EventTime)
-				values = append(values, event.Value)
-			}
+					for _, event := range batch {
+						dataProviders = append(dataProviders, event.DataProvider)
+						streamIDs = append(streamIDs, event.StreamID)
+						eventTimes = append(eventTimes, event.EventTime)
+						values = append(values, event.Value)
+					}
 
-			// Use UNNEST for efficient batch insert
-			_, err = tx.Execute(traceCtx, `
+					// Use UNNEST for efficient batch insert
+					_, err = tx.Execute(traceCtx, `
 				INSERT INTO `+constants.CacheSchemaName+`.cached_events 
 					(data_provider, stream_id, event_time, value)
 				SELECT * FROM UNNEST($1::TEXT[], $2::TEXT[], $3::INT8[], $4::DECIMAL(36,18)[])
@@ -381,38 +426,38 @@ func (c *CacheDB) CacheEventsWithIndex(ctx context.Context, events []CachedEvent
 					value = EXCLUDED.value
 			`, dataProviders, streamIDs, eventTimes, values)
 
-			if err != nil {
-				return nil, fmt.Errorf("insert events batch: %w", err)
-			}
-		}
-	}
-
-	// Cache index events if provided
-	if len(indexEvents) > 0 {
-		// Insert index events in batches
-		batchSize := 10000
-		for i := 0; i < len(indexEvents); i += batchSize {
-			end := i + batchSize
-			if end > len(indexEvents) {
-				end = len(indexEvents)
+					if err != nil {
+						return nil, fmt.Errorf("insert events batch: %w", err)
+					}
+				}
 			}
 
-			batch := indexEvents[i:end]
+			// Cache index events if provided
+			if len(indexEvents) > 0 {
+				// Insert index events in batches
+				batchSize := 10000
+				for i := 0; i < len(indexEvents); i += batchSize {
+					end := i + batchSize
+					if end > len(indexEvents) {
+						end = len(indexEvents)
+					}
 
-			// Build arrays for UNNEST
-			var dataProviders, streamIDs []string
-			var eventTimes []int64
-			var indexValues []*types.Decimal
+					batch := indexEvents[i:end]
 
-			for _, event := range batch {
-				dataProviders = append(dataProviders, event.DataProvider)
-				streamIDs = append(streamIDs, event.StreamID)
-				eventTimes = append(eventTimes, event.EventTime)
-				indexValues = append(indexValues, event.Value)
-			}
+					// Build arrays for UNNEST
+					var dataProviders, streamIDs []string
+					var eventTimes []int64
+					var indexValues []*types.Decimal
 
-			// Use UNNEST for efficient batch insert
-			_, err = tx.Execute(traceCtx, `
+					for _, event := range batch {
+						dataProviders = append(dataProviders, event.DataProvider)
+						streamIDs = append(streamIDs, event.StreamID)
+						eventTimes = append(eventTimes, event.EventTime)
+						indexValues = append(indexValues, event.Value)
+					}
+
+					// Use UNNEST for efficient batch insert
+					_, err = tx.Execute(traceCtx, `
 				INSERT INTO `+constants.CacheSchemaName+`.cached_index_events 
 					(data_provider, stream_id, event_time, value)
 				SELECT * FROM UNNEST($1::TEXT[], $2::TEXT[], $3::INT8[], $4::DECIMAL(36,18)[])
@@ -421,23 +466,29 @@ func (c *CacheDB) CacheEventsWithIndex(ctx context.Context, events []CachedEvent
 					value = EXCLUDED.value
 			`, dataProviders, streamIDs, eventTimes, indexValues)
 
-			if err != nil {
-				return nil, fmt.Errorf("insert index events batch: %w", err)
+					if err != nil {
+						return nil, fmt.Errorf("insert index events batch: %w", err)
+					}
+				}
 			}
-		}
-	}
 
-			// Update the last refreshed timestamp for the stream
+			// Update the refresh timestamp and blockchain height for the stream
 			if primaryProvider != "" && primaryStreamID != "" {
+				// Get current blockchain height
+				currentHeight, err := c.GetCurrentBlockHeight(traceCtx)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get current blockchain height: %w", err)
+				}
+
 				now := time.Now().Unix()
 				_, err = tx.Execute(traceCtx, `
 					UPDATE `+constants.CacheSchemaName+`.cached_streams
-					SET last_refreshed = $3
+					SET cache_refreshed_at_timestamp = $3, cache_height = $4
 					WHERE data_provider = $1 AND stream_id = $2
-				`, primaryProvider, primaryStreamID, now)
+				`, primaryProvider, primaryStreamID, now, currentHeight)
 
 				if err != nil {
-					return nil, fmt.Errorf("update last refreshed: %w", err)
+					return nil, fmt.Errorf("update refresh timestamp and height: %w", err)
 				}
 			}
 
@@ -447,8 +498,8 @@ func (c *CacheDB) CacheEventsWithIndex(ctx context.Context, events []CachedEvent
 
 			return nil, nil
 		}, attribute.Int("raw_count", len(events)),
-			attribute.Int("index_count", len(indexEvents)))
-	
+		attribute.Int("index_count", len(indexEvents)))
+
 	return err
 }
 
@@ -485,38 +536,38 @@ func (c *CacheDB) GetCachedEvents(ctx context.Context, dataProvider, streamID st
 			}
 
 			events := make([]CachedEvent, 0, len(results.Rows))
-	for _, row := range results.Rows {
-		if len(row) != 4 {
-			return nil, fmt.Errorf("expected 4 columns, got %d", len(row))
-		}
+			for _, row := range results.Rows {
+				if len(row) != 4 {
+					return nil, fmt.Errorf("expected 4 columns, got %d", len(row))
+				}
 
-		dataProvider, ok := row[0].(string)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert data_provider to string")
-		}
+				dataProvider, ok := row[0].(string)
+				if !ok {
+					return nil, fmt.Errorf("failed to convert data_provider to string")
+				}
 
-		streamID, ok := row[1].(string)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert stream_id to string")
-		}
+				streamID, ok := row[1].(string)
+				if !ok {
+					return nil, fmt.Errorf("failed to convert stream_id to string")
+				}
 
-		eventTime, ok := row[2].(int64)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert event_time to int64")
-		}
+				eventTime, ok := row[2].(int64)
+				if !ok {
+					return nil, fmt.Errorf("failed to convert event_time to int64")
+				}
 
-		value, ok := row[3].(*types.Decimal)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert value to *types.Decimal")
-		}
+				value, ok := row[3].(*types.Decimal)
+				if !ok {
+					return nil, fmt.Errorf("failed to convert value to *types.Decimal")
+				}
 
-		event := CachedEvent{
-			DataProvider: dataProvider,
-			StreamID:     streamID,
-			EventTime:    eventTime,
-			Value:        value,
-		}
-		events = append(events, event)
+				event := CachedEvent{
+					DataProvider: dataProvider,
+					StreamID:     streamID,
+					EventTime:    eventTime,
+					Value:        value,
+				}
+				events = append(events, event)
 			}
 
 			// Log slow queries or large result sets
@@ -609,8 +660,8 @@ func (c *CacheDB) GetCachedIndex(ctx context.Context, dataProvider, streamID str
 
 			return events, nil
 		}, attribute.Int64("from", fromTime),
-			attribute.Int64("to", toTime),
-			attribute.String("type", "index"))
+		attribute.Int64("to", toTime),
+		attribute.String("type", "index"))
 }
 
 // DeleteStreamData deletes all cached events for a stream
@@ -822,7 +873,7 @@ func (c *CacheDB) HasCachedData(ctx context.Context, dataProvider, streamID stri
 
 			return hasData, nil
 		}, attribute.Int64("from", fromTime),
-			attribute.Int64("to", toTime))
+		attribute.Int64("to", toTime))
 }
 
 // UpdateStreamConfigsAtomic atomically updates the cached_streams table
@@ -867,27 +918,29 @@ func (c *CacheDB) UpdateStreamConfigsAtomic(ctx context.Context, newConfigs []St
 	// Then, add/update new streams using batch operation
 	if len(newConfigs) > 0 {
 		var dataProviders, streamIDs, cronSchedules []string
-		var fromTimestamps, lastRefresheds []int64
+		var fromTimestamps, cacheRefreshedAtTimestamps, cacheHeights []int64
 
 		for _, config := range newConfigs {
 			dataProviders = append(dataProviders, config.DataProvider)
 			streamIDs = append(streamIDs, config.StreamID)
 			fromTimestamps = append(fromTimestamps, config.FromTimestamp)
-			lastRefresheds = append(lastRefresheds, config.LastRefreshed)
+			cacheRefreshedAtTimestamps = append(cacheRefreshedAtTimestamps, config.CacheRefreshedAtTimestamp)
+			cacheHeights = append(cacheHeights, config.CacheHeight)
 			cronSchedules = append(cronSchedules, config.CronSchedule)
 		}
 
-		// Execute the batch upsert, preserving last_refreshed if it exists
+		// Execute the batch upsert, preserving existing values if new values are zero
 		_, err = tx.Execute(ctx, `
 			INSERT INTO `+constants.CacheSchemaName+`.cached_streams 
-				(data_provider, stream_id, from_timestamp, last_refreshed, cron_schedule)
-			SELECT * FROM UNNEST($1::TEXT[], $2::TEXT[], $3::INT8[], $4::INT8[], $5::TEXT[])
+				(data_provider, stream_id, from_timestamp, cache_refreshed_at_timestamp, cache_height, cron_schedule)
+			SELECT * FROM UNNEST($1::TEXT[], $2::TEXT[], $3::INT8[], $4::INT8[], $5::INT8[], $6::TEXT[])
 			ON CONFLICT (data_provider, stream_id) 
 			DO UPDATE SET
 				from_timestamp = EXCLUDED.from_timestamp,
-				last_refreshed = COALESCE(NULLIF(EXCLUDED.last_refreshed, 0), cached_streams.last_refreshed),
+				cache_refreshed_at_timestamp = COALESCE(NULLIF(EXCLUDED.cache_refreshed_at_timestamp, 0), cached_streams.cache_refreshed_at_timestamp),
+				cache_height = COALESCE(NULLIF(EXCLUDED.cache_height, 0), cached_streams.cache_height),
 				cron_schedule = EXCLUDED.cron_schedule
-		`, dataProviders, streamIDs, fromTimestamps, lastRefresheds, cronSchedules)
+		`, dataProviders, streamIDs, fromTimestamps, cacheRefreshedAtTimestamps, cacheHeights, cronSchedules)
 
 		if err != nil {
 			return fmt.Errorf("batch upsert stream configs: %w", err)
@@ -908,7 +961,7 @@ func (c *CacheDB) UpdateStreamConfigsAtomic(ctx context.Context, newConfigs []St
 // getStreamConfigPool retrieves a stream's cache configuration using pool
 func (c *CacheDB) getStreamConfigPool(ctx context.Context, dataProvider, streamID string) (*StreamCacheConfig, error) {
 	results, err := c.db.Execute(ctx, `
-		SELECT data_provider, stream_id, from_timestamp, last_refreshed, cron_schedule
+		SELECT data_provider, stream_id, from_timestamp, cache_refreshed_at_timestamp, cache_height, cron_schedule
 		FROM `+constants.CacheSchemaName+`.cached_streams
 		WHERE data_provider = $1 AND stream_id = $2
 	`, dataProvider, streamID)
@@ -926,8 +979,8 @@ func (c *CacheDB) getStreamConfigPool(ctx context.Context, dataProvider, streamI
 	}
 
 	row := results.Rows[0]
-	if len(row) != 5 {
-		return nil, fmt.Errorf("expected 5 columns, got %d", len(row))
+	if len(row) != 6 {
+		return nil, fmt.Errorf("expected 6 columns, got %d", len(row))
 	}
 
 	dataProviderResult, ok := row[0].(string)
@@ -945,22 +998,28 @@ func (c *CacheDB) getStreamConfigPool(ctx context.Context, dataProvider, streamI
 		return nil, fmt.Errorf("failed to convert from_timestamp to int64")
 	}
 
-	lastRefreshed, ok := row[3].(int64)
+	cacheRefreshedAtTimestamp, ok := row[3].(int64)
 	if !ok {
-		return nil, fmt.Errorf("failed to convert last_refreshed to int64")
+		return nil, fmt.Errorf("failed to convert cache_refreshed_at_timestamp to int64")
 	}
 
-	cronSchedule, ok := row[4].(string)
+	cacheHeight, ok := row[4].(int64)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert cache_height to int64")
+	}
+
+	cronSchedule, ok := row[5].(string)
 	if !ok {
 		return nil, fmt.Errorf("failed to convert cron_schedule to string")
 	}
 
 	config := &StreamCacheConfig{
-		DataProvider:  dataProviderResult,
-		StreamID:      streamIDResult,
-		FromTimestamp: fromTimestamp,
-		LastRefreshed: lastRefreshed,
-		CronSchedule:  cronSchedule,
+		DataProvider:              dataProviderResult,
+		StreamID:                  streamIDResult,
+		FromTimestamp:             fromTimestamp,
+		CacheRefreshedAtTimestamp: cacheRefreshedAtTimestamp,
+		CacheHeight:               cacheHeight,
+		CronSchedule:              cronSchedule,
 	}
 
 	return config, nil
@@ -1045,7 +1104,8 @@ func (c *CacheDB) SetupCacheSchema(ctx context.Context) error {
 			data_provider TEXT NOT NULL,
 			stream_id TEXT NOT NULL,
 			from_timestamp INT8,
-			last_refreshed INT8,
+			cache_refreshed_at_timestamp INT8,
+			cache_height INT8,
 			cron_schedule TEXT,
 			PRIMARY KEY (data_provider, stream_id)
 		)`); err != nil {
@@ -1226,7 +1286,7 @@ func (c *CacheDB) GetLastEventBefore(ctx context.Context, dataProvider, streamID
 
 			return e, nil
 		}, attribute.Int64("before", before),
-			attribute.String("query", "last_before"))
+		attribute.String("query", "last_before"))
 }
 
 // GetFirstEventAfter retrieves the first event at or after the specified timestamp.
@@ -1289,5 +1349,5 @@ func (c *CacheDB) GetFirstEventAfter(ctx context.Context, dataProvider, streamID
 
 			return e, nil
 		}, attribute.Int64("after", after),
-			attribute.String("query", "first_after"))
+		attribute.String("query", "first_after"))
 }

--- a/extensions/tn_cache/internal/db_ops_test.go
+++ b/extensions/tn_cache/internal/db_ops_test.go
@@ -92,11 +92,12 @@ func TestCacheDB_UpdateStreamConfigsAtomic(t *testing.T) {
 
 	newConfigs := []StreamCacheConfig{
 		{
-			DataProvider:  "provider1",
-			StreamID:      "stream1",
-			FromTimestamp: 1234567890,
-			LastRefreshed: 1672531200, // 2023-01-01T00:00:00Z
-			CronSchedule:  "0 * * * *",
+			DataProvider:              "provider1",
+			StreamID:                  "stream1",
+			FromTimestamp:             1234567890,
+			CacheRefreshedAtTimestamp: 1672531200, // 2023-01-01T00:00:00Z
+			CacheHeight:               100,
+			CronSchedule:              "0 * * * *",
 		},
 	}
 

--- a/extensions/tn_cache/scheduler/resolution.go
+++ b/extensions/tn_cache/scheduler/resolution.go
@@ -540,10 +540,11 @@ func (s *CacheScheduler) updateCachedStreamsTable(ctx context.Context, resolvedS
 		key := fmt.Sprintf("%s:%s", spec.DataProvider, spec.StreamID)
 		newSet[key] = true
 
-		// Preserve last_refreshed if stream already exists
-		var lastRefreshed int64
+		// Preserve refresh data if stream already exists
+		var cacheRefreshedAtTimestamp, cacheHeight int64
 		if existing, exists := currentSet[key]; exists {
-			lastRefreshed = existing.LastRefreshed
+			cacheRefreshedAtTimestamp = existing.CacheRefreshedAtTimestamp
+			cacheHeight = existing.CacheHeight
 		}
 
 		var fromTimestamp int64
@@ -552,11 +553,12 @@ func (s *CacheScheduler) updateCachedStreamsTable(ctx context.Context, resolvedS
 		}
 
 		newConfigs = append(newConfigs, internal.StreamCacheConfig{
-			DataProvider:  spec.DataProvider,
-			StreamID:      spec.StreamID,
-			FromTimestamp: fromTimestamp,
-			LastRefreshed: lastRefreshed,
-			CronSchedule:  spec.Schedule.CronExpr,
+			DataProvider:              spec.DataProvider,
+			StreamID:                  spec.StreamID,
+			FromTimestamp:             fromTimestamp,
+			CacheRefreshedAtTimestamp: cacheRefreshedAtTimestamp,
+			CacheHeight:               cacheHeight,
+			CronSchedule:              spec.Schedule.CronExpr,
 		})
 	}
 

--- a/extensions/tn_cache/scheduler/scheduler.go
+++ b/extensions/tn_cache/scheduler/scheduler.go
@@ -316,11 +316,12 @@ func (s *CacheScheduler) storeStreamConfigs(ctx context.Context, directives []co
 		}
 
 		streamConfig := internal.StreamCacheConfig{
-			DataProvider:  directive.DataProvider,
-			StreamID:      directive.StreamID,
-			FromTimestamp: fromTimestamp,
-			LastRefreshed: 0, // Will be set on first refresh
-			CronSchedule:  directive.Schedule.CronExpr,
+			DataProvider:              directive.DataProvider,
+			StreamID:                  directive.StreamID,
+			FromTimestamp:             fromTimestamp,
+			CacheRefreshedAtTimestamp: 0, // Will be set on first refresh
+			CacheHeight:               0, // Will be set on first refresh
+			CronSchedule:              directive.Schedule.CronExpr,
 		}
 		configs = append(configs, streamConfig)
 	}
@@ -394,7 +395,7 @@ func (s *CacheScheduler) runInitialRefresh(directives []config.CacheDirective) {
 	for _, directive := range directives {
 		key := fmt.Sprintf("%s:%s", directive.DataProvider, directive.StreamID)
 		if config, exists := configMap[key]; exists {
-			if s.shouldSkipInitialRefresh(config.LastRefreshed, directive.Schedule.CronExpr) {
+			if s.shouldSkipInitialRefresh(config.CacheRefreshedAtTimestamp, directive.Schedule.CronExpr) {
 				skipped++
 				continue
 			}
@@ -539,7 +540,7 @@ func (s *CacheScheduler) RunFullRefreshSync(ctx context.Context) (int, error) {
 	for _, dir := range directives {
 		key := fmt.Sprintf("%s:%s", dir.DataProvider, dir.StreamID)
 		if conf, exists := configMap[key]; exists {
-			if s.shouldSkipInitialRefresh(conf.LastRefreshed, dir.Schedule.CronExpr) {
+			if s.shouldSkipInitialRefresh(conf.CacheRefreshedAtTimestamp, dir.Schedule.CronExpr) {
 				continue
 			}
 		}

--- a/extensions/tn_cache/tn_cache.go
+++ b/extensions/tn_cache/tn_cache.go
@@ -146,7 +146,8 @@ func InitializeCachePrecompile(ctx context.Context, service *common.Service, db 
 					IsTable: false,
 					Fields: []precompiles.PrecompileValue{
 						precompiles.NewPrecompileValue("has_data", types.BoolType, false),
-						precompiles.NewPrecompileValue("cached_at", types.IntType, false),
+						precompiles.NewPrecompileValue("cache_refreshed_at_timestamp", types.IntType, false),
+						precompiles.NewPrecompileValue("cache_height", types.IntType, false),
 					},
 				},
 				Handler: HandleHasCachedData,

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
-	github.com/trufnetwork/kwil-db v0.10.3-0.20250722191434-dcb1116dd549
-	github.com/trufnetwork/kwil-db/core v0.4.3-0.20250722191434-dcb1116dd549
+	github.com/trufnetwork/kwil-db v0.10.3-0.20250724144822-36aec996d7d7
+	github.com/trufnetwork/kwil-db/core v0.4.3-0.20250724144822-36aec996d7d7
 	github.com/trufnetwork/sdk-go v0.3.2-0.20250630062504-841b40cdb709
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa

--- a/go.sum
+++ b/go.sum
@@ -1204,10 +1204,10 @@ github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZ
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPDo=
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250722191434-dcb1116dd549 h1:k1JsK1rVJ04+Ifqz3ZFC56SSip/xAVHdzzNbMEPla4Q=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250722191434-dcb1116dd549/go.mod h1:xskYWZKkPSQOpSo7yqcqpZzcqIRw06dRgLb9TwIvtAI=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250722191434-dcb1116dd549 h1:Yq4PxsVEwpxTayiJJCEFheecd0vrCYuADDu1oVVIsl8=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250722191434-dcb1116dd549/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
+github.com/trufnetwork/kwil-db v0.10.3-0.20250724144822-36aec996d7d7 h1:spyWCA1A/WdjDF4x7Zp99tlXRipK/qjMMt4PtOvnxmA=
+github.com/trufnetwork/kwil-db v0.10.3-0.20250724144822-36aec996d7d7/go.mod h1:xskYWZKkPSQOpSo7yqcqpZzcqIRw06dRgLb9TwIvtAI=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20250724144822-36aec996d7d7 h1:1nicTFTiw5H1nsufJVWJXyzg+C7q0u/+QWPq3UCbSf0=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20250724144822-36aec996d7d7/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2 h1:DCq8MzbWH0wZmICNmMVsSzUHUPl+2vqRhluEABjxl88=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2/go.mod h1:Y0MJpPp9QXU5vC6Gpoilql2NkgmGNcbHm9HYC2v2N8s=
 github.com/trufnetwork/sdk-go v0.3.2-0.20250630062504-841b40cdb709 h1:d9EqPXIjbq/atzEncK5dM3Z9oStx1BxCGuL/sjefeCw=

--- a/internal/migrations/901-utilities.sql
+++ b/internal/migrations/901-utilities.sql
@@ -111,12 +111,13 @@ CREATE OR REPLACE ACTION helper_check_cache(
 
     if $is_caching_enabled {
         $has_cached_data BOOL := false;
-        $cached_at INT8;
-        $has_cached_data, $cached_at := tn_cache.has_cached_data($data_provider, $stream_id, $from, $to);
+        $cache_refreshed_at_timestamp INT8;
+        $cache_height INT8;
+        $has_cached_data, $cache_refreshed_at_timestamp, $cache_height := tn_cache.has_cached_data($data_provider, $stream_id, $from, $to);
         
         if $has_cached_data {
-            -- Cache hit - get most recent cached data
-            NOTICE('{"cache_hit": true, "cached_at": ' || $cached_at::TEXT || '}');
+            -- Cache hit - get most recent cached data, show height to users
+            NOTICE('{"cache_hit": true, "cache_height": ' || $cache_height::TEXT || ', "cache_refreshed_at_timestamp": ' || $cache_refreshed_at_timestamp::TEXT || '}');
             $cache_hit := true;
         } else {
             -- Cache miss - log and fallback to original logic

--- a/tests/extensions/tn_cache/cache_height_tracking_test.go
+++ b/tests/extensions/tn_cache/cache_height_tracking_test.go
@@ -1,0 +1,117 @@
+package tn_cache_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kwilTesting "github.com/trufnetwork/kwil-db/testing"
+	"github.com/trufnetwork/kwil-db/node/meta"
+	"github.com/trufnetwork/node/internal/migrations"
+	testutils "github.com/trufnetwork/node/tests/streams/utils"
+	"github.com/trufnetwork/node/tests/streams/utils/procedure"
+	"github.com/trufnetwork/node/tests/streams/utils/setup"
+	"github.com/trufnetwork/sdk-go/core/types"
+	"github.com/trufnetwork/sdk-go/core/util"
+)
+
+// TestCacheHeightTracking verifies that cache stores and returns blockchain height information:
+// - Cache stores the blockchain height when data is cached
+// - has_cached_data returns cached_at (actually the height) and logs show both cached_at_height and current_height
+// - Height values are properly tracked through refresh cycles
+func TestCacheHeightTracking(t *testing.T) {
+	deployer := "0x0000000000000000000000000000000000000456"
+	streamId := util.GenerateStreamId("height_tracking_test")
+	cacheConfig := testutils.TestCache(deployer, streamId.String())
+
+	testutils.RunSchemaTest(t, kwilTesting.SchemaTest{
+		Name:        "cache_height_tracking_test",
+		SeedScripts: migrations.GetSeedScriptPaths(),
+		FunctionTests: []kwilTesting.TestFunc{
+			func(ctx context.Context, platform *kwilTesting.Platform) error {
+				helper := testutils.SetupCacheTest(ctx, platform, cacheConfig)
+				defer helper.Cleanup()
+
+				deployerAddr, err := util.NewEthereumAddressFromString(deployer)
+				require.NoError(t, err)
+
+				platform = procedure.WithSigner(platform, deployerAddr.Bytes())
+
+				// Setup test data - use composed stream to test cache (like other working tests)
+				err = setup.SetupComposedFromMarkdown(ctx, setup.MarkdownComposedSetupInput{
+					Platform: platform,
+					StreamId: streamId,
+					MarkdownData: `
+					| event_time | value_1 | value_2 | value_3 |
+					|------------|---------|---------|---------|
+					| 100        | 10      | 20      | 30      |
+					| 200        | 15      | 25      | 35      |
+					`,
+					Height: 1,
+				})
+				require.NoError(t, err)
+
+				// Refresh cache to populate data with height
+				recordsCached, err := helper.RefreshAllStreamsSync(ctx)
+				require.NoError(t, err)
+				assert.Greater(t, recordsCached, 0, "Should have cached some records")
+
+				// Wait a moment to ensure the database has processed the cache update
+				time.Sleep(100 * time.Millisecond)
+
+				// Update blockchain height to 2 to simulate progression
+				err = meta.SetChainState(ctx, platform.DB, 2, []byte("test-hash-height-2"), false)
+				require.NoError(t, err)
+
+				// Query to trigger cache check - this should log cache metadata including heights
+				useCache := true
+				fromTime := int64(50)
+				toTime := int64(250)
+				
+				// Execute query that will use cache and return logs
+				result, err := procedure.GetRecordWithLogs(ctx, procedure.GetRecordInput{
+					Platform: platform,
+					StreamLocator: types.StreamLocator{
+						StreamId:     streamId,
+						DataProvider: deployerAddr,
+					},
+					UseCache: &useCache,
+					FromTime: &fromTime,
+					ToTime:   &toTime,
+					Height:   2, // Simulate being at a later block height
+				})
+				require.NoError(t, err)
+				require.NotNil(t, result)
+
+				// Check logs for height information
+				var cacheLog string
+				for _, log := range result.Logs {
+					if strings.Contains(log, "cache_hit") {
+						cacheLog = log
+						break
+					}
+				}
+				
+				require.NotEmpty(t, cacheLog, "Should have cache hit log with height information")
+				t.Logf("Cache log: %s", cacheLog)
+				
+				// Verify the log contains height fields
+				assert.Contains(t, cacheLog, "cache_hit", "Log should contain cache_hit field")
+				assert.Contains(t, cacheLog, "cache_height", "Log should contain cache_height")
+				assert.Contains(t, cacheLog, "cache_refreshed_at_timestamp", "Log should contain cache_refreshed_at_timestamp")
+				
+				// The cache_height should be 1 (when we cached)
+				assert.Contains(t, cacheLog, `"cache_hit": true`, "Should be a cache hit")
+				assert.Contains(t, cacheLog, `"cache_height": 1`, "Cache height should be 1")
+				// Verify cache_refreshed_at_timestamp is present and positive
+				assert.Regexp(t, `"cache_refreshed_at_timestamp": \d+`, cacheLog, "Should contain valid cache_refreshed_at_timestamp")
+
+				return nil
+			},
+		},
+	}, testutils.GetTestOptionsWithCache(cacheConfig))
+}
+

--- a/tests/extensions/tn_cache/cache_observability_test.go
+++ b/tests/extensions/tn_cache/cache_observability_test.go
@@ -19,7 +19,7 @@ import (
 
 // TestCacheObservability verifies cache monitoring and logging functionality:
 // - JSON formatted cache hit/miss logs
-// - Proper log fields (cache_hit, cached_at)
+// - Proper log fields (cache_hit, cached_at_height, current_height)
 // - Log capture mechanism works correctly
 func TestCacheObservability(t *testing.T) {
 	deployer := "0x0000000000000000000000000000000000000123"
@@ -125,13 +125,23 @@ func TestCacheObservability(t *testing.T) {
 					}
 				}
 
-				// Verify cache hit log is valid JSON with timestamp
+				// Verify cache hit log is valid JSON with height
 				require.Len(t, cacheLogs, 1, "Should have one cache hit log")
 				var hitLog map[string]interface{}
 				err = json.Unmarshal([]byte(cacheLogs[0]), &hitLog)
 				assert.NoError(t, err, "Cache hit log should be valid JSON")
 				assert.Equal(t, true, hitLog["cache_hit"], "Second query should be cache hit")
-				assert.NotNil(t, hitLog["cached_at"], "Cache hit should include cached_at timestamp")
+				assert.NotNil(t, hitLog["cache_height"], "Cache hit should include cache_height")
+				assert.NotNil(t, hitLog["cache_refreshed_at_timestamp"], "Cache hit should include cache_refreshed_at_timestamp")
+
+				// Verify height values are valid
+				cacheHeight, ok := hitLog["cache_height"].(float64)
+				assert.True(t, ok, "cache_height should be a number")
+				assert.Greater(t, cacheHeight, float64(0), "cache_height should be positive")
+
+				refreshTimestamp, ok := hitLog["cache_refreshed_at_timestamp"].(float64)
+				assert.True(t, ok, "cache_refreshed_at_timestamp should be a number")
+				assert.Greater(t, refreshTimestamp, float64(0), "cache_refreshed_at_timestamp should be positive")
 
 				// Test 3: Verify get_index cache miss log format
 				cacheLogs = nil // Reset logs
@@ -159,7 +169,7 @@ func TestCacheObservability(t *testing.T) {
 					}
 				}
 
-				// Verify index cache hit logs are valid JSON with timestamp
+				// Verify index cache hit logs are valid JSON with height
 				// get_index can generate multiple cache hit logs (for base value and current values)
 				require.GreaterOrEqual(t, len(cacheLogs), 1, "Should have at least one index cache hit log")
 				for i, logStr := range cacheLogs {
@@ -167,7 +177,17 @@ func TestCacheObservability(t *testing.T) {
 					err = json.Unmarshal([]byte(logStr), &indexHitLog)
 					assert.NoError(t, err, "Index cache hit log %d should be valid JSON", i)
 					assert.Equal(t, true, indexHitLog["cache_hit"], "Index query %d should be cache hit", i)
-					assert.NotNil(t, indexHitLog["cached_at"], "Index cache hit %d should include cached_at timestamp", i)
+					assert.NotNil(t, indexHitLog["cache_height"], "Index cache hit %d should include cache_height", i)
+					assert.NotNil(t, indexHitLog["cache_refreshed_at_timestamp"], "Index cache hit %d should include cache_refreshed_at_timestamp", i)
+
+					// Verify height values are valid for index
+					cacheHeight, ok := indexHitLog["cache_height"].(float64)
+					assert.True(t, ok, "Index cache_height %d should be a number", i)
+					assert.Greater(t, cacheHeight, float64(0), "Index cache_height %d should be positive", i)
+
+					refreshTimestamp, ok := indexHitLog["cache_refreshed_at_timestamp"].(float64)
+					assert.True(t, ok, "Index cache_refreshed_at_timestamp %d should be a number", i)
+					assert.Greater(t, refreshTimestamp, float64(0), "Index cache_refreshed_at_timestamp %d should be positive", i)
 				}
 
 				return nil

--- a/tests/streams/utils/utils.go
+++ b/tests/streams/utils/utils.go
@@ -374,9 +374,16 @@ func RunSchemaTest(t *testing.T, s kwilTesting.SchemaTest, options *Options) {
 	kwilOpts := &kwilTesting.Options{
 		UseTestContainer: true,
 		Logger:           t,
+		SetupMetaStore:   true, // Enable kwild_chain schema for blockchain height testing
+		InitialHeight:    1,    // Set initial blockchain height for tests (match production default)
 	}
 	if options != nil && options.Options != nil {
 		kwilOpts = options.Options
+		// Ensure meta store is always enabled for cache extension tests
+		kwilOpts.SetupMetaStore = true
+		if kwilOpts.InitialHeight <= 0 {
+			kwilOpts.InitialHeight = 1 // Default test height matches production
+		}
 	}
 
 	// Default to enabled with fallback (as original schema.go)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

  Adds deterministic multi-node cache behavior by storing blockchain height information alongside cached data. Cache operations now capture the actual block height when data is refreshed, enabling nodes to make consistent decisions about cache validity.

  Key changes:
  - Add last_refresh_height column to cached_streams table
  - Implement height access through SQL helper bridge pattern
  - Update has_cached_data to return 3 values (data, timestamp, height)
  - Enhanced cache metadata includes both cached and current heights


## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/truf-network/issues/1036

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Will check it again tomorrow, many things unclean and might fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache metadata now includes both the blockchain height and the cache refresh timestamp, providing enhanced transparency for cache status.

* **Bug Fixes**
  * Ensured consistent return values for cache status queries, now always including cache height and refreshed timestamp.

* **Tests**
  * Added and updated tests to verify cache height tracking and observability, ensuring accurate cache metadata reporting.

* **Chores**
  * Updated dependencies to the latest versions for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->