### PR TITLE
feat: view list taxonomies by height

### DIFF
--- a/internal/migrations/016-taxonomy-query-actions.sql
+++ b/internal/migrations/016-taxonomy-query-actions.sql
@@ -1,0 +1,296 @@
+/*
+    TAXONOMY QUERY ACTIONS
+    
+    This migration adds SQL actions to query taxonomies by block height range.
+    Required for explorer synchronization to detect taxonomy changes efficiently.
+    
+    Actions Created:
+    - list_taxonomies_by_height: Main action for height-based taxonomy querying
+    - get_taxonomies_for_streams: Batch processing for specific streams
+    
+    Use Case:
+    Explorer synchronizer can call list_taxonomies_by_height(@height - 1000, @height, ...)
+    to detect taxonomy changes incrementally without expensive full-stream scanning.
+*/
+
+/**
+ * list_taxonomies_by_height: Queries taxonomies within a specific block height range.
+ * Supports pagination and latest-only filtering for efficient synchronization.
+ * 
+ * Parameters:
+ *   $from_height: Start height (inclusive). If NULL, uses earliest available.
+ *   $to_height: End height (inclusive). If NULL, uses current height.
+ *   $limit: Maximum number of results to return.
+ *   $offset: Number of results to skip for pagination.
+ *   $latest_only: If true, returns only latest group_sequence per stream.
+ * 
+ * Returns:
+ *   Table with taxonomy entries matching the criteria, ordered by created_at ASC.
+ *   
+ * Logic:
+ *   1. If both from_height and to_height are NULL -> fetch latest set of taxonomies
+ *   2. Latest set is defined by latest created_at and max group_sequence per stream
+ *   3. One stream can have multiple taxonomy sets, only return latest if latest_only=true
+ *   4. Filter by height range if provided
+ *   5. Only active taxonomies (disabled_at IS NULL)
+ *   6. Order by created_at ASC for consistent pagination
+ */
+CREATE OR REPLACE ACTION list_taxonomies_by_height(
+    $from_height INT8,
+    $to_height INT8,
+    $limit INT,
+    $offset INT,
+    $latest_only BOOL
+) PUBLIC view returns table(
+    data_provider TEXT,
+    stream_id TEXT,
+    child_data_provider TEXT,
+    child_stream_id TEXT,
+    weight NUMERIC(36,18),
+    created_at INT8,
+    group_sequence INT8,
+    start_time INT8
+) {
+    -- Set defaults for pagination
+    if $limit IS NULL {
+        $limit := 1000;
+    }
+    if $offset IS NULL {
+        $offset := 0;
+    }
+    if $latest_only IS NULL {
+        $latest_only := false;
+    }
+    
+    -- Get current block height for default behavior
+    $current_block INT8 := @height;
+    
+    -- Determine effective height range
+    $effective_from INT8;
+    $effective_to INT8;
+    
+    if $from_height IS NULL AND $to_height IS NULL {
+        -- Special case: return latest set of taxonomies
+        -- Use a reasonable lookback window to find recent taxonomies
+        $effective_from := $current_block - 1000;
+        $effective_to := $current_block;
+    } else {
+        $effective_from := COALESCE($from_height, 0);
+        $effective_to := COALESCE($to_height, $current_block);
+    }
+    
+    -- Validate height range
+    if $effective_from > $effective_to {
+        ERROR('Invalid height range: from_height (' || $effective_from || ') > to_height (' || $effective_to || ')');
+    }
+    
+    if $latest_only {
+        -- Return only latest group_sequence per stream within height range
+        -- Get all child relationships for the latest taxonomy set of each stream
+        RETURN WITH stream_latest_info AS (
+            SELECT 
+                t.data_provider,
+                t.stream_id,
+                MAX(t.created_at) as max_created_at
+            FROM taxonomies t
+            WHERE t.created_at >= $effective_from
+              AND t.created_at <= $effective_to
+              AND t.disabled_at IS NULL
+            GROUP BY t.data_provider, t.stream_id
+        ),
+        stream_latest_group AS (
+            SELECT 
+                sli.data_provider,
+                sli.stream_id,
+                sli.max_created_at,
+                MAX(t.group_sequence) as max_group_sequence
+            FROM stream_latest_info sli
+            JOIN taxonomies t ON sli.data_provider = t.data_provider 
+                AND sli.stream_id = t.stream_id 
+                AND sli.max_created_at = t.created_at
+            WHERE t.disabled_at IS NULL
+            GROUP BY sli.data_provider, sli.stream_id, sli.max_created_at
+        )
+        SELECT 
+            t.data_provider,
+            t.stream_id,
+            t.child_data_provider,
+            t.child_stream_id,
+            t.weight,
+            t.created_at,
+            t.group_sequence,
+            t.start_time
+        FROM stream_latest_group slg
+        JOIN taxonomies t ON slg.data_provider = t.data_provider 
+            AND slg.stream_id = t.stream_id 
+            AND slg.max_created_at = t.created_at 
+            AND slg.max_group_sequence = t.group_sequence
+        WHERE t.disabled_at IS NULL
+        ORDER BY t.created_at ASC, t.data_provider ASC, t.stream_id ASC, t.child_data_provider ASC, t.child_stream_id ASC
+        LIMIT $limit OFFSET $offset;
+    } else {
+        -- Return all taxonomies within height range
+        RETURN SELECT 
+            t.data_provider,
+            t.stream_id,
+            t.child_data_provider,
+            t.child_stream_id,
+            t.weight,
+            t.created_at,
+            t.group_sequence,
+            t.start_time
+        FROM taxonomies t
+        WHERE t.created_at >= $effective_from
+          AND t.created_at <= $effective_to
+          AND t.disabled_at IS NULL
+        ORDER BY t.created_at ASC
+        LIMIT $limit OFFSET $offset;
+    }
+};
+
+/**
+ * get_taxonomies_for_streams: Batch fetch taxonomies for specific streams.
+ * Uses efficient WITH RECURSIVE pattern for array processing.
+ * 
+ * Parameters:
+ *   $data_providers: Array of data provider addresses.
+ *   $stream_ids: Array of stream IDs (must match data_providers length).
+ *   $latest_only: If true, returns only latest group_sequence per stream.
+ * 
+ * Returns:
+ *   Table with taxonomy entries for the specified streams.
+ *   
+ * Use Case:
+ *   When sync process needs to verify taxonomy for specific streams.
+ */
+CREATE OR REPLACE ACTION get_taxonomies_for_streams(
+    $data_providers TEXT[],
+    $stream_ids TEXT[],
+    $latest_only BOOL
+) PUBLIC view returns table(
+    data_provider TEXT,
+    stream_id TEXT,
+    child_data_provider TEXT,
+    child_stream_id TEXT,
+    weight NUMERIC(36,18),
+    created_at INT8,
+    group_sequence INT8,
+    start_time INT8
+) {
+    -- Use helper function to avoid expensive for-loop roundtrips
+    $data_providers := helper_lowercase_array($data_providers);
+    
+    -- Set default for latest_only
+    if $latest_only IS NULL {
+        $latest_only := false;
+    }
+    
+    -- Validate array lengths match
+    if array_length($data_providers) != array_length($stream_ids) {
+        ERROR('Data providers and stream IDs arrays must have the same length');
+    }
+    
+    if $latest_only {
+        -- Return only latest group_sequence per stream
+        RETURN WITH RECURSIVE 
+        indexes AS (
+            SELECT 1 AS idx
+            UNION ALL
+            SELECT idx + 1 FROM indexes
+            WHERE idx < array_length($data_providers)
+        ),
+        stream_arrays AS (
+            SELECT 
+                $data_providers AS data_providers,
+                $stream_ids AS stream_ids
+        ),
+        all_pairs AS (
+            SELECT 
+                stream_arrays.data_providers[idx] AS data_provider,
+                stream_arrays.stream_ids[idx] AS stream_id
+            FROM indexes
+            JOIN stream_arrays ON 1=1
+        ),
+        unique_pairs AS (
+            SELECT DISTINCT data_provider, stream_id
+            FROM all_pairs
+        ),
+        stream_latest_info AS (
+            SELECT 
+                up.data_provider,
+                up.stream_id,
+                MAX(t.created_at) as max_created_at
+            FROM unique_pairs up
+            JOIN taxonomies t ON up.data_provider = t.data_provider AND up.stream_id = t.stream_id
+            WHERE t.disabled_at IS NULL
+            GROUP BY up.data_provider, up.stream_id
+        ),
+        stream_latest_group AS (
+            SELECT 
+                sli.data_provider,
+                sli.stream_id,
+                sli.max_created_at,
+                MAX(t.group_sequence) as max_group_sequence
+            FROM stream_latest_info sli
+            JOIN taxonomies t ON sli.data_provider = t.data_provider 
+                AND sli.stream_id = t.stream_id 
+                AND sli.max_created_at = t.created_at
+            WHERE t.disabled_at IS NULL
+            GROUP BY sli.data_provider, sli.stream_id, sli.max_created_at
+        )
+        SELECT 
+            ap.data_provider,
+            ap.stream_id,
+            t.child_data_provider,
+            t.child_stream_id,
+            t.weight,
+            t.created_at,
+            t.group_sequence,
+            t.start_time
+        FROM all_pairs ap
+        JOIN stream_latest_group slg ON ap.data_provider = slg.data_provider AND ap.stream_id = slg.stream_id
+        JOIN taxonomies t ON slg.data_provider = t.data_provider 
+            AND slg.stream_id = t.stream_id 
+            AND slg.max_created_at = t.created_at 
+            AND slg.max_group_sequence = t.group_sequence
+        WHERE t.disabled_at IS NULL;
+    } else {
+        -- Return all taxonomies for specified streams
+        RETURN WITH RECURSIVE 
+        indexes AS (
+            SELECT 1 AS idx
+            UNION ALL
+            SELECT idx + 1 FROM indexes
+            WHERE idx < array_length($data_providers)
+        ),
+        stream_arrays AS (
+            SELECT 
+                $data_providers AS data_providers,
+                $stream_ids AS stream_ids
+        ),
+        all_pairs AS (
+            SELECT 
+                stream_arrays.data_providers[idx] AS data_provider,
+                stream_arrays.stream_ids[idx] AS stream_id
+            FROM indexes
+            JOIN stream_arrays ON 1=1
+        ),
+        unique_pairs AS (
+            SELECT DISTINCT data_provider, stream_id
+            FROM all_pairs
+        )
+        SELECT 
+            ap.data_provider,
+            ap.stream_id,
+            t.child_data_provider,
+            t.child_stream_id,
+            t.weight,
+            t.created_at,
+            t.group_sequence,
+            t.start_time
+        FROM all_pairs ap
+        JOIN unique_pairs up ON ap.data_provider = up.data_provider AND ap.stream_id = up.stream_id
+        JOIN taxonomies t ON up.data_provider = t.data_provider AND up.stream_id = t.stream_id
+        WHERE t.disabled_at IS NULL;
+    }
+};

