### PR TITLE
fix: weird spikes and erratic values in hourly stream data

### DIFF
--- a/internal/migrations/018-fix-array-ordering-get-stream-ids.sql
+++ b/internal/migrations/018-fix-array-ordering-get-stream-ids.sql
@@ -1,0 +1,44 @@
+CREATE OR REPLACE ACTION get_stream_ids(
+    $data_providers TEXT[],
+    $stream_ids TEXT[]
+) PRIVATE VIEW RETURNS (stream_ids INT[]) {
+    -- Use WITH RECURSIVE to process stream ids lookup in single SQL operation
+    -- This avoids the expensive for-loop roundtrips
+    for $row in WITH RECURSIVE
+    indexes AS (
+        SELECT 1 AS idx
+        UNION ALL
+        SELECT idx + 1 FROM indexes
+        WHERE idx < array_length($data_providers)
+    ),
+    input_arrays AS (
+        SELECT
+            $data_providers AS data_providers,
+            $stream_ids AS stream_ids
+    ),
+    stream_lookups AS (
+        SELECT
+            idx,
+            s.id AS stream_ref
+        FROM indexes
+        JOIN input_arrays ON 1=1
+        JOIN data_providers dp ON dp.address = input_arrays.data_providers[idx]
+        JOIN streams s ON s.data_provider_id = dp.id
+                      AND s.stream_id = input_arrays.stream_ids[idx]
+    ),
+    build_array AS (
+        SELECT 1 AS current_idx, ARRAY[]::INT[] AS result
+        UNION ALL
+        SELECT
+            ba.current_idx + 1,
+            array_append(ba.result, sl.stream_ref)
+        FROM build_array ba
+        JOIN stream_lookups sl ON sl.idx = ba.current_idx
+        WHERE ba.current_idx <= array_length($data_providers)
+    )
+    SELECT result AS stream_refs
+    FROM build_array
+    WHERE current_idx = array_length($data_providers) + 1 {
+      return $row.stream_refs;
+    }
+};


### PR DESCRIPTION
This commit resolves the weird spikes and erratic values appearing in hourly stream data, including AI Index and Meme Index streams. Users were seeing inconsistent data patterns with normal values (~9.0) suddenly spiking to extreme values (11,532.36) or dropping to micro-decimals (0.06).

- Hourly stream data showing unpredictable spikes and anomalous values
- AI Index and Meme Index streams displaying inconsistent patterns
- Example: $TRUF Normal data flow (~8-9 range) contaminated with extreme outliers
- Data integrity issues affecting stream reliability and user confidence
- Issue manifested around block height 195,403 in production streams

Investigation revealed that data from different streams was being incorrectly mixed together due to a bug in the stream ID lookup function. This caused:

1. **Data Cross-Contamination**: Multiple data sources writing to the same stream
2. **Value Mix-Up**: AI Index data mixed with other unrelated streams
3. **Inconsistent Patterns**: Normal index values contaminated with foreign data
4. **Timing Correlation**: Issue started when new batch insertion logic was deployed

Fixed the underlying stream identification logic to ensure:
- Each stream receives only its intended data
- Batch operations maintain data integrity
- Stream ID assignments are deterministic and consistent
- Proper isolation between different data sources

- Verified with `kwil-cli call-action get_stream_ids text[]:0x7f573e177ee7ec50eb5dee59478285054e4e74e7,0x4710a8d8f0d845da110086812a32de6d90d7ff5c,0x4710a8d8f0d845da110086812a32de6d90d7ff5c,0x4710a8d8f0d845da110086812a32de6d90d7ff5c text[]:sta03956198c62f84cab99854ce8ff55,st04ebb38623197b73a85c8e4d92cdff,st07770ba3e3657abed80f79ea9c4721,st0a2285ff84f15971428604bb17cf37` that array ordering now works correctly
- Expected: `[16457, 1, 2, 3]`, Actual: `[16457, 1, 2, 3]` ✅
- Previous buggy version returned: `[1, 2, 16457]` ❌

- `internal/migrations/018-fix-array-ordering-get-stream-ids.sql`: New migration with fixed function

This fix prevents future data contamination and ensures stream data integrity for all batch insertion operations.

resolves: https://github.com/trufnetwork/truf-data-provider/issues/756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the ordering of stream identifiers so results consistently match the input sequence across lookups.
* **Performance**
  * Optimized stream ID retrieval to run as a single database operation, reducing latency and improving responsiveness.
* **Stability**
  * Improved reliability of stream resolution, minimizing inconsistencies in edge cases and lowering the risk of errors during data fetching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->