### PR TITLE
fix(docs): tn_cache configuration files to string

### DIFF
--- a/docs/node-operator-guide.md
+++ b/docs/node-operator-guide.md
@@ -470,7 +470,7 @@ The `tn_cache` extension provides **node-local caching** for expensive stream qu
 
 ```toml
 [extensions.tn_cache]
-enabled = true
+enabled = "true"
 # add stream configs here – see detailed guide for examples
 ```
 

--- a/extensions/tn_cache/README.md
+++ b/extensions/tn_cache/README.md
@@ -9,7 +9,7 @@ Enable and configure the extension in your node's `config.toml` file.
 ```toml
 [extensions.tn_cache]
 # Enable or disable the extension.
-enabled = true
+enabled = "true"
 
 # Optional: Schedule for re-resolving wildcards and IncludeChildren (default: daily at midnight)
 # Set to empty string to disable automatic re-resolution
@@ -239,13 +239,13 @@ The `tn_cache` extension accelerates **read-only** stream queries by storing res
 |-------|--------------|
 | **Startup** | Parses `config.toml`, resolves wildcards/`include_children`, stores directives in `ext_tn_cache.cached_streams`, performs an initial refresh (skips if refreshed this cron period). |
 | **Runtime** | Background scheduler refreshes streams on their `cron_schedule`.  If the node is syncing or the last block age exceeds `max_block_age`, refreshes are **paused**.  Wildcards / children are re-resolved on `resolution_schedule` (default daily). |
-| **Shutdown / Disable** | Setting `enabled = false` and restarting cleans up the cache schema safely.  Cached data persists across restarts while enabled. |
+| **Shutdown / Disable** | Setting `enabled = "false"` and restarting cleans up the cache schema safely.  Cached data persists across restarts while enabled. |
 
 ### 3. Minimal Configuration Recap
 Enable in `config.toml`:
 ```toml
 [extensions.tn_cache]
-enabled = true
+enabled = "true"
 # ONE of the blocks below
 # inline JSON
 streams_inline = '''[ { "data_provider":"0xabc...", "stream_id":"st123...", "cron_schedule":"0 * * * *" } ]'''
@@ -286,7 +286,7 @@ These edge-cases cause actions to **bypass the cache and recompute on the fly** 
 |-----------|----------------------|--------|
 | `get_record_composed`, `get_index_composed`, `get_index_change` | `frozen_at IS NOT NULL` | Cache disabled – a historical *frozen* snapshot must be computed exactly. |
 | same | `base_time IS NOT NULL` | Cache disabled – custom base time changes the whole index curve. |
-| same | `tn_cache` disabled on node, or `enabled = false` in `config.toml` | Falls back to full computation. |
+| same | `tn_cache` disabled on node, or `enabled = "false"` in `config.toml` | Falls back to full computation. |
 | *primitive* versions (`*_primitive`) | Any call | Never cached – primitives read directly from `primitive_events`. |
 
 Additional notes:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Changed the `enabled` field in the `tn_cache` extension configuration from a boolean to a string in both the node operator guide and the README documentation, ensuring correctness.
 
## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix https://github.com/trufnetwork/truf-network/issues/1066

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples in the documentation to represent the tn_cache extension's enabled option as a string ("true"/"false") instead of a boolean (true/false). This change is reflected consistently across all relevant documentation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->