--- a/tests/streams/taxonomy_query_actions_test.go
+++ b/tests/streams/taxonomy_query_actions_test.go
@@ -1,0 +1,576 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	kwilTesting "github.com/trufnetwork/kwil-db/testing"
+	"github.com/trufnetwork/node/internal/migrations"
+	testutils "github.com/trufnetwork/node/tests/streams/utils"
+	"github.com/trufnetwork/node/tests/streams/utils/procedure"
+	"github.com/trufnetwork/node/tests/streams/utils/setup"
+	"github.com/trufnetwork/node/tests/streams/utils/table"
+	"github.com/trufnetwork/sdk-go/core/types"
+	"github.com/trufnetwork/sdk-go/core/util"
+)
+
+// TestTaxonomyQueryActions tests the new taxonomy query actions
+func TestTaxonomyQueryActions(t *testing.T) {
+	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
+		Name:        "taxonomy_query_actions_test",
+		SeedScripts: migrations.GetSeedScriptPaths(),
+		FunctionTests: []kwilTesting.TestFunc{
+			testListTaxonomiesByHeight(t),
+			testListTaxonomiesByHeightWithLatestOnly(t),
+			testListTaxonomiesByHeightPagination(t),
+			testGetTaxonomiesForStreams(t),
+			testGetTaxonomiesForStreamsLatestOnly(t),
+		},
+	}, testutils.GetTestOptionsWithCache().Options)
+}
+
+// testListTaxonomiesByHeight tests basic height-based taxonomy querying
+func testListTaxonomiesByHeight(t *testing.T) kwilTesting.TestFunc {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		// Setup deployer
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x0000000000000000000000000000000000000123")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+
+		// Create test streams
+		composedStreamId := util.GenerateStreamId("composed_test_1")
+		child1StreamId := util.GenerateStreamId("child_test_1")
+		child2StreamId := util.GenerateStreamId("child_test_2")
+
+		// Setup composed stream
+		err := setup.SetupComposedStream(ctx, setup.SetupComposedStreamInput{
+			Platform: platform,
+			StreamId: composedStreamId,
+			Height:   100, // Create at height 100
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up composed stream")
+		}
+
+		// Setup child streams
+		err = setup.SetupPrimitive(ctx, setup.SetupPrimitiveInput{
+			Platform: platform,
+			Height:   100,
+			PrimitiveStreamWithData: setup.PrimitiveStreamWithData{
+				PrimitiveStreamDefinition: setup.PrimitiveStreamDefinition{
+					StreamLocator: types.StreamLocator{
+						StreamId:     child1StreamId,
+						DataProvider: deployer,
+					},
+				},
+				Data: []setup.InsertRecordInput{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up first child stream")
+		}
+
+		err = setup.SetupPrimitive(ctx, setup.SetupPrimitiveInput{
+			Platform: platform,
+			Height:   100,
+			PrimitiveStreamWithData: setup.PrimitiveStreamWithData{
+				PrimitiveStreamDefinition: setup.PrimitiveStreamDefinition{
+					StreamLocator: types.StreamLocator{
+						StreamId:     child2StreamId,
+						DataProvider: deployer,
+					},
+				},
+				Data: []setup.InsertRecordInput{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up second child stream")
+		}
+
+		// Create taxonomies at different heights
+		composedStreamLocator := types.StreamLocator{
+			StreamId:     composedStreamId,
+			DataProvider: deployer,
+		}
+
+		// First taxonomy at height 150
+		err = procedure.SetTaxonomy(ctx, procedure.SetTaxonomyInput{
+			Platform:      platform,
+			StreamLocator: composedStreamLocator,
+			DataProviders: []string{deployer.Address()},
+			StreamIds:     []string{child1StreamId.String()},
+			Weights:       []string{"1.0"},
+			StartTime:     nil,
+			Height:        150,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting first taxonomy")
+		}
+
+		// Second taxonomy at height 200
+		err = procedure.SetTaxonomy(ctx, procedure.SetTaxonomyInput{
+			Platform:      platform,
+			StreamLocator: composedStreamLocator,
+			DataProviders: []string{deployer.Address()},
+			StreamIds:     []string{child2StreamId.String()},
+			Weights:       []string{"1.0"},
+			StartTime:     nil,
+			Height:        200,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting second taxonomy")
+		}
+
+		// Test querying taxonomies by height range
+		fromHeight := int64(140)
+		toHeight := int64(190)
+
+		result, err := procedure.ListTaxonomiesByHeight(ctx, procedure.ListTaxonomiesByHeightInput{
+			Platform:   platform,
+			FromHeight: &fromHeight,
+			ToHeight:   &toHeight,
+			Limit:      nil,
+			Offset:     nil,
+			LatestOnly: nil,
+			Height:     250,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error listing taxonomies by height")
+		}
+
+		// Should return only the first taxonomy (created at height 150)
+		expected := `
+		| data_provider | stream_id | child_data_provider | child_stream_id | weight | created_at | group_sequence | start_time |
+		|---------------|-----------|---------------------|-----------------|--------|------------|----------------|------------|
+		| 0x0000000000000000000000000000000000000123 | ` + composedStreamId.String() + ` | 0x0000000000000000000000000000000000000123 | ` + child1StreamId.String() + ` | 1.000000000000000000 | 150 | 1 | 0 |
+		`
+
+		table.AssertResultRowsEqualMarkdownTable(t, table.AssertResultRowsEqualMarkdownTableInput{
+			Actual:   result,
+			Expected: expected,
+		})
+
+		return nil
+	}
+}
+
+// testListTaxonomiesByHeightWithLatestOnly tests latest_only functionality with multiple child streams
+func testListTaxonomiesByHeightWithLatestOnly(t *testing.T) kwilTesting.TestFunc {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		// Setup deployer
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x0000000000000000000000000000000000000124")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+
+		// Create test streams
+		composedStreamId := util.GenerateStreamId("composed_test_2")
+		childStreamId1 := util.GenerateStreamId("child_test_3a")
+		childStreamId2 := util.GenerateStreamId("child_test_3b")
+
+		// Setup streams
+		err := setup.SetupComposedStream(ctx, setup.SetupComposedStreamInput{
+			Platform: platform,
+			StreamId: composedStreamId,
+			Height:   300,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up composed stream")
+		}
+
+		err = setup.SetupPrimitive(ctx, setup.SetupPrimitiveInput{
+			Platform: platform,
+			Height:   300,
+			PrimitiveStreamWithData: setup.PrimitiveStreamWithData{
+				PrimitiveStreamDefinition: setup.PrimitiveStreamDefinition{
+					StreamLocator: types.StreamLocator{
+						StreamId:     childStreamId1,
+						DataProvider: deployer,
+					},
+				},
+				Data: []setup.InsertRecordInput{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up first child stream")
+		}
+
+		err = setup.SetupPrimitive(ctx, setup.SetupPrimitiveInput{
+			Platform: platform,
+			Height:   300,
+			PrimitiveStreamWithData: setup.PrimitiveStreamWithData{
+				PrimitiveStreamDefinition: setup.PrimitiveStreamDefinition{
+					StreamLocator: types.StreamLocator{
+						StreamId:     childStreamId2,
+						DataProvider: deployer,
+					},
+				},
+				Data: []setup.InsertRecordInput{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up second child stream")
+		}
+
+		composedStreamLocator := types.StreamLocator{
+			StreamId:     composedStreamId,
+			DataProvider: deployer,
+		}
+
+		// Create first taxonomy with single child
+		err = procedure.SetTaxonomy(ctx, procedure.SetTaxonomyInput{
+			Platform:      platform,
+			StreamLocator: composedStreamLocator,
+			DataProviders: []string{deployer.Address()},
+			StreamIds:     []string{childStreamId1.String()},
+			Weights:       []string{"1.0"},
+			StartTime:     nil,
+			Height:        350,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting first taxonomy")
+		}
+
+		// Create second taxonomy with multiple children (this should be returned by latest_only)
+		err = procedure.SetTaxonomy(ctx, procedure.SetTaxonomyInput{
+			Platform:      platform,
+			StreamLocator: composedStreamLocator,
+			DataProviders: []string{deployer.Address(), deployer.Address()},
+			StreamIds:     []string{childStreamId1.String(), childStreamId2.String()},
+			Weights:       []string{"0.6", "0.4"},
+			StartTime:     nil,
+			Height:        400,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting second taxonomy")
+		}
+
+		// Test with latest_only = true
+		latestOnly := true
+		result, err := procedure.ListTaxonomiesByHeight(ctx, procedure.ListTaxonomiesByHeightInput{
+			Platform:   platform,
+			FromHeight: nil, // Get all
+			ToHeight:   nil, // Get all
+			Limit:      nil,
+			Offset:     nil,
+			LatestOnly: &latestOnly,
+			Height:     450,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error listing taxonomies with latest_only")
+		}
+
+		// Should return both children from the latest taxonomy (created at height 400, group_sequence 2)
+		if len(result) != 2 {
+			return errors.Errorf("expected 2 results for latest taxonomy with multiple children, got %d", len(result))
+		}
+
+		// Verify all results are from the latest taxonomy
+		for _, row := range result {
+			if row[5] != "400" { // created_at column
+				return errors.Errorf("expected created_at=400, got %s", row[5])
+			}
+			if row[6] != "2" { // group_sequence column  
+				return errors.Errorf("expected group_sequence=2, got %s", row[6])
+			}
+		}
+
+		return nil
+	}
+}
+
+// testListTaxonomiesByHeightPagination tests pagination functionality
+func testListTaxonomiesByHeightPagination(t *testing.T) kwilTesting.TestFunc {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		// Setup deployer
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x0000000000000000000000000000000000000125")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+
+		// Create multiple taxonomies for pagination testing
+		for i := 1; i <= 3; i++ {
+			composedStreamId := util.GenerateStreamId(fmt.Sprintf("composed_paging_%d", i))
+			childStreamId := util.GenerateStreamId(fmt.Sprintf("child_paging_%d", i))
+
+			// Setup streams
+			err := setup.SetupComposedStream(ctx, setup.SetupComposedStreamInput{
+				Platform: platform,
+				StreamId: composedStreamId,
+				Height:   500 + int64(i)*10,
+			})
+			if err != nil {
+				return errors.Wrapf(err, "error setting up composed stream %d", i)
+			}
+
+			err = setup.SetupPrimitive(ctx, setup.SetupPrimitiveInput{
+				Platform: platform,
+				Height:   500 + int64(i)*10,
+				PrimitiveStreamWithData: setup.PrimitiveStreamWithData{
+					PrimitiveStreamDefinition: setup.PrimitiveStreamDefinition{
+						StreamLocator: types.StreamLocator{
+							StreamId:     childStreamId,
+							DataProvider: deployer,
+						},
+					},
+					Data: []setup.InsertRecordInput{},
+				},
+			})
+			if err != nil {
+				return errors.Wrapf(err, "error setting up child stream %d", i)
+			}
+
+			// Create taxonomy
+			composedStreamLocator := types.StreamLocator{
+				StreamId:     composedStreamId,
+				DataProvider: deployer,
+			}
+
+			err = procedure.SetTaxonomy(ctx, procedure.SetTaxonomyInput{
+				Platform:      platform,
+				StreamLocator: composedStreamLocator,
+				DataProviders: []string{deployer.Address()},
+				StreamIds:     []string{childStreamId.String()},
+				Weights:       []string{"1.0"},
+				StartTime:     nil,
+				Height:        600 + int64(i)*10,
+			})
+			if err != nil {
+				return errors.Wrapf(err, "error setting taxonomy %d", i)
+			}
+		}
+
+		// Test pagination - get first 2 results
+		limit := 2
+		offset := 0
+		result, err := procedure.ListTaxonomiesByHeight(ctx, procedure.ListTaxonomiesByHeightInput{
+			Platform:   platform,
+			FromHeight: nil,
+			ToHeight:   nil,
+			Limit:      &limit,
+			Offset:     &offset,
+			LatestOnly: nil,
+			Height:     700,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error listing taxonomies with pagination")
+		}
+
+		// Should return first 2 taxonomies ordered by created_at ASC
+		if len(result) != 2 {
+			return errors.Errorf("expected 2 results, got %d", len(result))
+		}
+
+		// Test second page
+		offset = 2
+		result2, err := procedure.ListTaxonomiesByHeight(ctx, procedure.ListTaxonomiesByHeightInput{
+			Platform:   platform,
+			FromHeight: nil,
+			ToHeight:   nil,
+			Limit:      &limit,
+			Offset:     &offset,
+			LatestOnly: nil,
+			Height:     700,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error listing taxonomies page 2")
+		}
+
+		// Should return remaining results
+		if len(result2) == 0 {
+			return errors.New("expected at least 1 result on page 2")
+		}
+
+		return nil
+	}
+}
+
+// testGetTaxonomiesForStreams tests batch stream querying
+func testGetTaxonomiesForStreams(t *testing.T) kwilTesting.TestFunc {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		// Setup deployer
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x0000000000000000000000000000000000000126")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+
+		// Create test streams
+		composedStreamId1 := util.GenerateStreamId("composed_batch_1")
+		composedStreamId2 := util.GenerateStreamId("composed_batch_2")
+		childStreamId := util.GenerateStreamId("child_batch")
+
+		// Setup streams
+		err := setup.SetupComposedStream(ctx, setup.SetupComposedStreamInput{
+			Platform: platform,
+			StreamId: composedStreamId1,
+			Height:   800,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up first composed stream")
+		}
+
+		err = setup.SetupComposedStream(ctx, setup.SetupComposedStreamInput{
+			Platform: platform,
+			StreamId: composedStreamId2,
+			Height:   800,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up second composed stream")
+		}
+
+		err = setup.SetupPrimitive(ctx, setup.SetupPrimitiveInput{
+			Platform: platform,
+			Height:   800,
+			PrimitiveStreamWithData: setup.PrimitiveStreamWithData{
+				PrimitiveStreamDefinition: setup.PrimitiveStreamDefinition{
+					StreamLocator: types.StreamLocator{
+						StreamId:     childStreamId,
+						DataProvider: deployer,
+					},
+				},
+				Data: []setup.InsertRecordInput{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up child stream")
+		}
+
+		// Create taxonomies for both streams
+		for i, streamId := range []util.StreamId{composedStreamId1, composedStreamId2} {
+			composedStreamLocator := types.StreamLocator{
+				StreamId:     streamId,
+				DataProvider: deployer,
+			}
+
+			err = procedure.SetTaxonomy(ctx, procedure.SetTaxonomyInput{
+				Platform:      platform,
+				StreamLocator: composedStreamLocator,
+				DataProviders: []string{deployer.Address()},
+				StreamIds:     []string{childStreamId.String()},
+				Weights:       []string{fmt.Sprintf("%.1f", float64(i+1)*0.5)},
+				StartTime:     nil,
+				Height:        850 + int64(i)*10,
+			})
+			if err != nil {
+				return errors.Wrapf(err, "error setting taxonomy %d", i+1)
+			}
+		}
+
+		// Test batch querying
+		result, err := procedure.GetTaxonomiesForStreams(ctx, procedure.GetTaxonomiesForStreamsInput{
+			Platform: platform,
+			DataProviders: []string{
+				deployer.Address(),
+				deployer.Address(),
+			},
+			StreamIds: []string{
+				composedStreamId1.String(),
+				composedStreamId2.String(),
+			},
+			LatestOnly: nil,
+			Height:     900,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error getting taxonomies for streams")
+		}
+
+		// Should return taxonomies for both streams
+		if len(result) != 2 {
+			return errors.Errorf("expected 2 results, got %d", len(result))
+		}
+
+		return nil
+	}
+}
+
+// testGetTaxonomiesForStreamsLatestOnly tests batch querying with latest_only
+func testGetTaxonomiesForStreamsLatestOnly(t *testing.T) kwilTesting.TestFunc {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		// Setup deployer
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x0000000000000000000000000000000000000127")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+
+		// Create test stream
+		composedStreamId := util.GenerateStreamId("composed_batch_latest")
+		childStreamId := util.GenerateStreamId("child_batch_latest")
+
+		// Setup streams
+		err := setup.SetupComposedStream(ctx, setup.SetupComposedStreamInput{
+			Platform: platform,
+			StreamId: composedStreamId,
+			Height:   1000,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up composed stream")
+		}
+
+		err = setup.SetupPrimitive(ctx, setup.SetupPrimitiveInput{
+			Platform: platform,
+			Height:   1000,
+			PrimitiveStreamWithData: setup.PrimitiveStreamWithData{
+				PrimitiveStreamDefinition: setup.PrimitiveStreamDefinition{
+					StreamLocator: types.StreamLocator{
+						StreamId:     childStreamId,
+						DataProvider: deployer,
+					},
+				},
+				Data: []setup.InsertRecordInput{},
+			},
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting up child stream")
+		}
+
+		composedStreamLocator := types.StreamLocator{
+			StreamId:     composedStreamId,
+			DataProvider: deployer,
+		}
+
+		// Create multiple taxonomies for the same stream
+		err = procedure.SetTaxonomy(ctx, procedure.SetTaxonomyInput{
+			Platform:      platform,
+			StreamLocator: composedStreamLocator,
+			DataProviders: []string{deployer.Address()},
+			StreamIds:     []string{childStreamId.String()},
+			Weights:       []string{"0.3"},
+			StartTime:     nil,
+			Height:        1050,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting first taxonomy")
+		}
+
+		err = procedure.SetTaxonomy(ctx, procedure.SetTaxonomyInput{
+			Platform:      platform,
+			StreamLocator: composedStreamLocator,
+			DataProviders: []string{deployer.Address()},
+			StreamIds:     []string{childStreamId.String()},
+			Weights:       []string{"0.7"},
+			StartTime:     nil,
+			Height:        1100,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error setting second taxonomy")
+		}
+
+		// Test batch querying with latest_only = true
+		latestOnly := true
+		result, err := procedure.GetTaxonomiesForStreams(ctx, procedure.GetTaxonomiesForStreamsInput{
+			Platform:      platform,
+			DataProviders: []string{deployer.Address()},
+			StreamIds:     []string{composedStreamId.String()},
+			LatestOnly:    &latestOnly,
+			Height:        1150,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error getting taxonomies for streams with latest_only")
+		}
+
+		// Should return only the latest taxonomy
+		if len(result) != 1 {
+			return errors.Errorf("expected 1 result, got %d", len(result))
+		}
+
+		// Verify it's the latest one (weight 0.7)
+		if result[0][4] != "0.700000000000000000" { // weight column
+			return errors.Errorf("expected weight 0.700000000000000000, got %s", result[0][4])
+		}
+
+		return nil
+	}
+}

--- a/tests/streams/utils/procedure/execute.go
+++ b/tests/streams/utils/procedure/execute.go
@@ -761,3 +761,85 @@ func GetDatabaseSize(ctx context.Context, input GetDatabaseSizeInput) (int64, er
 
 	return *databaseSize, nil
 }
+
+// ListTaxonomiesByHeight executes list_taxonomies_by_height action
+func ListTaxonomiesByHeight(ctx context.Context, input ListTaxonomiesByHeightInput) ([]ResultRow, error) {
+	deployer, err := util.NewEthereumAddressFromBytes(input.Platform.Deployer)
+	if err != nil {
+		return nil, errors.Wrap(err, "error in ListTaxonomiesByHeight.NewEthereumAddressFromBytes")
+	}
+
+	txContext := &common.TxContext{
+		Ctx:          ctx,
+		BlockContext: &common.BlockContext{Height: input.Height},
+		Signer:       input.Platform.Deployer,
+		Caller:       deployer.Address(),
+		TxID:         input.Platform.Txid(),
+	}
+
+	engineContext := &common.EngineContext{
+		TxContext: txContext,
+	}
+
+	var resultRows [][]any
+	r, err := input.Platform.Engine.Call(engineContext, input.Platform.DB, "", "list_taxonomies_by_height", []any{
+		input.FromHeight,
+		input.ToHeight,
+		input.Limit,
+		input.Offset,
+		input.LatestOnly,
+	}, func(row *common.Row) error {
+		values := make([]any, len(row.Values))
+		copy(values, row.Values)
+		resultRows = append(resultRows, values)
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error in ListTaxonomiesByHeight.Call")
+	}
+	if r.Error != nil {
+		return nil, errors.Wrap(r.Error, "error in ListTaxonomiesByHeight.Call")
+	}
+
+	return processResultRows(resultRows)
+}
+
+// GetTaxonomiesForStreams executes get_taxonomies_for_streams action
+func GetTaxonomiesForStreams(ctx context.Context, input GetTaxonomiesForStreamsInput) ([]ResultRow, error) {
+	deployer, err := util.NewEthereumAddressFromBytes(input.Platform.Deployer)
+	if err != nil {
+		return nil, errors.Wrap(err, "error in GetTaxonomiesForStreams.NewEthereumAddressFromBytes")
+	}
+
+	txContext := &common.TxContext{
+		Ctx:          ctx,
+		BlockContext: &common.BlockContext{Height: input.Height},
+		Signer:       input.Platform.Deployer,
+		Caller:       deployer.Address(),
+		TxID:         input.Platform.Txid(),
+	}
+
+	engineContext := &common.EngineContext{
+		TxContext: txContext,
+	}
+
+	var resultRows [][]any
+	r, err := input.Platform.Engine.Call(engineContext, input.Platform.DB, "", "get_taxonomies_for_streams", []any{
+		input.DataProviders,
+		input.StreamIds,
+		input.LatestOnly,
+	}, func(row *common.Row) error {
+		values := make([]any, len(row.Values))
+		copy(values, row.Values)
+		resultRows = append(resultRows, values)
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "error in GetTaxonomiesForStreams.Call")
+	}
+	if r.Error != nil {
+		return nil, errors.Wrap(r.Error, "error in GetTaxonomiesForStreams.Call")
+	}
+
+	return processResultRows(resultRows)
+}

--- a/tests/streams/utils/procedure/types.go
+++ b/tests/streams/utils/procedure/types.go
@@ -141,3 +141,21 @@ type ListRoleMembersInput struct {
 	Owner    string
 	RoleName string
 }
+
+type ListTaxonomiesByHeightInput struct {
+	Platform   *kwilTesting.Platform
+	FromHeight *int64
+	ToHeight   *int64
+	Limit      *int
+	Offset     *int
+	LatestOnly *bool
+	Height     int64
+}
+
+type GetTaxonomiesForStreamsInput struct {
+	Platform      *kwilTesting.Platform
+	DataProviders []string
+	StreamIds     []string
+	LatestOnly    *bool
+	Height        int64
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/trufnetwork/truf-network/issues/1080

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to query taxonomy data by block height range or by specific streams, with support for pagination and filtering to show only the latest taxonomy per stream.
  * Enabled batch retrieval of taxonomy entries for multiple streams at once.

* **Tests**
  * Introduced comprehensive tests covering taxonomy queries by height, latest-only filtering, pagination, batch retrieval, column correctness, and error handling.

* **Chores**
  * Added new utility functions and input types to support taxonomy query testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->