### PR TITLE
chore: include digest benchmark

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/montanaflynn/stats v0.7.1
-	github.com/panjf2000/ants/v2 v2.10.0
 	github.com/pkg/errors v0.9.1
-	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/samber/lo v1.47.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
@@ -196,7 +194,7 @@ require (
 	github.com/multiformats/go-multistream v0.6.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77 // indirect
+	github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77
 	github.com/onsi/ginkgo/v2 v2.22.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,8 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
-	github.com/trufnetwork/kwil-db v0.10.3-0.20250825142932-2b3197aeaf9a
-	github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825142932-2b3197aeaf9a
+	github.com/trufnetwork/kwil-db v0.10.3-0.20250829040222-799cf48f758e
+	github.com/trufnetwork/kwil-db/core v0.4.3-0.20250829040222-799cf48f758e
 	github.com/trufnetwork/sdk-go v0.3.2-0.20250630062504-841b40cdb709
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa

--- a/go.mod
+++ b/go.mod
@@ -10,15 +10,19 @@ require (
 	github.com/docker/docker v28.0.1+incompatible
 	github.com/fbiville/markdown-table-formatter v0.3.0
 	github.com/go-co-op/gocron v1.37.0
+	github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/montanaflynn/stats v0.7.1
+	github.com/panjf2000/ants/v2 v2.10.0
 	github.com/pkg/errors v0.9.1
+	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/samber/lo v1.47.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
-	github.com/trufnetwork/kwil-db v0.10.3-0.20250825143650-0504e34154ce
-	github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825143650-0504e34154ce
+	github.com/trufnetwork/kwil-db v0.10.3-0.20250825142932-2b3197aeaf9a
+	github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825142932-2b3197aeaf9a
 	github.com/trufnetwork/sdk-go v0.3.2-0.20250630062504-841b40cdb709
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa

--- a/go.sum
+++ b/go.sum
@@ -1220,6 +1220,8 @@ github.com/trufnetwork/kwil-db v0.10.3-0.20250825094640-1d31b2785b9d h1:EYmJgRoB
 github.com/trufnetwork/kwil-db v0.10.3-0.20250825094640-1d31b2785b9d/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db v0.10.3-0.20250825142932-2b3197aeaf9a h1:tfZmBt8xhjnAw1RB3NJoKGlznjZca1G47j1neSVb7Kw=
 github.com/trufnetwork/kwil-db v0.10.3-0.20250825142932-2b3197aeaf9a/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
+github.com/trufnetwork/kwil-db v0.10.3-0.20250829040222-799cf48f758e h1:pfdGR7fw1v7C5A5DQc8CdR+ROV2yKaRpWLuT4W86zx8=
+github.com/trufnetwork/kwil-db v0.10.3-0.20250829040222-799cf48f758e/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250820013721-26effaee3b2a h1:vewqh7xR1cIfIFATW+HwYhpCuLtUWbHH2R+Cr9ylCI4=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250820013721-26effaee3b2a/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250823041522-ec54fdc11d4f h1:IhNoF96yUQtKaqSUZ9AuWD0sxWbjAWnN7q1VzvB58A8=
@@ -1228,6 +1230,8 @@ github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825094640-1d31b2785b9d h1:Wzus
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825094640-1d31b2785b9d/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825142932-2b3197aeaf9a h1:quSev6rGDbxb2MfEdhGz/jisS0D/pNK4kwXxUv9g4+0=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825142932-2b3197aeaf9a/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20250829040222-799cf48f758e h1:k0LKW2SdfBcJE2rpMrgWMR3xJojnS4wJPBOGEHB1Il4=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20250829040222-799cf48f758e/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2 h1:DCq8MzbWH0wZmICNmMVsSzUHUPl+2vqRhluEABjxl88=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2/go.mod h1:Y0MJpPp9QXU5vC6Gpoilql2NkgmGNcbHm9HYC2v2N8s=
 github.com/trufnetwork/sdk-go v0.3.2-0.20250630062504-841b40cdb709 h1:d9EqPXIjbq/atzEncK5dM3Z9oStx1BxCGuL/sjefeCw=

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,7 @@ github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZ
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
+github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-yaml v1.9.8/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=
 github.com/goccy/go-yaml v1.11.0/go.mod h1:H+mJrWtjPTJAHvRbV09MCK9xYwODM+wRTVFFTWckfng=
@@ -949,6 +950,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mr-tron/base58 v1.1.2/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
@@ -1004,6 +1006,7 @@ github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/panjf2000/ants/v2 v2.10.0/go.mod h1:7ZxyxsqE4vvW0M7LSD8aI3cKwgFhBHbxnlN8mDqHa1I=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
@@ -1099,6 +1102,7 @@ github.com/quic-go/webtransport-go v0.8.1-0.20241018022711-4ac2c9250e66 h1:4WFk6
 github.com/quic-go/webtransport-go v0.8.1-0.20241018022711-4ac2c9250e66/go.mod h1:Vp72IJajgeOL6ddqrAhmp7IM9zbTcgkQxD/YdxrVwMw=
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
+github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -1214,16 +1218,16 @@ github.com/trufnetwork/kwil-db v0.10.3-0.20250823041522-ec54fdc11d4f h1:b6WLvfLK
 github.com/trufnetwork/kwil-db v0.10.3-0.20250823041522-ec54fdc11d4f/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db v0.10.3-0.20250825094640-1d31b2785b9d h1:EYmJgRoBkKjIaWXeJj1c8a1w5ShakEAx3hlYeEikfb8=
 github.com/trufnetwork/kwil-db v0.10.3-0.20250825094640-1d31b2785b9d/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250825143650-0504e34154ce h1:xxKuLzhX/OKztdAwfCZHJHl3KvBmhDPir0Nx/mR87DM=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250825143650-0504e34154ce/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
+github.com/trufnetwork/kwil-db v0.10.3-0.20250825142932-2b3197aeaf9a h1:tfZmBt8xhjnAw1RB3NJoKGlznjZca1G47j1neSVb7Kw=
+github.com/trufnetwork/kwil-db v0.10.3-0.20250825142932-2b3197aeaf9a/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250820013721-26effaee3b2a h1:vewqh7xR1cIfIFATW+HwYhpCuLtUWbHH2R+Cr9ylCI4=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250820013721-26effaee3b2a/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250823041522-ec54fdc11d4f h1:IhNoF96yUQtKaqSUZ9AuWD0sxWbjAWnN7q1VzvB58A8=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250823041522-ec54fdc11d4f/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825094640-1d31b2785b9d h1:WzusG5mn00iCdNdhMYpi744sbgevQfRZaajjMMYIINM=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825094640-1d31b2785b9d/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825143650-0504e34154ce h1:N0eXGf6X7U7znKCTbQwmba3y8f8tqK2pUdQ69kL6ZJE=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825143650-0504e34154ce/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825142932-2b3197aeaf9a h1:quSev6rGDbxb2MfEdhGz/jisS0D/pNK4kwXxUv9g4+0=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825142932-2b3197aeaf9a/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2 h1:DCq8MzbWH0wZmICNmMVsSzUHUPl+2vqRhluEABjxl88=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2/go.mod h1:Y0MJpPp9QXU5vC6Gpoilql2NkgmGNcbHm9HYC2v2N8s=
 github.com/trufnetwork/sdk-go v0.3.2-0.20250630062504-841b40cdb709 h1:d9EqPXIjbq/atzEncK5dM3Z9oStx1BxCGuL/sjefeCw=

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,7 @@ github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZ
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaLENm+P+Tv+MfurjSw0=
+github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1 h1:FWNFq4fM1wPfcK40yHE5UO3RUdSNPaBC+j3PokzA6OQ=
 github.com/gocarina/gocsv v0.0.0-20240520201108-78e41c74b4b1/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-yaml v1.9.8/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=
@@ -950,6 +951,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
@@ -1006,7 +1008,6 @@ github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
-github.com/panjf2000/ants/v2 v2.10.0/go.mod h1:7ZxyxsqE4vvW0M7LSD8aI3cKwgFhBHbxnlN8mDqHa1I=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
 github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
@@ -1102,7 +1103,6 @@ github.com/quic-go/webtransport-go v0.8.1-0.20241018022711-4ac2c9250e66 h1:4WFk6
 github.com/quic-go/webtransport-go v0.8.1-0.20241018022711-4ac2c9250e66/go.mod h1:Vp72IJajgeOL6ddqrAhmp7IM9zbTcgkQxD/YdxrVwMw=
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
-github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -1212,24 +1212,8 @@ github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZ
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPDo=
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250820013721-26effaee3b2a h1:Sv15i++axBV/GPfkxh3DmbKbUEG/NcfxVIlBc+KZV6U=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250820013721-26effaee3b2a/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250823041522-ec54fdc11d4f h1:b6WLvfLK6UmltLfQg4Z3fxZiVEVRztSHA8gxhk3Wrbg=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250823041522-ec54fdc11d4f/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250825094640-1d31b2785b9d h1:EYmJgRoBkKjIaWXeJj1c8a1w5ShakEAx3hlYeEikfb8=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250825094640-1d31b2785b9d/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250825142932-2b3197aeaf9a h1:tfZmBt8xhjnAw1RB3NJoKGlznjZca1G47j1neSVb7Kw=
-github.com/trufnetwork/kwil-db v0.10.3-0.20250825142932-2b3197aeaf9a/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db v0.10.3-0.20250829040222-799cf48f758e h1:pfdGR7fw1v7C5A5DQc8CdR+ROV2yKaRpWLuT4W86zx8=
 github.com/trufnetwork/kwil-db v0.10.3-0.20250829040222-799cf48f758e/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250820013721-26effaee3b2a h1:vewqh7xR1cIfIFATW+HwYhpCuLtUWbHH2R+Cr9ylCI4=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250820013721-26effaee3b2a/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250823041522-ec54fdc11d4f h1:IhNoF96yUQtKaqSUZ9AuWD0sxWbjAWnN7q1VzvB58A8=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250823041522-ec54fdc11d4f/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825094640-1d31b2785b9d h1:WzusG5mn00iCdNdhMYpi744sbgevQfRZaajjMMYIINM=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825094640-1d31b2785b9d/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825142932-2b3197aeaf9a h1:quSev6rGDbxb2MfEdhGz/jisS0D/pNK4kwXxUv9g4+0=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20250825142932-2b3197aeaf9a/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250829040222-799cf48f758e h1:k0LKW2SdfBcJE2rpMrgWMR3xJojnS4wJPBOGEHB1Il4=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20250829040222-799cf48f758e/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2 h1:DCq8MzbWH0wZmICNmMVsSzUHUPl+2vqRhluEABjxl88=

--- a/internal/benchmark/digest/.gitignore
+++ b/internal/benchmark/digest/.gitignore
@@ -1,0 +1,2 @@
+# Benchmark results - these are generated files and should not be committed
+bench_results/

--- a/internal/benchmark/digest/constants.go
+++ b/internal/benchmark/digest/constants.go
@@ -16,15 +16,6 @@ const (
 
 	// HourSeconds is the number of seconds in an hour
 	HourSeconds = 3600
-
-	// DefaultDigestConfig holds default configuration values for the digest system
-	DefaultDigestConfig = `
-	{
-		"max_batch_size": 1000,
-		"auto_digest_enabled": true,
-		"prune_threshold_days": 30,
-		"batch_timeout_seconds": 300
-	}`
 )
 
 // Table names for digest operations
@@ -36,12 +27,6 @@ var (
 		"pending_prune_days",
 		"streams",
 	}
-
-	// CoreDigestTables contains the essential tables for digest functionality
-	CoreDigestTables = []string{
-		"primitive_events",
-		"pending_prune_days",
-	}
 )
 
 // Benchmark configuration constants
@@ -52,162 +37,17 @@ const (
 	// This matches the default value in the auto_digest SQL function
 	DefaultDeleteCap = 10000
 
-	// DeleteCapSmall is 1K - for testing small batch performance
-	DeleteCapSmall = 1000
-
-	// DeleteCapMedium is 10K - for testing medium batch performance
-	DeleteCapMedium = 10000
-
-	// DeleteCapLarge is 100K - for testing large batch performance
-	DeleteCapLarge = 100000
-
-	// DeleteCapXL is 1M - for testing extra large batch performance
-	DeleteCapXL = 1000000
-
 	// ProductionRecordsPerDay is the realistic number of records per day in production
 	ProductionRecordsPerDay = 24
 
 	// DefaultSamples is the default number of samples per benchmark case
 	DefaultSamples = 3
-
-	// DefaultTimeoutSeconds is the default timeout for benchmark operations
-	DefaultTimeoutSeconds = 300
-
-	// MaxWorkers is the maximum number of concurrent workers for data insertion
-	MaxWorkers = 50
-
-	// MaxConcurrency is the maximum concurrency level for sized wait group
-	MaxConcurrency = 10
-
-	// MemoryCheckInterval is the interval for memory usage checks
-	MemoryCheckInterval = 100 * 1024 * 1024 // 100MB
 )
 
 // Data generation patterns
 const (
-	// Pattern names for different data generation strategies
-	PatternRandom    = "random"
-	PatternDups50    = "dups50"
-	PatternMonotonic = "monotonic"
-	PatternEqual     = "equal"
-	PatternTimeDup   = "time_dup"
-)
-
-// File paths and extensions
-const (
-	// DefaultResultsPath is the default path for benchmark results
-	DefaultResultsPath = "benchmark_results.csv"
-
-	// DefaultSummaryPath is the default path for summary reports
-	DefaultSummaryPath = "benchmark_summary.md"
-
-	// DefaultStatsPath is the default path for statistical analysis reports
-	DefaultStatsPath = "statistical_analysis.md"
-
-	// CSVExtension is the file extension for CSV files
-	CSVExtension = ".csv"
-
-	// MarkdownExtension is the file extension for Markdown files
-	MarkdownExtension = ".md"
-
-	// ResultsFileSmoke is the default output file for smoke suite
-	ResultsFileSmoke = "./digest_smoke_results.csv"
-	// ResultsFileMedium is the default output file for medium suite
-	ResultsFileMedium = "./digest_medium_results.csv"
-	// ResultsFileExtreme is the default output file for extreme suite
-	ResultsFileExtreme = "./digest_extreme_results.csv"
-	// ResultsFileCustom is the default output file for custom suite
-	ResultsFileCustom = "./digest_custom_results.csv"
-)
-
-// Memory and resource limits
-const (
-	// MaxMemoryThreshold is the maximum memory usage threshold before warning
-	MaxMemoryThreshold = 1024 * 1024 * 1024 // 1GB
-
-	// WALGrowthThreshold is the maximum WAL growth threshold before warning
-	WALGrowthThreshold = 100 * 1024 * 1024 // 100MB
-)
-
-// Test configuration
-const (
-	// SmokeTestStreams is the number of streams for smoke tests
-	SmokeTestStreams = 2
-
-	// SmokeTestDays is the number of days per stream for smoke tests
-	SmokeTestDays = 1
-
-	// SmokeTestRecords is the number of records per day for smoke tests
-	SmokeTestRecords = 100
-
-	// MediumTestStreams is the number of streams for medium tests
-	MediumTestStreams = 5
-
-	// MediumTestDays is the number of days per stream for medium tests
-	MediumTestDays = 10
-
-	// MediumTestRecords is the number of records per day for medium tests
-	MediumTestRecords = 1000
-
-	// ExtremeTestStreams is the number of streams for extreme tests
-	ExtremeTestStreams = 20
-
-	// ExtremeTestDays is the number of days per stream for extreme tests
-	ExtremeTestDays = 50
-
-	// ExtremeTestRecords is the number of records per day for extreme tests
-	ExtremeTestRecords = 10000
-)
-
-// Pre-defined benchmark cases for different test suites
-var (
-	// SmokeTestCases defines the benchmark cases for smoke testing
-	// Quick tests with small data to verify basic functionality
-	SmokeTestCases = []DigestBenchmarkCase{
-		{Streams: 10, DaysPerStream: 1, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: DeleteCapSmall, Pattern: PatternRandom, Samples: 1}, // 1K cap - fast smoke test
-	}
-
-	// MediumTestCases defines test cases for medium-scale testing
-	// Tests delete cap variations (1K, 10K, 100K, 1M) with realistic production data
-	//
-	// IMPORTANT: The 25k streams × 12 days are NOT intended to test deleting all that data.
-	// They create a realistic environment with substantial data volume (~7.2M total records)
-	// to expose indexing and performance issues. The delete cap controls actual processing,
-	// giving us ~600k records/day for realistic medium-scale processing scenarios.
-	MediumTestCases = []DigestBenchmarkCase{
-		{Streams: 25000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: DeleteCapSmall, Pattern: PatternRandom, Samples: DefaultSamples},  // 1K cap - tests small batch performance (~600k records/day)
-		{Streams: 25000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: DeleteCapMedium, Pattern: PatternRandom, Samples: DefaultSamples}, // 10K cap - tests medium batch performance (~600k records/day)
-		{Streams: 25000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: DeleteCapLarge, Pattern: PatternRandom, Samples: DefaultSamples},  // 100K cap - tests large batch performance (~600k records/day)
-		{Streams: 25000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: DeleteCapXL, Pattern: PatternRandom, Samples: DefaultSamples},     // 1M cap - tests extra large batch performance (~600k records/day)
-	}
-
-	// BigTestCases defines test cases for big-scale testing
-	// Tests delete cap behavior at big scales with large datasets
-	//
-	// IMPORTANT: The 50k streams × 12 days are NOT intended to test deleting all that data.
-	// They create a big environment to stress-test the system and expose performance
-	// issues that only appear at scale. The delete cap controls actual processing,
-	// giving us ~1.2M records/day for realistic large-scale processing scenarios.
-	BigTestCases = []DigestBenchmarkCase{
-		{Streams: 50000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: DeleteCapSmall, Pattern: PatternRandom, Samples: 2},  // 1K cap - tests small batch with big data (~1.2M records/day)
-		{Streams: 50000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: DeleteCapMedium, Pattern: PatternRandom, Samples: 2}, // 10K cap - tests medium batch with big data (~1.2M records/day)
-		{Streams: 50000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: DeleteCapLarge, Pattern: PatternRandom, Samples: 2},  // 100K cap - tests large batch with big data (~1.2M records/day)
-		{Streams: 50000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: DeleteCapXL, Pattern: PatternRandom, Samples: 2},     // 1M cap - tests extra large batch with big data (~1.2M records/day)
-	}
-)
-
-// Env & configuration keys
-const (
-	// EnvPrefixDigest is the environment variables prefix for custom config
-	EnvPrefixDigest = "DIGEST_"
-
-	EnvKeyStreams = "streams"
-	EnvKeyDays    = "days"
-	EnvKeyRecords = "records"
-
-	EnvKeyPatterns = "patterns"
-	EnvKeySamples  = "samples"
-	EnvKeyResults  = "results_path"
+	// PatternRandom is the primary data generation pattern used in benchmarks
+	PatternRandom = "random"
 )
 
 // Common SQL queries

--- a/internal/benchmark/digest/constants.go
+++ b/internal/benchmark/digest/constants.go
@@ -48,8 +48,8 @@ var (
 const (
 	InsertBatchSize = 100000
 
-	// DefaultDeleteCap is the default maximum number of rows that can be deleted in a single batch_digest call
-	// This matches the default value in the batch_digest SQL function
+	// DefaultDeleteCap is the default maximum number of rows that can be deleted in a single auto_digest call
+	// This matches the default value in the auto_digest SQL function
 	DefaultDeleteCap = 10000
 
 	// DeleteCapSmall is 1K - for testing small batch performance

--- a/internal/benchmark/digest/constants.go
+++ b/internal/benchmark/digest/constants.go
@@ -46,7 +46,7 @@ var (
 
 // Benchmark configuration constants
 const (
-	InsertBatchSize = 100000
+	InsertBatchSize = 20000
 
 	// DefaultDeleteCap is the default maximum number of rows that can be deleted in a single auto_digest call
 	// This matches the default value in the auto_digest SQL function

--- a/internal/benchmark/digest/constants.go
+++ b/internal/benchmark/digest/constants.go
@@ -1,0 +1,193 @@
+package digest
+
+// Database and system constants
+const (
+	// DockerPostgresContainer is the name of the PostgreSQL container for memory monitoring
+	DockerPostgresContainer = "kwil-testing-postgres"
+
+	// DefaultSchema is the database schema used for fully qualifying tables
+	DefaultSchema = "main"
+
+	// DefaultDataProviderAddress is the fallback address used in tests and benchmarks
+	DefaultDataProviderAddress = "0x1234567890123456789012345678901234567890"
+
+	// DaySeconds is the number of seconds in a day
+	DaySeconds = 86400
+
+	// HourSeconds is the number of seconds in an hour
+	HourSeconds = 3600
+
+	// DefaultDigestConfig holds default configuration values for the digest system
+	DefaultDigestConfig = `
+	{
+		"max_batch_size": 1000,
+		"auto_digest_enabled": true,
+		"prune_threshold_days": 30,
+		"batch_timeout_seconds": 300
+	}`
+)
+
+// Table names for digest operations
+var (
+	// DigestTables contains all table names relevant to digest operations
+	DigestTables = []string{
+		"primitive_events",
+		"primitive_event_type",
+		"pending_prune_days",
+		"streams",
+	}
+
+	// CoreDigestTables contains the essential tables for digest functionality
+	CoreDigestTables = []string{
+		"primitive_events",
+		"pending_prune_days",
+	}
+)
+
+// Benchmark configuration constants
+const (
+	// DefaultBatchSize is the default batch size for digest operations
+	// Increased from 1000 to 5000 to reduce GC pressure from array copies
+	DefaultBatchSize = 5000
+
+	// DefaultSamples is the default number of samples per benchmark case
+	DefaultSamples = 3
+
+	// DefaultTimeoutSeconds is the default timeout for benchmark operations
+	DefaultTimeoutSeconds = 300
+
+	// MaxWorkers is the maximum number of concurrent workers for data insertion
+	MaxWorkers = 50
+
+	// MaxConcurrency is the maximum concurrency level for sized wait group
+	MaxConcurrency = 10
+
+	// MemoryCheckInterval is the interval for memory usage checks
+	MemoryCheckInterval = 100 * 1024 * 1024 // 100MB
+)
+
+// Data generation patterns
+const (
+	// Pattern names for different data generation strategies
+	PatternRandom    = "random"
+	PatternDups50    = "dups50"
+	PatternMonotonic = "monotonic"
+	PatternEqual     = "equal"
+	PatternTimeDup   = "time_dup"
+)
+
+// File paths and extensions
+const (
+	// DefaultResultsPath is the default path for benchmark results
+	DefaultResultsPath = "benchmark_results.csv"
+
+	// DefaultSummaryPath is the default path for summary reports
+	DefaultSummaryPath = "benchmark_summary.md"
+
+	// DefaultStatsPath is the default path for statistical analysis reports
+	DefaultStatsPath = "statistical_analysis.md"
+
+	// CSVExtension is the file extension for CSV files
+	CSVExtension = ".csv"
+
+	// MarkdownExtension is the file extension for Markdown files
+	MarkdownExtension = ".md"
+
+	// ResultsFileSmoke is the default output file for smoke suite
+	ResultsFileSmoke = "./digest_smoke_results.csv"
+	// ResultsFileMedium is the default output file for medium suite
+	ResultsFileMedium = "./digest_medium_results.csv"
+	// ResultsFileExtreme is the default output file for extreme suite
+	ResultsFileExtreme = "./digest_extreme_results.csv"
+	// ResultsFileCustom is the default output file for custom suite
+	ResultsFileCustom = "./digest_custom_results.csv"
+)
+
+// Memory and resource limits
+const (
+	// MaxMemoryThreshold is the maximum memory usage threshold before warning
+	MaxMemoryThreshold = 1024 * 1024 * 1024 // 1GB
+
+	// WALGrowthThreshold is the maximum WAL growth threshold before warning
+	WALGrowthThreshold = 100 * 1024 * 1024 // 100MB
+)
+
+// Test configuration
+const (
+	// SmokeTestStreams is the number of streams for smoke tests
+	SmokeTestStreams = 2
+
+	// SmokeTestDays is the number of days per stream for smoke tests
+	SmokeTestDays = 1
+
+	// SmokeTestRecords is the number of records per day for smoke tests
+	SmokeTestRecords = 100
+
+	// MediumTestStreams is the number of streams for medium tests
+	MediumTestStreams = 5
+
+	// MediumTestDays is the number of days per stream for medium tests
+	MediumTestDays = 10
+
+	// MediumTestRecords is the number of records per day for medium tests
+	MediumTestRecords = 1000
+
+	// ExtremeTestStreams is the number of streams for extreme tests
+	ExtremeTestStreams = 20
+
+	// ExtremeTestDays is the number of days per stream for extreme tests
+	ExtremeTestDays = 50
+
+	// ExtremeTestRecords is the number of records per day for extreme tests
+	ExtremeTestRecords = 10000
+)
+
+// Pre-defined benchmark cases for different test suites
+var (
+	// SmokeTestCases defines the benchmark cases for smoke testing
+	SmokeTestCases = []DigestBenchmarkCase{
+		{Streams: 100, DaysPerStream: 1, RecordsPerDay: 50, BatchSize: 50, Pattern: PatternRandom, Samples: 1},
+		{Streams: 1000, DaysPerStream: 1, RecordsPerDay: 50, BatchSize: 50, Pattern: PatternRandom, Samples: 1},
+		{Streams: 10000, DaysPerStream: 1, RecordsPerDay: 50, BatchSize: 50, Pattern: PatternRandom, Samples: 1},
+	}
+
+	// MediumTestCases defines the benchmark cases for medium-scale testing
+	MediumTestCases = []DigestBenchmarkCase{
+		{Streams: 10000, DaysPerStream: 1, RecordsPerDay: 2, BatchSize: 100, Pattern: PatternRandom, Samples: DefaultSamples},
+		{Streams: 10000, DaysPerStream: 1, RecordsPerDay: 2, BatchSize: 500, Pattern: PatternRandom, Samples: DefaultSamples},
+		{Streams: 10000, DaysPerStream: 1, RecordsPerDay: 2, BatchSize: 1000, Pattern: PatternRandom, Samples: DefaultSamples},
+		{Streams: 10000, DaysPerStream: 30, RecordsPerDay: 2, BatchSize: 500, Pattern: PatternRandom, Samples: DefaultSamples},
+		{Streams: 10000, DaysPerStream: 1, RecordsPerDay: 50, BatchSize: 1000, Pattern: PatternRandom, Samples: DefaultSamples},
+	}
+
+	// ExtremeTestCases defines the benchmark cases for extreme-scale testing
+	ExtremeTestCases = []DigestBenchmarkCase{
+		{Streams: 100000, DaysPerStream: 1, RecordsPerDay: 4, BatchSize: 200, Pattern: PatternRandom, Samples: 2},
+		{Streams: 100000, DaysPerStream: 30, RecordsPerDay: 4, BatchSize: 200, Pattern: PatternRandom, Samples: 2},
+		{Streams: 100000, DaysPerStream: 90, RecordsPerDay: 4, BatchSize: 200, Pattern: PatternRandom, Samples: 2},
+	}
+)
+
+// Env & configuration keys
+const (
+	// EnvPrefixDigest is the environment variables prefix for custom config
+	EnvPrefixDigest = "DIGEST_"
+
+	EnvKeyStreams    = "streams"
+	EnvKeyDays       = "days"
+	EnvKeyRecords    = "records"
+	EnvKeyBatchSizes = "batch_sizes"
+	EnvKeyPatterns   = "patterns"
+	EnvKeySamples    = "samples"
+	EnvKeyResults    = "results_path"
+)
+
+// Common SQL queries
+const (
+	SQLCountPendingPruneDays   = "SELECT COUNT(*) FROM pending_prune_days"
+	SQLCountPrimitiveEvents    = "SELECT COUNT(*) FROM primitive_events"
+	SQLCountPrimitiveEventType = "SELECT COUNT(*) FROM primitive_event_type"
+
+	SQLWalGetLSN = "SELECT pg_current_wal_insert_lsn()::text"
+	SQLWalDiff   = "SELECT pg_wal_lsn_diff($after_lsn, $before_lsn)"
+)

--- a/internal/benchmark/digest/digest_benchmark_test.go
+++ b/internal/benchmark/digest/digest_benchmark_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
+	"path/filepath"
 	"testing"
 
 	kwilTesting "github.com/trufnetwork/kwil-db/testing"
 	utils "github.com/trufnetwork/node/tests/streams/utils"
 	"github.com/trufnetwork/node/tests/streams/utils/procedure"
 	"github.com/trufnetwork/sdk-go/core/util"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/trufnetwork/node/internal/migrations"
 )
@@ -146,7 +148,7 @@ func createBenchmarkSuiteFunc(t *testing.T, scale DigestBenchmarkScale) func(con
 		if err := SaveDigestResultsCSV(allResults, outputFile); err != nil {
 			t.Logf("Warning: failed to save results to %s: %v", outputFile, err)
 		} else {
-			t.Logf("%s test results saved to %s", strings.Title(scale.Name), outputFile)
+			t.Logf("%s test results saved to %s", cases.Title(language.English).String(scale.Name), outputFile)
 		}
 
 		// Create summary report
@@ -157,7 +159,7 @@ func createBenchmarkSuiteFunc(t *testing.T, scale DigestBenchmarkScale) func(con
 			t.Logf("Summary report created at %s", summaryFile)
 		}
 
-		t.Logf("%s test completed successfully - processed %d total results", strings.Title(scale.Name), len(allResults))
+		t.Logf("%s test completed successfully - processed %d total results", cases.Title(language.English).String(scale.Name), len(allResults))
 		return nil
 	}
 }
@@ -343,8 +345,8 @@ func TestDigestCSVExport(t *testing.T) {
 	}
 
 	// Test CSV export
-	tempFile := "/tmp/test_digest_results.csv"
-	defer os.Remove(tempFile)
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "test_digest_results.csv")
 
 	if err := SaveDigestResultsCSV(results, tempFile); err != nil {
 		t.Fatalf("Failed to save CSV: %v", err)
@@ -408,8 +410,9 @@ func TestDigestMarkdownExport(t *testing.T) {
 		},
 	}
 
-	// Test markdown export to bench_results directory
-	summaryFile := "bench_results/test_markdown_summary.md"
+	// Test markdown export to temp directory
+	tempDir := t.TempDir()
+	summaryFile := filepath.Join(tempDir, "test_markdown_summary.md")
 	if err := ExportResultsSummary(results, summaryFile); err != nil {
 		t.Fatalf("Failed to export markdown summary: %v", err)
 	}

--- a/internal/benchmark/digest/digest_benchmark_test.go
+++ b/internal/benchmark/digest/digest_benchmark_test.go
@@ -191,8 +191,8 @@ func testDigestMediumSuite(t *testing.T) func(ctx context.Context, platform *kwi
 		// 1) Global setup ONCE with maximum streams (superset for all cases)
 		// Use the case with the most streams as our global setup
 		maxStreamsCase := DigestBenchmarkCase{
-			Streams:       10000,                   // Maximum streams needed for delete cap tests
-			DaysPerStream: 30,                      // Maximum days needed
+			Streams:       25000,                   // Maximum streams needed for MediumTestCases (25k streams)
+			DaysPerStream: 12,                      // Match MediumTestCases days
 			RecordsPerDay: ProductionRecordsPerDay, // Production records per day
 
 			DeleteCap: DefaultDeleteCap,

--- a/internal/benchmark/digest/digest_benchmark_test.go
+++ b/internal/benchmark/digest/digest_benchmark_test.go
@@ -4,13 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/knadh/koanf/providers/env"
-	"github.com/knadh/koanf/v2"
 	kwilTesting "github.com/trufnetwork/kwil-db/testing"
 	utils "github.com/trufnetwork/node/tests/streams/utils"
 	"github.com/trufnetwork/node/tests/streams/utils/procedure"
@@ -19,70 +15,161 @@ import (
 	"github.com/trufnetwork/node/internal/migrations"
 )
 
+// DigestBenchmarkScale defines the configuration for different benchmark scales.
+// - exact_fit: Measures optimal performance when data volume matches delete cap exactly (10K/100K caps)
+// - with_excess: Tests real-world scenarios with excess data, detecting indexing/algorithmic issues (1K/10K/100K caps)
+//
+// Uses TestCases[0].RecordsPerDay for setup data generation (eliminates SetupRecords redundancy)
+type DigestBenchmarkScale struct {
+	Name         string
+	Description  string
+	SetupStreams int
+	SetupDays    int
+	TestCases    []DigestBenchmarkCase // RecordsPerDay from first test case used for setup
+}
+
+// Benchmark scale configurations - kept DRY in a single location for easy maintenance
+var benchmarkScales = map[string]DigestBenchmarkScale{
+	"smoke": {
+		Name:         "smoke",
+		Description:  "fastest test suite for basic validation",
+		SetupStreams: 5,
+		SetupDays:    1,
+		TestCases: []DigestBenchmarkCase{
+			{Streams: 2, DaysPerStream: 1, RecordsPerDay: 2, DeleteCap: 1000, Pattern: PatternRandom, Samples: 1},
+			{Streams: 3, DaysPerStream: 1, RecordsPerDay: 2, DeleteCap: 1000, Pattern: PatternRandom, Samples: 1},
+		},
+	},
+	"exact_fit": {
+		Name:         "exact_fit",
+		Description:  "exact fit testing - data volume matches delete cap exactly",
+		SetupStreams: 200,
+		SetupDays:    1,
+		TestCases: []DigestBenchmarkCase{
+			{Streams: 200, DaysPerStream: 1, RecordsPerDay: 500, DeleteCap: 10000, Pattern: PatternRandom, Samples: 3, IdempotencyCheck: true},
+			{Streams: 200, DaysPerStream: 1, RecordsPerDay: 500, DeleteCap: 100000, Pattern: PatternRandom, Samples: 3, IdempotencyCheck: true},
+		},
+	},
+	"with_excess": {
+		Name:         "with_excess",
+		Description:  "excess data testing - measures performance with more data than processed",
+		SetupStreams: 25000,
+		SetupDays:    12,
+		TestCases: []DigestBenchmarkCase{
+			{Streams: 25000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: 1000, Pattern: PatternRandom, Samples: DefaultSamples},   // 1K cap - tests small batch performance (~600k records/day)
+			{Streams: 25000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: 10000, Pattern: PatternRandom, Samples: DefaultSamples},  // 10K cap - tests medium batch performance (~600k records/day)
+			{Streams: 25000, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: 100000, Pattern: PatternRandom, Samples: DefaultSamples}, // 100K cap - tests large batch performance (~600k records/day)
+		},
+	},
+}
+
 // TestBenchDigest_Smoke runs the smoke test suite for basic digest functionality validation.
 // This is the fastest test suite, focusing on core functionality rather than performance.
+// IDE will show individual run gutter for this test.
 func TestBenchDigest_Smoke(t *testing.T) {
-	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
-		Name:        "digest_benchmark_smoke",
-		SeedScripts: migrations.GetSeedScriptPaths(),
-		FunctionTests: []kwilTesting.TestFunc{
-			WithDigestBenchmarkSetup(testDigestSmokeSuite(t)),
-		},
-	}, utils.GetTestOptions())
+	runDigestBenchmarkScale(t, benchmarkScales["smoke"])
 }
 
-// TestBenchDigest_Medium runs the medium test suite for scaling analysis.
-// This tests performance characteristics across different scales.
-// Uses delete cap focused approach with realistic dataset to expose indexing issues.
-func TestBenchDigest_Medium(t *testing.T) {
-	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
-		Name:        "digest_benchmark_medium",
-		SeedScripts: migrations.GetSeedScriptPaths(),
-		FunctionTests: []kwilTesting.TestFunc{
-			WithDigestBenchmarkSetup(testDigestMediumSuite(t)),
-		},
-	}, utils.GetTestOptions())
+// TestBenchDigest_ExactFit runs the exact fit test suite.
+// Measures performance when data volume matches delete cap exactly (optimal scenarios).
+// IDE will show individual run gutter for this test.
+func TestBenchDigest_ExactFit(t *testing.T) {
+	runDigestBenchmarkScale(t, benchmarkScales["exact_fit"])
 }
 
-// TestBenchDigest_Big runs the big test suite for stress testing.
-// This tests maximum scale performance with large data sets.
-// Uses delete cap focused approach with big dataset to expose scaling limits.
-func TestBenchDigest_Big(t *testing.T) {
-	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
-		Name:        "digest_benchmark_big",
-		SeedScripts: migrations.GetSeedScriptPaths(),
-		FunctionTests: []kwilTesting.TestFunc{
-			WithDigestBenchmarkSetup(testDigestBigSuite(t)),
-		},
-	}, utils.GetTestOptions())
+// TestBenchDigest_WithExcess runs the with excess test suite.
+// Tests performance with excess data beyond processing capacity (real-world scenarios).
+// IDE will show individual run gutter for this test.
+func TestBenchDigest_WithExcess(t *testing.T) {
+	runDigestBenchmarkScale(t, benchmarkScales["with_excess"])
 }
 
-// TestBenchDigest_Custom runs a custom test suite based on environment variables.
-// This allows for flexible test configuration without code changes.
-func TestBenchDigest_Custom(t *testing.T) {
-	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
-		Name:        "digest_benchmark_custom",
-		SeedScripts: migrations.GetSeedScriptPaths(),
-		FunctionTests: []kwilTesting.TestFunc{
-			WithDigestBenchmarkSetup(testDigestCustomSuite(t)),
-		},
-	}, utils.GetTestOptions())
+// createBenchmarkSuiteFunc creates a benchmark suite function for the given scale.
+// All scales now use consistent delete cap behavior with runCaseWithDeleteCap.
+func createBenchmarkSuiteFunc(t *testing.T, scale DigestBenchmarkScale) func(context.Context, *kwilTesting.Platform) error {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		if len(scale.TestCases) == 0 {
+			t.Fatalf("Scale %s has no test cases defined", scale.Name)
+		}
+
+		testCases := scale.TestCases
+		setupRecords := scale.TestCases[0].RecordsPerDay
+
+		// Provide scale-specific context in logging
+		switch scale.Name {
+		case "smoke":
+			t.Logf("Running smoke test suite with delete cap variations (%d cases)", len(testCases))
+			t.Logf("Focus: Fast validation of basic digest functionality")
+		case "exact_fit":
+			t.Logf("Running exact_fit test suite with delete cap variations (%d cases)", len(testCases))
+			t.Logf("Focus: Delete cap behavior when data volume matches processing capacity exactly")
+		case "with_excess":
+			t.Logf("Running with_excess test suite with delete cap variations (%d cases)", len(testCases))
+			t.Logf("Focus: Delete cap behavior (1K/10K/100K) with excess data to detect indexing/algorithmic issues")
+		}
+
+		// Setup data generation for all test cases
+		setupCase := DigestBenchmarkCase{
+			Streams:       scale.SetupStreams,
+			DaysPerStream: scale.SetupDays,
+			RecordsPerDay: setupRecords,
+			Pattern:       PatternRandom,
+			Samples:       1,
+		}
+
+		setupInput := DigestSetupInput{Platform: platform, Case: setupCase}
+		if err := SetupBenchmarkData(ctx, setupInput); err != nil {
+			return fmt.Errorf("global setup failed: %w", err)
+		}
+
+		// Run each test case in a transaction using consistent delete cap behavior
+		results := make(map[string][]DigestRunResult)
+		for i, testCase := range testCases {
+			t.Logf("Running %s case %d/%d with delete_cap=%d", scale.Name, i+1, len(testCases), testCase.DeleteCap)
+
+			if err := runCaseWithDeleteCap(ctx, platform, testCase, func(txPlatform *kwilTesting.Platform, caseResults []DigestRunResult) {
+				caseKey := fmt.Sprintf("streams_%d_days_%d_records_%d_deletecap_%d_pattern_%s",
+					testCase.Streams, testCase.DaysPerStream, testCase.RecordsPerDay, testCase.DeleteCap, testCase.Pattern)
+				results[caseKey] = caseResults
+			}); err != nil {
+				return fmt.Errorf("failed to run %s case %d (delete_cap=%d): %w", scale.Name, i, testCase.DeleteCap, err)
+			}
+		}
+
+		// Collect and export results
+		var allResults []DigestRunResult
+		for _, caseResults := range results {
+			allResults = append(allResults, caseResults...)
+		}
+
+		outputFile := fmt.Sprintf("digest_%s_results.csv", scale.Name)
+		if err := SaveDigestResultsCSV(allResults, outputFile); err != nil {
+			t.Logf("Warning: failed to save results to %s: %v", outputFile, err)
+		} else {
+			t.Logf("%s test results saved to %s", strings.Title(scale.Name), outputFile)
+		}
+
+		// Create summary report
+		summaryFile := strings.Replace(outputFile, ".csv", "_summary.md", 1)
+		if err := ExportResultsSummary(allResults, summaryFile); err != nil {
+			t.Logf("Warning: failed to create summary report: %v", err)
+		} else {
+			t.Logf("Summary report created at %s", summaryFile)
+		}
+
+		t.Logf("%s test completed successfully - processed %d total results", strings.Title(scale.Name), len(allResults))
+		return nil
+	}
 }
 
-// TestBenchDigest_DeleteCap runs the delete cap focused test suite.
-// This creates maximum streams once and tests different delete cap values under transactions.
-//
-// PURPOSE: The large dataset (25k streams × 12 days × 24 records/day) creates a realistic
-// production-like environment that exposes indexing and performance issues. The delete
-// cap parameter (1K, 10K, 100K, 1M) is what actually controls the processing volume, allowing
-// us to measure how the system performs with different batch sizes while maintaining
-// realistic data distribution patterns that match production usage (~600k records/day).
-func TestBenchDigest_DeleteCap(t *testing.T) {
+// runDigestBenchmarkScale runs a specific benchmark scale.
+// This is the core function that handles all benchmark execution logic.
+func runDigestBenchmarkScale(t *testing.T, scale DigestBenchmarkScale) {
 	kwilTesting.RunSchemaTest(t, kwilTesting.SchemaTest{
-		Name:        "digest_benchmark_delete_cap",
+		Name:        fmt.Sprintf("digest_benchmark_%s", scale.Name),
 		SeedScripts: migrations.GetSeedScriptPaths(),
 		FunctionTests: []kwilTesting.TestFunc{
-			WithDigestBenchmarkSetup(testDigestDeleteCapSuite(t)),
+			WithDigestBenchmarkSetup(createBenchmarkSuiteFunc(t, scale)),
 		},
 	}, utils.GetTestOptions())
 }
@@ -103,415 +190,6 @@ func WithDigestBenchmarkSetup(testFn func(ctx context.Context, platform *kwilTes
 		// This wrapper only sets up the platform environment
 
 		return testFn(ctx, platform)
-	}
-}
-
-// testDigestSmokeSuite runs the smoke test cases for basic validation.
-func testDigestSmokeSuite(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
-	return func(ctx context.Context, platform *kwilTesting.Platform) error {
-		runner := NewBenchmarkRunner(platform, t)
-
-		// Use very small test cases for fast smoke test
-		smokeCases := []DigestBenchmarkCase{
-			{Streams: 2, DaysPerStream: 1, RecordsPerDay: 2, DeleteCap: DefaultDeleteCap, Pattern: PatternRandom, Samples: 1},
-			{Streams: 3, DaysPerStream: 1, RecordsPerDay: 2, DeleteCap: DefaultDeleteCap, Pattern: PatternRandom, Samples: 1},
-		}
-
-		t.Logf("Running smoke test suite with %d cases", len(smokeCases))
-
-		// Setup minimal benchmark data for smoke tests
-		t.Logf("Setting up benchmark data...")
-		setupStart := time.Now()
-
-		setupCase := DigestBenchmarkCase{
-			Streams:       5, // Very small for fast smoke test
-			DaysPerStream: 1, // Single day
-			RecordsPerDay: 5, // Very few records
-
-			DeleteCap: DefaultDeleteCap,
-			Pattern:   PatternRandom,
-			Samples:   1,
-		}
-		setupInput := DigestSetupInput{
-			Platform: platform,
-			Case:     setupCase,
-		}
-
-		if err := SetupBenchmarkData(ctx, setupInput); err != nil {
-			return fmt.Errorf("failed to setup benchmark data: %w", err)
-		}
-
-		setupDuration := time.Since(setupStart)
-		t.Logf("Benchmark data setup completed in %v", setupDuration)
-
-		// Run benchmark cases
-		t.Logf("Running benchmark cases...")
-		benchmarkStart := time.Now()
-
-		results, err := runner.RunMultipleCases(ctx, smokeCases)
-		if err != nil {
-			return fmt.Errorf("smoke test suite failed: %w", err)
-		}
-
-		benchmarkDuration := time.Since(benchmarkStart)
-		t.Logf("Benchmark execution completed in %v", benchmarkDuration)
-
-		// Export results
-		t.Logf("Exporting results...")
-		var allResults []DigestRunResult
-		for _, caseResults := range results {
-			allResults = append(allResults, caseResults...)
-		}
-
-		outputFile := ResultsFileSmoke
-		if err := SaveDigestResultsCSV(allResults, outputFile); err != nil {
-			t.Logf("Warning: failed to save results to %s: %v", outputFile, err)
-		} else {
-			t.Logf("Smoke test results saved to %s", outputFile)
-		}
-
-		// Log summary
-		totalDuration := time.Since(setupStart)
-		t.Logf("Smoke test completed successfully - processed %d total results in %v", len(allResults), totalDuration)
-
-		return nil
-	}
-}
-
-// testDigestMediumSuite runs the medium test cases for scaling analysis.
-func testDigestMediumSuite(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
-	return func(ctx context.Context, platform *kwilTesting.Platform) error {
-		// Use medium-scale test cases
-		mediumCases := MediumTestCases
-
-		t.Logf("Running medium test suite with delete cap variations (%d cases)", len(mediumCases))
-		t.Logf("This suite creates maximum streams once and tests delete cap variations under transactions")
-		t.Logf("Focus: Delete cap behavior (1K/10K/100K/1M) with realistic data volume for indexing performance testing")
-
-		// 1) Global setup ONCE with maximum streams (superset for all cases)
-		// Use the case with the most streams as our global setup
-		maxStreamsCase := DigestBenchmarkCase{
-			Streams:       25000,                   // Maximum streams needed for MediumTestCases (25k streams)
-			DaysPerStream: 12,                      // Match MediumTestCases days
-			RecordsPerDay: ProductionRecordsPerDay, // Production records per day
-
-			DeleteCap: DefaultDeleteCap,
-			Pattern:   PatternRandom,
-			Samples:   1,
-		}
-		t.Logf("Performing global setup with superset: %+v", maxStreamsCase)
-		if err := SetupBenchmarkData(ctx, DigestSetupInput{Platform: platform, Case: maxStreamsCase}); err != nil {
-			return fmt.Errorf("global setup failed: %w", err)
-		}
-
-		// 2) Per-case execution inside a transaction with different delete caps
-		results := make(map[string][]DigestRunResult)
-		for i, testCase := range mediumCases {
-			t.Logf("Running medium case %d/%d with delete_cap=%d: %+v", i+1, len(mediumCases), testCase.DeleteCap, testCase)
-
-			if err := runCaseWithDeleteCap(ctx, platform, testCase, func(txPlatform *kwilTesting.Platform, caseResults []DigestRunResult) {
-				caseKey := fmt.Sprintf("streams_%d_days_%d_records_%d_deletecap_%d_pattern_%s",
-					testCase.Streams, testCase.DaysPerStream, testCase.RecordsPerDay, testCase.DeleteCap, testCase.Pattern)
-				results[caseKey] = caseResults
-			}); err != nil {
-				return fmt.Errorf("failed to run medium case %d: %w", i, err)
-			}
-		}
-
-		// Export results
-		var allResults []DigestRunResult
-		for _, caseResults := range results {
-			allResults = append(allResults, caseResults...)
-		}
-
-		outputFile := ResultsFileMedium
-		if err := SaveDigestResultsCSV(allResults, outputFile); err != nil {
-			t.Logf("Warning: failed to save results to %s: %v", outputFile, err)
-		} else {
-			t.Logf("Medium test results saved to %s", outputFile)
-		}
-
-		// Create summary report
-		summaryFile := strings.Replace(outputFile, ".csv", "_summary.md", 1)
-		if err := ExportResultsSummary(allResults, summaryFile); err != nil {
-			t.Logf("Warning: failed to create summary report: %v", err)
-		} else {
-			t.Logf("Summary report created at %s", summaryFile)
-		}
-
-		t.Logf("Medium test completed successfully - processed %d total results", len(allResults))
-
-		return nil
-	}
-}
-
-// testDigestBigSuite runs the big test cases for stress testing.
-func testDigestBigSuite(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
-	return func(ctx context.Context, platform *kwilTesting.Platform) error {
-		// Use big-scale test cases
-		bigCases := BigTestCases
-
-		t.Logf("Running big test suite with delete cap variations (%d cases)", len(bigCases))
-		t.Logf("Warning: Big tests may take significant time and resources")
-		t.Logf("This suite creates maximum streams once and tests delete cap variations under transactions")
-		t.Logf("Strategy: Large dataset exposes scaling issues, delete cap (1K/10K/100K/1M) controls actual processing volume")
-
-		// 1) Global setup ONCE with maximum streams (superset for all cases)
-		// This big dataset creates the most challenging environment to expose
-		// performance and scaling issues that only appear at production scale.
-		// The delete cap (not the total data size) controls actual deletion volume.
-		maxStreamsCase := DigestBenchmarkCase{
-			Streams:       50000,                   // Scaled down for manageability while maintaining big conditions
-			DaysPerStream: 60,                      // Long history to test temporal query patterns
-			RecordsPerDay: ProductionRecordsPerDay, // Production-like data density (24 records/day)
-
-			DeleteCap: DefaultDeleteCap, // This will be overridden per test case
-			Pattern:   PatternRandom,
-			Samples:   1,
-		}
-		t.Logf("Performing global setup with superset: %+v", maxStreamsCase)
-		t.Logf("Note: Big dataset tests system limits, but delete cap controls actual processing volume")
-		if err := SetupBenchmarkData(ctx, DigestSetupInput{Platform: platform, Case: maxStreamsCase}); err != nil {
-			return fmt.Errorf("global setup failed: %w", err)
-		}
-
-		// 2) Per-case execution inside a transaction with different delete caps
-		results := make(map[string][]DigestRunResult)
-		for i, testCase := range bigCases {
-			t.Logf("Running big case %d/%d with delete_cap=%d: %+v", i+1, len(bigCases), testCase.DeleteCap, testCase)
-
-			if err := runCaseWithDeleteCap(ctx, platform, testCase, func(txPlatform *kwilTesting.Platform, caseResults []DigestRunResult) {
-				caseKey := fmt.Sprintf("streams_%d_days_%d_records_%d_deletecap_%d_pattern_%s",
-					testCase.Streams, testCase.DaysPerStream, testCase.RecordsPerDay, testCase.DeleteCap, testCase.Pattern)
-				results[caseKey] = caseResults
-			}); err != nil {
-				return fmt.Errorf("failed to run big case %d: %w", i, err)
-			}
-		}
-
-		// Export results
-		var allResults []DigestRunResult
-		for _, caseResults := range results {
-			allResults = append(allResults, caseResults...)
-		}
-
-		outputFile := "digest_big_results.csv"
-		if err := SaveDigestResultsCSV(allResults, outputFile); err != nil {
-			t.Logf("Warning: failed to save results to %s: %v", outputFile, err)
-		} else {
-			t.Logf("Big test results saved to %s", outputFile)
-		}
-
-		// Create summary report
-		summaryFile := strings.Replace(outputFile, ".csv", "_summary.md", 1)
-		if err := ExportResultsSummary(allResults, summaryFile); err != nil {
-			t.Logf("Warning: failed to create summary report: %v", err)
-		} else {
-			t.Logf("Summary report created at %s", summaryFile)
-		}
-
-		t.Logf("Big test completed successfully - processed %d total results", len(allResults))
-
-		return nil
-	}
-}
-
-// CustomBenchmarkConfig holds configuration for custom benchmark runs.
-type CustomBenchmarkConfig struct {
-	Streams []int `koanf:"streams"`
-	Days    []int `koanf:"days"`
-	Records []int `koanf:"records"`
-
-	Patterns    []string `koanf:"patterns"`
-	Samples     int      `koanf:"samples"`
-	ResultsPath string   `koanf:"results_path"`
-}
-
-// DefaultCustomConfig returns the default configuration for custom benchmarks.
-func DefaultCustomConfig() CustomBenchmarkConfig {
-	return CustomBenchmarkConfig{
-		Streams: []int{100, 1000, 10000},
-		Days:    []int{1, 30},
-		Records: []int{2, 50},
-
-		Patterns:    []string{"random", "dups50", "monotonic"},
-		Samples:     3,
-		ResultsPath: ResultsFileCustom,
-	}
-}
-
-// LoadCustomConfig loads benchmark configuration from environment variables using koanf.
-func LoadCustomConfig() (CustomBenchmarkConfig, error) {
-	k := koanf.New(".")
-
-	// Load default configuration
-	config := DefaultCustomConfig()
-
-	// Override with environment variables
-	if err := k.Load(env.Provider(EnvPrefixDigest, ".", func(s string) string {
-		// Convert DIGEST_STREAMS -> streams, etc.
-		return strings.ToLower(strings.TrimPrefix(s, EnvPrefixDigest))
-	}), nil); err != nil {
-		return config, fmt.Errorf("error loading env config: %w", err)
-	}
-
-	// Parse comma-separated integer lists
-	if streamsStr := k.String(EnvKeyStreams); streamsStr != "" {
-		if streams, err := parseIntList(streamsStr); err != nil {
-			return config, fmt.Errorf("error parsing streams: %w", err)
-		} else {
-			config.Streams = streams
-		}
-	}
-
-	if daysStr := k.String(EnvKeyDays); daysStr != "" {
-		if days, err := parseIntList(daysStr); err != nil {
-			return config, fmt.Errorf("error parsing days: %w", err)
-		} else {
-			config.Days = days
-		}
-	}
-
-	if recordsStr := k.String(EnvKeyRecords); recordsStr != "" {
-		if records, err := parseIntList(recordsStr); err != nil {
-			return config, fmt.Errorf("error parsing records: %w", err)
-		} else {
-			config.Records = records
-		}
-	}
-
-	if patternsStr := k.String(EnvKeyPatterns); patternsStr != "" {
-		config.Patterns = parseStringList(patternsStr)
-	}
-
-	// Parse simple values
-	if samples := k.Int(EnvKeySamples); samples > 0 {
-		config.Samples = samples
-	}
-
-	if resultsPath := k.String(EnvKeyResults); resultsPath != "" {
-		config.ResultsPath = resultsPath
-	}
-
-	return config, nil
-}
-
-// parseIntList parses a comma-separated string into a slice of integers.
-func parseIntList(s string) ([]int, error) {
-	if s == "" {
-		return []int{}, nil
-	}
-
-	parts := strings.Split(s, ",")
-	result := make([]int, 0, len(parts))
-
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-
-		val, err := strconv.Atoi(part)
-		if err != nil {
-			return nil, fmt.Errorf("invalid integer '%s': %w", part, err)
-		}
-		result = append(result, val)
-	}
-
-	return result, nil
-}
-
-// parseStringList parses a comma-separated string into a slice of strings.
-func parseStringList(s string) []string {
-	if s == "" {
-		return []string{}
-	}
-	parts := strings.Split(s, ",")
-	out := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
-}
-
-// testDigestDeleteCapSuite runs delete cap focused test cases.
-// This creates maximum streams once and tests different delete cap values under transactions.
-//
-// KEY INSIGHT: The multiple streams and days create a realistic dataset that exposes
-// indexing and performance issues that smaller datasets might miss. The delete cap
-// parameter (1K, 10K, 1M) is what actually controls how many records get processed/deleted, not
-// the total data volume. The dataset uses production-like patterns (24 records/day) to ensure
-// we're testing in conditions similar to production while focusing the performance measurement
-// on the delete cap behavior.
-func testDigestDeleteCapSuite(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
-	return func(ctx context.Context, platform *kwilTesting.Platform) error {
-		// Use medium-scale test cases (same as medium suite for consistency)
-		deleteCapCases := MediumTestCases
-
-		t.Logf("Running delete cap test suite with %d cases", len(deleteCapCases))
-		t.Logf("This suite creates maximum streams once and tests delete cap variations under transactions")
-		t.Logf("Note: Large dataset ensures realistic indexing/query patterns, but delete cap (1K/10K/100K/1M) controls actual deletion volume")
-
-		// 1) Global setup ONCE with maximum streams (superset for all cases)
-		// This creates a realistic dataset that exceeds what we'll actually delete,
-		// ensuring we test with production-like data volumes and indexing patterns.
-		// The delete cap (not the total data size) controls actual deletion volume.
-		maxStreamsCase := DigestBenchmarkCase{
-			Streams:       10000,                   // Creates realistic stream diversity for indexing tests
-			DaysPerStream: 30,                      // Sufficient history to test temporal patterns
-			RecordsPerDay: ProductionRecordsPerDay, // Production-like data density (24 records/day)
-
-			DeleteCap: DefaultDeleteCap, // This will be overridden per test case
-			Pattern:   PatternRandom,
-			Samples:   1,
-		}
-		t.Logf("Performing global setup with superset: %+v", maxStreamsCase)
-		t.Logf("Note: This large dataset ensures realistic indexing/query patterns for performance testing")
-		if err := SetupBenchmarkData(ctx, DigestSetupInput{Platform: platform, Case: maxStreamsCase}); err != nil {
-			return fmt.Errorf("global setup failed: %w", err)
-		}
-
-		// 2) Per-case execution inside a transaction with different delete caps
-		results := make(map[string][]DigestRunResult)
-		for i, testCase := range deleteCapCases {
-			t.Logf("Running delete cap case %d/%d with delete_cap=%d: %+v", i+1, len(deleteCapCases), testCase.DeleteCap, testCase)
-
-			if err := runCaseWithDeleteCap(ctx, platform, testCase, func(txPlatform *kwilTesting.Platform, caseResults []DigestRunResult) {
-				caseKey := fmt.Sprintf("streams_%d_days_%d_records_%d_deletecap_%d_pattern_%s",
-					testCase.Streams, testCase.DaysPerStream, testCase.RecordsPerDay, testCase.DeleteCap, testCase.Pattern)
-				results[caseKey] = caseResults
-			}); err != nil {
-				return fmt.Errorf("failed to run delete cap case %d: %w", i, err)
-			}
-		}
-
-		// Export results
-		var allResults []DigestRunResult
-		for _, caseResults := range results {
-			allResults = append(allResults, caseResults...)
-		}
-
-		outputFile := "digest_delete_cap_results.csv"
-		if err := SaveDigestResultsCSV(allResults, outputFile); err != nil {
-			t.Logf("Warning: failed to save results to %s: %v", outputFile, err)
-		} else {
-			t.Logf("Delete cap test results saved to %s", outputFile)
-		}
-
-		// Create summary report
-		summaryFile := strings.Replace(outputFile, ".csv", "_summary.md", 1)
-		if err := ExportResultsSummary(allResults, summaryFile); err != nil {
-			t.Logf("Warning: failed to create summary report: %v", err)
-		} else {
-			t.Logf("Summary report created at %s", summaryFile)
-		}
-
-		t.Logf("Delete cap test completed successfully - processed %d total results", len(allResults))
-
-		return nil
 	}
 }
 
@@ -575,75 +253,6 @@ func runCaseWithDeleteCap(ctx context.Context, platform *kwilTesting.Platform, t
 
 	resultHandler(txPlatform, caseResults)
 	return nil
-}
-
-// testDigestCustomSuite runs custom test cases based on environment variables.
-func testDigestCustomSuite(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
-	return func(ctx context.Context, platform *kwilTesting.Platform) error {
-		runner := NewBenchmarkRunner(platform, t)
-
-		// Load configuration using koanf
-		config, err := LoadCustomConfig()
-		if err != nil {
-			t.Logf("Warning: Failed to load custom config, using defaults: %v", err)
-			config = DefaultCustomConfig()
-		}
-
-		// Generate all combinations using lo functions for cleaner code
-		var customCases []DigestBenchmarkCase
-
-		// Use nested loops to generate all combinations
-		for _, streams := range config.Streams {
-			for _, days := range config.Days {
-				for _, records := range config.Records {
-					for _, pattern := range config.Patterns {
-						customCases = append(customCases, DigestBenchmarkCase{
-							Streams:          streams,
-							DaysPerStream:    days,
-							RecordsPerDay:    records,
-							DeleteCap:        DefaultDeleteCap,
-							Pattern:          pattern,
-							Samples:          config.Samples,
-							IdempotencyCheck: false, // Disable for performance in large runs
-						})
-					}
-				}
-			}
-		}
-
-		t.Logf("Running custom test suite with %d cases", len(customCases))
-		t.Logf("Configuration: streams=%v, days=%v, records=%v, patterns=%v, samples=%d",
-			config.Streams, config.Days, config.Records, config.Patterns, config.Samples)
-
-		results, err := runner.RunMultipleCases(ctx, customCases)
-		if err != nil {
-			return fmt.Errorf("custom test suite failed: %w", err)
-		}
-
-		// Export results
-		var allResults []DigestRunResult
-		for _, caseResults := range results {
-			allResults = append(allResults, caseResults...)
-		}
-
-		if err := SaveDigestResultsCSV(allResults, config.ResultsPath); err != nil {
-			t.Logf("Warning: failed to save results to %s: %v", config.ResultsPath, err)
-		} else {
-			t.Logf("Custom test results saved to %s", config.ResultsPath)
-		}
-
-		// Create summary report
-		summaryFile := strings.Replace(config.ResultsPath, ".csv", "_summary.md", 1)
-		if err := ExportResultsSummary(allResults, summaryFile); err != nil {
-			t.Logf("Warning: failed to create summary report: %v", err)
-		} else {
-			t.Logf("Summary report created at %s", summaryFile)
-		}
-
-		t.Logf("Custom test completed successfully - processed %d total results", len(allResults))
-
-		return nil
-	}
 }
 
 // Environment variable parsing is now handled by koanf in LoadCustomConfig()

--- a/internal/benchmark/digest/digest_benchmark_test.go
+++ b/internal/benchmark/digest/digest_benchmark_test.go
@@ -43,11 +43,11 @@ var benchmarkScales = map[string]DigestBenchmarkScale{
 	"exact_fit": {
 		Name:         "exact_fit",
 		Description:  "exact fit testing - data volume matches delete cap exactly",
-		SetupStreams: 200,
-		SetupDays:    1,
+		SetupStreams: 347,
+		SetupDays:    12,
 		TestCases: []DigestBenchmarkCase{
-			{Streams: 200, DaysPerStream: 1, RecordsPerDay: 500, DeleteCap: 10000, Pattern: PatternRandom, Samples: 3, IdempotencyCheck: true},
-			{Streams: 200, DaysPerStream: 1, RecordsPerDay: 500, DeleteCap: 100000, Pattern: PatternRandom, Samples: 3, IdempotencyCheck: true},
+			{Streams: 347, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: 10000, Pattern: PatternRandom, Samples: DefaultSamples, IdempotencyCheck: true},
+			{Streams: 347, DaysPerStream: 12, RecordsPerDay: ProductionRecordsPerDay, DeleteCap: 100000, Pattern: PatternRandom, Samples: DefaultSamples, IdempotencyCheck: true},
 		},
 	},
 	"with_excess": {

--- a/internal/benchmark/digest/digest_benchmark_test.go
+++ b/internal/benchmark/digest/digest_benchmark_test.go
@@ -76,6 +76,9 @@ func TestBenchDigest_Smoke(t *testing.T) {
 // Measures performance when data volume matches delete cap exactly (optimal scenarios).
 // IDE will show individual run gutter for this test.
 func TestBenchDigest_ExactFit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping benchmark test in short mode")
+	}
 	runDigestBenchmarkScale(t, benchmarkScales["exact_fit"])
 }
 
@@ -83,6 +86,9 @@ func TestBenchDigest_ExactFit(t *testing.T) {
 // Tests performance with excess data beyond processing capacity (real-world scenarios).
 // IDE will show individual run gutter for this test.
 func TestBenchDigest_WithExcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping benchmark test in short mode")
+	}
 	runDigestBenchmarkScale(t, benchmarkScales["with_excess"])
 }
 

--- a/internal/benchmark/digest/digest_benchmark_test.go
+++ b/internal/benchmark/digest/digest_benchmark_test.go
@@ -380,6 +380,10 @@ func LoadCustomConfig() (CustomBenchmarkConfig, error) {
 		}
 	}
 
+	if patternsStr := k.String(EnvKeyPatterns); patternsStr != "" {
+		config.Patterns = parseStringList(patternsStr)
+	}
+
 	// Parse simple values
 	if samples := k.Int(EnvKeySamples); samples > 0 {
 		config.Samples = samples
@@ -415,6 +419,22 @@ func parseIntList(s string) ([]int, error) {
 	}
 
 	return result, nil
+}
+
+// parseStringList parses a comma-separated string into a slice of strings.
+func parseStringList(s string) []string {
+	if s == "" {
+		return []string{}
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // testDigestDeleteCapSuite runs delete cap focused test cases.

--- a/internal/benchmark/digest/digest_unit_test.go
+++ b/internal/benchmark/digest/digest_unit_test.go
@@ -8,74 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSliceCandidates tests the candidate slicing functionality.
-func TestSliceCandidates(t *testing.T) {
-	tests := []struct {
-		name       string
-		streamRefs []int
-		dayIdxs    []int
-		batchSize  int
-		expected   int // number of batches
-	}{
-		{
-			name:       "empty_input",
-			streamRefs: []int{},
-			dayIdxs:    []int{},
-			batchSize:  10,
-			expected:   0,
-		},
-		{
-			name:       "single_batch",
-			streamRefs: []int{1, 2, 3},
-			dayIdxs:    []int{0, 1, 2},
-			batchSize:  10,
-			expected:   1,
-		},
-		{
-			name:       "multiple_batches",
-			streamRefs: []int{1, 2, 3, 4, 5},
-			dayIdxs:    []int{0, 1, 2, 3, 4},
-			batchSize:  2,
-			expected:   3, // 2, 2, 1
-		},
-		{
-			name:       "mismatched_lengths",
-			streamRefs: []int{1, 2, 3},
-			dayIdxs:    []int{0, 1}, // different length
-			batchSize:  2,
-			expected:   0, // should return nil
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := SliceCandidates(tt.streamRefs, tt.dayIdxs, tt.batchSize)
-
-			if tt.expected == 0 && len(result) == 0 {
-				// Expected empty result
-				return
-			}
-
-			if tt.expected == 0 {
-				t.Errorf("expected empty result but got %d batches", len(result))
-				return
-			}
-
-			assert.Equal(t, tt.expected, len(result), "number of batches should match")
-
-			// Verify batch structure
-			for i, candidateBatch := range result {
-				assert.Greater(t, len(candidateBatch.StreamRefs), 0, "batch %d should not be empty", i)
-
-				// Each batch should have the same structure
-				assert.Equal(t, len(candidateBatch.StreamRefs), len(candidateBatch.DayIdxs),
-					"stream refs and day idxs should have same length in batch")
-				assert.LessOrEqual(t, len(candidateBatch.StreamRefs), tt.batchSize,
-					"batch size should not exceed requested size")
-			}
-		})
-	}
-}
+// TestSliceCandidates was removed - batching functionality is no longer used.
+// All candidates are now processed in a single call to batch_digest.
 
 // TestAggregateResults tests the result aggregation functionality.
 func TestAggregateResults(t *testing.T) {
@@ -97,9 +31,9 @@ func TestAggregateResults(t *testing.T) {
 						Streams:       10,
 						DaysPerStream: 5,
 						RecordsPerDay: 100,
-						BatchSize:     50,
-						Pattern:       "random",
-						Samples:       3,
+
+						Pattern: "random",
+						Samples: 3,
 					},
 					Candidates:           50,
 					ProcessedDays:        25,
@@ -117,9 +51,9 @@ func TestAggregateResults(t *testing.T) {
 					Streams:       10,
 					DaysPerStream: 5,
 					RecordsPerDay: 100,
-					BatchSize:     50,
-					Pattern:       "random",
-					Samples:       3,
+
+					Pattern: "random",
+					Samples: 3,
 				},
 				Candidates:           50,
 				ProcessedDays:        25,
@@ -213,9 +147,9 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
-				BatchSize:     50,
-				Pattern:       "random",
-				Samples:       3,
+
+				Pattern: "random",
+				Samples: 3,
 			},
 			wantErr: false,
 		},
@@ -225,9 +159,9 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       0,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
-				BatchSize:     50,
-				Pattern:       "random",
-				Samples:       3,
+
+				Pattern: "random",
+				Samples: 3,
 			},
 			wantErr: true,
 		},
@@ -237,9 +171,9 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 0,
 				RecordsPerDay: 100,
-				BatchSize:     50,
-				Pattern:       "random",
-				Samples:       3,
+
+				Pattern: "random",
+				Samples: 3,
 			},
 			wantErr: true,
 		},
@@ -249,9 +183,9 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 0,
-				BatchSize:     50,
-				Pattern:       "random",
-				Samples:       3,
+
+				Pattern: "random",
+				Samples: 3,
 			},
 			wantErr: true,
 		},
@@ -261,9 +195,9 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
-				BatchSize:     0,
-				Pattern:       "random",
-				Samples:       3,
+
+				Pattern: "random",
+				Samples: 3,
 			},
 			wantErr: true,
 		},
@@ -273,9 +207,9 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
-				BatchSize:     50,
-				Pattern:       PatternRandom,
-				Samples:       3,
+
+				Pattern: PatternRandom,
+				Samples: 3,
 			},
 			wantErr: false,
 		},
@@ -285,9 +219,9 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
-				BatchSize:     50,
-				Pattern:       "random",
-				Samples:       0,
+
+				Pattern: "random",
+				Samples: 0,
 			},
 			wantErr: true,
 		},
@@ -383,9 +317,9 @@ func TestConvertToSavedResult(t *testing.T) {
 			Streams:       10,
 			DaysPerStream: 5,
 			RecordsPerDay: 100,
-			BatchSize:     50,
-			Pattern:       "random",
-			Samples:       3,
+
+			Pattern: "random",
+			Samples: 3,
 		},
 		Candidates:           50,
 		ProcessedDays:        25,
@@ -404,7 +338,7 @@ func TestConvertToSavedResult(t *testing.T) {
 	assert.Equal(t, input.Case.Streams, result.Streams)
 	assert.Equal(t, input.Case.DaysPerStream, result.DaysPerStream)
 	assert.Equal(t, input.Case.RecordsPerDay, result.RecordsPerDay)
-	assert.Equal(t, input.Case.BatchSize, result.BatchSize)
+	// BatchSize was removed - we now send all candidates in one call
 	assert.Equal(t, input.Case.Pattern, result.Pattern)
 	assert.Equal(t, input.Case.Samples, result.Samples)
 	assert.Equal(t, input.Candidates, result.Candidates)
@@ -430,15 +364,15 @@ func TestDataGenerationPatterns(t *testing.T) {
 				Streams:       5,
 				DaysPerStream: 2,
 				RecordsPerDay: 10,
-				BatchSize:     5,
-				Pattern:       pattern,
-				Samples:       1,
+
+				Pattern: pattern,
+				Samples: 1,
 			}
 
 			// Should not panic when creating the case
 			err := ValidateBenchmarkCase(c)
 			// Pattern validation may not be implemented, so we just check that basic validation passes
-			if c.Streams > 0 && c.DaysPerStream > 0 && c.RecordsPerDay > 0 && c.BatchSize > 0 && c.Samples > 0 {
+			if c.Streams > 0 && c.DaysPerStream > 0 && c.RecordsPerDay > 0 && c.Samples > 0 {
 				// These should be valid if the pattern validation isn't implemented
 				assert.NoError(t, err, "basic validation should pass for pattern %s", pattern)
 			}
@@ -466,7 +400,7 @@ func TestConstants(t *testing.T) {
 	// Test that resource limits are reasonable
 	assert.Greater(t, MaxWorkers, 0, "MaxWorkers should be positive")
 	assert.Greater(t, MaxConcurrency, 0, "MaxConcurrency should be positive")
-	assert.Greater(t, DefaultBatchSize, 0, "DefaultBatchSize should be positive")
+	// BatchSize was removed - we now send all candidates in one call
 	assert.Greater(t, DefaultSamples, 0, "DefaultSamples should be positive")
 
 	// Test that test configurations are reasonable
@@ -482,9 +416,9 @@ func TestBenchmarkCaseCreation(t *testing.T) {
 		Streams:       SmokeTestStreams,
 		DaysPerStream: SmokeTestDays,
 		RecordsPerDay: SmokeTestRecords,
-		BatchSize:     DefaultBatchSize,
-		Pattern:       PatternRandom,
-		Samples:       DefaultSamples,
+
+		Pattern: PatternRandom,
+		Samples: DefaultSamples,
 	}
 
 	err := ValidateBenchmarkCase(c)
@@ -494,7 +428,7 @@ func TestBenchmarkCaseCreation(t *testing.T) {
 	assert.Greater(t, c.Streams, 0, "streams should be positive")
 	assert.Greater(t, c.DaysPerStream, 0, "days per stream should be positive")
 	assert.Greater(t, c.RecordsPerDay, 0, "records per day should be positive")
-	assert.Greater(t, c.BatchSize, 0, "batch size should be positive")
+	// BatchSize validation removed - we now send all candidates in one call
 	assert.Greater(t, c.Samples, 0, "samples should be positive")
 	assert.NotEmpty(t, c.Pattern, "pattern should not be empty")
 }

--- a/internal/benchmark/digest/digest_unit_test.go
+++ b/internal/benchmark/digest/digest_unit_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestSliceCandidates was removed - batching functionality is no longer used.
-// All candidates are now processed in a single call to batch_digest.
+// All candidates are now processed in a single call to auto_digest.
 
 // TestAggregateResults tests the result aggregation functionality.
 func TestAggregateResults(t *testing.T) {
@@ -147,6 +147,7 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
+				DeleteCap:     1000,
 
 				Pattern: "random",
 				Samples: 3,
@@ -159,6 +160,7 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       0,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
+				DeleteCap:     1000,
 
 				Pattern: "random",
 				Samples: 3,
@@ -171,6 +173,7 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 0,
 				RecordsPerDay: 100,
+				DeleteCap:     1000,
 
 				Pattern: "random",
 				Samples: 3,
@@ -183,6 +186,7 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 0,
+				DeleteCap:     1000,
 
 				Pattern: "random",
 				Samples: 3,
@@ -195,6 +199,7 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
+				DeleteCap:     0,
 
 				Pattern: "random",
 				Samples: 3,
@@ -207,6 +212,7 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
+				DeleteCap:     1000,
 
 				Pattern: PatternRandom,
 				Samples: 3,
@@ -219,6 +225,7 @@ func TestValidateBenchmarkCase(t *testing.T) {
 				Streams:       10,
 				DaysPerStream: 5,
 				RecordsPerDay: 100,
+				DeleteCap:     1000,
 
 				Pattern: "random",
 				Samples: 0,
@@ -338,7 +345,6 @@ func TestConvertToSavedResult(t *testing.T) {
 	assert.Equal(t, input.Case.Streams, result.Streams)
 	assert.Equal(t, input.Case.DaysPerStream, result.DaysPerStream)
 	assert.Equal(t, input.Case.RecordsPerDay, result.RecordsPerDay)
-	// BatchSize was removed - we now send all candidates in one call
 	assert.Equal(t, input.Case.Pattern, result.Pattern)
 	assert.Equal(t, input.Case.Samples, result.Samples)
 	assert.Equal(t, input.Candidates, result.Candidates)
@@ -400,7 +406,7 @@ func TestConstants(t *testing.T) {
 	// Test that resource limits are reasonable
 	assert.Greater(t, MaxWorkers, 0, "MaxWorkers should be positive")
 	assert.Greater(t, MaxConcurrency, 0, "MaxConcurrency should be positive")
-	// BatchSize was removed - we now send all candidates in one call
+	// DeleteCap controls processing - we now use auto_digest which sends all candidates in one call
 	assert.Greater(t, DefaultSamples, 0, "DefaultSamples should be positive")
 
 	// Test that test configurations are reasonable
@@ -428,7 +434,7 @@ func TestBenchmarkCaseCreation(t *testing.T) {
 	assert.Greater(t, c.Streams, 0, "streams should be positive")
 	assert.Greater(t, c.DaysPerStream, 0, "days per stream should be positive")
 	assert.Greater(t, c.RecordsPerDay, 0, "records per day should be positive")
-	// BatchSize validation removed - we now send all candidates in one call
+	// DeleteCap controls processing - we now use auto_digest which sends all candidates in one call
 	assert.Greater(t, c.Samples, 0, "samples should be positive")
 	assert.NotEmpty(t, c.Pattern, "pattern should not be empty")
 }

--- a/internal/benchmark/digest/digest_unit_test.go
+++ b/internal/benchmark/digest/digest_unit_test.go
@@ -1,0 +1,500 @@
+package digest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSliceCandidates tests the candidate slicing functionality.
+func TestSliceCandidates(t *testing.T) {
+	tests := []struct {
+		name       string
+		streamRefs []int
+		dayIdxs    []int
+		batchSize  int
+		expected   int // number of batches
+	}{
+		{
+			name:       "empty_input",
+			streamRefs: []int{},
+			dayIdxs:    []int{},
+			batchSize:  10,
+			expected:   0,
+		},
+		{
+			name:       "single_batch",
+			streamRefs: []int{1, 2, 3},
+			dayIdxs:    []int{0, 1, 2},
+			batchSize:  10,
+			expected:   1,
+		},
+		{
+			name:       "multiple_batches",
+			streamRefs: []int{1, 2, 3, 4, 5},
+			dayIdxs:    []int{0, 1, 2, 3, 4},
+			batchSize:  2,
+			expected:   3, // 2, 2, 1
+		},
+		{
+			name:       "mismatched_lengths",
+			streamRefs: []int{1, 2, 3},
+			dayIdxs:    []int{0, 1}, // different length
+			batchSize:  2,
+			expected:   0, // should return nil
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SliceCandidates(tt.streamRefs, tt.dayIdxs, tt.batchSize)
+
+			if tt.expected == 0 && len(result) == 0 {
+				// Expected empty result
+				return
+			}
+
+			if tt.expected == 0 {
+				t.Errorf("expected empty result but got %d batches", len(result))
+				return
+			}
+
+			assert.Equal(t, tt.expected, len(result), "number of batches should match")
+
+			// Verify batch structure
+			for i, candidateBatch := range result {
+				assert.Greater(t, len(candidateBatch.StreamRefs), 0, "batch %d should not be empty", i)
+
+				// Each batch should have the same structure
+				assert.Equal(t, len(candidateBatch.StreamRefs), len(candidateBatch.DayIdxs),
+					"stream refs and day idxs should have same length in batch")
+				assert.LessOrEqual(t, len(candidateBatch.StreamRefs), tt.batchSize,
+					"batch size should not exceed requested size")
+			}
+		})
+	}
+}
+
+// TestAggregateResults tests the result aggregation functionality.
+func TestAggregateResults(t *testing.T) {
+	tests := []struct {
+		name     string
+		results  []DigestRunResult
+		expected DigestRunResult
+	}{
+		{
+			name:     "empty_input",
+			results:  []DigestRunResult{},
+			expected: DigestRunResult{},
+		},
+		{
+			name: "single_result",
+			results: []DigestRunResult{
+				{
+					Case: DigestBenchmarkCase{
+						Streams:       10,
+						DaysPerStream: 5,
+						RecordsPerDay: 100,
+						BatchSize:     50,
+						Pattern:       "random",
+						Samples:       3,
+					},
+					Candidates:           50,
+					ProcessedDays:        25,
+					TotalDeletedRows:     1000,
+					TotalPreservedRows:   2000,
+					Duration:             5 * time.Second,
+					MemoryMaxBytes:       1024 * 1024 * 100, // 100MB
+					DaysPerSecond:        5.0,
+					RowsDeletedPerSecond: 200.0,
+					WALBytes:             nil,
+				},
+			},
+			expected: DigestRunResult{
+				Case: DigestBenchmarkCase{
+					Streams:       10,
+					DaysPerStream: 5,
+					RecordsPerDay: 100,
+					BatchSize:     50,
+					Pattern:       "random",
+					Samples:       3,
+				},
+				Candidates:           50,
+				ProcessedDays:        25,
+				TotalDeletedRows:     1000,
+				TotalPreservedRows:   2000,
+				Duration:             5 * time.Second,
+				MemoryMaxBytes:       1024 * 1024 * 100, // 100MB
+				DaysPerSecond:        5.0,
+				RowsDeletedPerSecond: 200.0,
+				WALBytes:             nil,
+			},
+		},
+		{
+			name: "multiple_results",
+			results: []DigestRunResult{
+				{
+					Candidates:           30,
+					ProcessedDays:        15,
+					TotalDeletedRows:     500,
+					TotalPreservedRows:   1000,
+					Duration:             3 * time.Second,
+					MemoryMaxBytes:       50 * 1024 * 1024, // 50MB
+					DaysPerSecond:        5.0,
+					RowsDeletedPerSecond: 166.67,
+					WALBytes:             nil,
+				},
+				{
+					Candidates:           20,
+					ProcessedDays:        10,
+					TotalDeletedRows:     300,
+					TotalPreservedRows:   800,
+					Duration:             2 * time.Second,
+					MemoryMaxBytes:       75 * 1024 * 1024, // 75MB
+					DaysPerSecond:        5.0,
+					RowsDeletedPerSecond: 150.0,
+					WALBytes:             nil,
+				},
+			},
+			expected: DigestRunResult{
+				Candidates:           50,               // 30 + 20
+				ProcessedDays:        25,               // 15 + 10
+				TotalDeletedRows:     800,              // 500 + 300
+				TotalPreservedRows:   1800,             // 1000 + 800
+				Duration:             5 * time.Second,  // 3 + 2
+				MemoryMaxBytes:       75 * 1024 * 1024, // max(50MB, 75MB) = 75MB
+				DaysPerSecond:        5.0,              // 25 / 5
+				RowsDeletedPerSecond: 160.0,            // 800 / 5
+				WALBytes:             nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AggregateResults(tt.results)
+
+			if len(tt.results) == 0 {
+				assert.Equal(t, DigestRunResult{}, result, "empty input should return zero result")
+				return
+			}
+
+			assert.Equal(t, tt.expected.Candidates, result.Candidates, "candidates should match")
+			assert.Equal(t, tt.expected.ProcessedDays, result.ProcessedDays, "processed days should match")
+			assert.Equal(t, tt.expected.TotalDeletedRows, result.TotalDeletedRows, "deleted rows should match")
+			assert.Equal(t, tt.expected.TotalPreservedRows, result.TotalPreservedRows, "preserved rows should match")
+			assert.Equal(t, tt.expected.Duration, result.Duration, "duration should match")
+			assert.Equal(t, tt.expected.MemoryMaxBytes, result.MemoryMaxBytes, "memory should match")
+
+			// Verify calculated throughput metrics
+			if result.Duration.Seconds() > 0 {
+				expectedDaysPerSec := float64(result.ProcessedDays) / result.Duration.Seconds()
+				assert.InDelta(t, expectedDaysPerSec, result.DaysPerSecond, 0.1, "days per second should be calculated correctly")
+
+				expectedRowsPerSec := float64(result.TotalDeletedRows) / result.Duration.Seconds()
+				assert.InDelta(t, expectedRowsPerSec, result.RowsDeletedPerSecond, 0.1, "rows per second should be calculated correctly")
+			}
+		})
+	}
+}
+
+// TestValidateBenchmarkCase tests benchmark case validation.
+func TestValidateBenchmarkCase(t *testing.T) {
+	tests := []struct {
+		name    string
+		c       DigestBenchmarkCase
+		wantErr bool
+	}{
+		{
+			name: "valid_case",
+			c: DigestBenchmarkCase{
+				Streams:       10,
+				DaysPerStream: 5,
+				RecordsPerDay: 100,
+				BatchSize:     50,
+				Pattern:       "random",
+				Samples:       3,
+			},
+			wantErr: false,
+		},
+		{
+			name: "zero_streams",
+			c: DigestBenchmarkCase{
+				Streams:       0,
+				DaysPerStream: 5,
+				RecordsPerDay: 100,
+				BatchSize:     50,
+				Pattern:       "random",
+				Samples:       3,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero_days",
+			c: DigestBenchmarkCase{
+				Streams:       10,
+				DaysPerStream: 0,
+				RecordsPerDay: 100,
+				BatchSize:     50,
+				Pattern:       "random",
+				Samples:       3,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero_records",
+			c: DigestBenchmarkCase{
+				Streams:       10,
+				DaysPerStream: 5,
+				RecordsPerDay: 0,
+				BatchSize:     50,
+				Pattern:       "random",
+				Samples:       3,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero_batch_size",
+			c: DigestBenchmarkCase{
+				Streams:       10,
+				DaysPerStream: 5,
+				RecordsPerDay: 100,
+				BatchSize:     0,
+				Pattern:       "random",
+				Samples:       3,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid_pattern",
+			c: DigestBenchmarkCase{
+				Streams:       10,
+				DaysPerStream: 5,
+				RecordsPerDay: 100,
+				BatchSize:     50,
+				Pattern:       PatternRandom,
+				Samples:       3,
+			},
+			wantErr: false,
+		},
+		{
+			name: "zero_samples",
+			c: DigestBenchmarkCase{
+				Streams:       10,
+				DaysPerStream: 5,
+				RecordsPerDay: 100,
+				BatchSize:     50,
+				Pattern:       "random",
+				Samples:       0,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBenchmarkCase(tt.c)
+			if tt.wantErr {
+				assert.Error(t, err, "expected validation error but got none")
+			} else {
+				assert.NoError(t, err, "expected no validation error but got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateResult tests result validation.
+func TestValidateResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  DigestRunResult
+		wantErr bool
+	}{
+		{
+			name: "valid_result",
+			result: DigestRunResult{
+				Candidates:           50,
+				ProcessedDays:        25,
+				TotalDeletedRows:     1000,
+				TotalPreservedRows:   2000,
+				Duration:             5 * time.Second,
+				MemoryMaxBytes:       100 * 1024 * 1024,
+				DaysPerSecond:        5.0,
+				RowsDeletedPerSecond: 200.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative_candidates",
+			result: DigestRunResult{
+				Candidates:         -1,
+				ProcessedDays:      25,
+				TotalDeletedRows:   1000,
+				TotalPreservedRows: 2000,
+				Duration:           5 * time.Second,
+				MemoryMaxBytes:     100 * 1024 * 1024,
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero_memory",
+			result: DigestRunResult{
+				Candidates:         50,
+				ProcessedDays:      25,
+				TotalDeletedRows:   1000,
+				TotalPreservedRows: 2000,
+				Duration:           5 * time.Second,
+				MemoryMaxBytes:     0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative_duration",
+			result: DigestRunResult{
+				Candidates:         50,
+				ProcessedDays:      25,
+				TotalDeletedRows:   1000,
+				TotalPreservedRows: 2000,
+				Duration:           -1 * time.Second,
+				MemoryMaxBytes:     100 * 1024 * 1024,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateResult(tt.result)
+			if tt.wantErr {
+				assert.Error(t, err, "expected validation error but got none")
+			} else {
+				assert.NoError(t, err, "expected no validation error but got: %v", err)
+			}
+		})
+	}
+}
+
+// TestConvertToSavedResult tests CSV conversion.
+func TestConvertToSavedResult(t *testing.T) {
+	input := DigestRunResult{
+		Case: DigestBenchmarkCase{
+			Streams:       10,
+			DaysPerStream: 5,
+			RecordsPerDay: 100,
+			BatchSize:     50,
+			Pattern:       "random",
+			Samples:       3,
+		},
+		Candidates:           50,
+		ProcessedDays:        25,
+		TotalDeletedRows:     1000,
+		TotalPreservedRows:   2000,
+		Duration:             5 * time.Second,
+		MemoryMaxBytes:       100 * 1024 * 1024, // 100MB
+		DaysPerSecond:        5.0,
+		RowsDeletedPerSecond: 200.0,
+		WALBytes:             &[]int64{1024}[0], // 1024 bytes
+	}
+
+	result := ConvertToSavedResult(input)
+
+	// Verify conversion
+	assert.Equal(t, input.Case.Streams, result.Streams)
+	assert.Equal(t, input.Case.DaysPerStream, result.DaysPerStream)
+	assert.Equal(t, input.Case.RecordsPerDay, result.RecordsPerDay)
+	assert.Equal(t, input.Case.BatchSize, result.BatchSize)
+	assert.Equal(t, input.Case.Pattern, result.Pattern)
+	assert.Equal(t, input.Case.Samples, result.Samples)
+	assert.Equal(t, input.Candidates, result.Candidates)
+	assert.Equal(t, input.ProcessedDays, result.ProcessedDays)
+	assert.Equal(t, input.TotalDeletedRows, result.TotalDeleted)
+	assert.Equal(t, input.TotalPreservedRows, result.TotalPreserved)
+	assert.Equal(t, int64(5000), result.DurationMs) // 5 seconds in milliseconds
+	assert.Equal(t, input.DaysPerSecond, result.DaysPerSec)
+	assert.Equal(t, input.RowsDeletedPerSecond, result.RowsDeletedPerSec)
+	assert.Equal(t, uint64(100*1024*1024), result.MemoryMB*1024*1024) // Memory in bytes
+	assert.Equal(t, input.WALBytes, result.WalBytes)
+	assert.NotEmpty(t, result.Timestamp)
+}
+
+// TestDataGenerationPatterns tests the data generation patterns.
+func TestDataGenerationPatterns(t *testing.T) {
+	patterns := []string{PatternRandom, PatternDups50, PatternMonotonic, PatternEqual, PatternTimeDup}
+
+	for _, pattern := range patterns {
+		t.Run("pattern_"+pattern, func(t *testing.T) {
+			// Test that we can create benchmark cases with each pattern
+			c := DigestBenchmarkCase{
+				Streams:       5,
+				DaysPerStream: 2,
+				RecordsPerDay: 10,
+				BatchSize:     5,
+				Pattern:       pattern,
+				Samples:       1,
+			}
+
+			// Should not panic when creating the case
+			err := ValidateBenchmarkCase(c)
+			// Pattern validation may not be implemented, so we just check that basic validation passes
+			if c.Streams > 0 && c.DaysPerStream > 0 && c.RecordsPerDay > 0 && c.BatchSize > 0 && c.Samples > 0 {
+				// These should be valid if the pattern validation isn't implemented
+				assert.NoError(t, err, "basic validation should pass for pattern %s", pattern)
+			}
+		})
+	}
+}
+
+// TestConstants tests that all constants are properly defined.
+func TestConstants(t *testing.T) {
+	// Test that all table names are defined
+	assert.NotEmpty(t, DigestTables, "DigestTables should not be empty")
+	assert.Contains(t, DigestTables, "primitive_events", "should contain primitive_events")
+	assert.Contains(t, DigestTables, "pending_prune_days", "should contain pending_prune_days")
+
+	// Test that all patterns are defined
+	assert.NotEmpty(t, PatternRandom, "PatternRandom should not be empty")
+	assert.NotEmpty(t, PatternDups50, "PatternDups50 should not be empty")
+	assert.NotEmpty(t, PatternMonotonic, "PatternMonotonic should not be empty")
+	assert.NotEmpty(t, PatternEqual, "PatternEqual should not be empty")
+	assert.NotEmpty(t, PatternTimeDup, "PatternTimeDup should not be empty")
+
+	// Test that container name is defined
+	assert.NotEmpty(t, DockerPostgresContainer, "DockerPostgresContainer should not be empty")
+
+	// Test that resource limits are reasonable
+	assert.Greater(t, MaxWorkers, 0, "MaxWorkers should be positive")
+	assert.Greater(t, MaxConcurrency, 0, "MaxConcurrency should be positive")
+	assert.Greater(t, DefaultBatchSize, 0, "DefaultBatchSize should be positive")
+	assert.Greater(t, DefaultSamples, 0, "DefaultSamples should be positive")
+
+	// Test that test configurations are reasonable
+	assert.Greater(t, SmokeTestStreams, 0, "SmokeTestStreams should be positive")
+	assert.Greater(t, MediumTestStreams, 0, "MediumTestStreams should be positive")
+	assert.Greater(t, ExtremeTestStreams, 0, "ExtremeTestStreams should be positive")
+}
+
+// TestBenchmarkCaseCreation tests creation of benchmark cases.
+func TestBenchmarkCaseCreation(t *testing.T) {
+	// Test creation with constants
+	c := DigestBenchmarkCase{
+		Streams:       SmokeTestStreams,
+		DaysPerStream: SmokeTestDays,
+		RecordsPerDay: SmokeTestRecords,
+		BatchSize:     DefaultBatchSize,
+		Pattern:       PatternRandom,
+		Samples:       DefaultSamples,
+	}
+
+	err := ValidateBenchmarkCase(c)
+	require.NoError(t, err, "benchmark case with constants should be valid")
+
+	// Test that the case has reasonable values
+	assert.Greater(t, c.Streams, 0, "streams should be positive")
+	assert.Greater(t, c.DaysPerStream, 0, "days per stream should be positive")
+	assert.Greater(t, c.RecordsPerDay, 0, "records per day should be positive")
+	assert.Greater(t, c.BatchSize, 0, "batch size should be positive")
+	assert.Greater(t, c.Samples, 0, "samples should be positive")
+	assert.NotEmpty(t, c.Pattern, "pattern should not be empty")
+}

--- a/internal/benchmark/digest/digest_unit_test.go
+++ b/internal/benchmark/digest/digest_unit_test.go
@@ -31,13 +31,13 @@ func TestAggregateResults(t *testing.T) {
 						Pattern:       PatternRandom,
 						Samples:       3,
 					},
-					Candidates:           50,
-					ProcessedDays:        25,
-					TotalDeletedRows:     1000,
-					TotalPreservedRows:   2000,
+					Candidates:       50,
+					ProcessedDays:    25,
+					TotalDeletedRows: 1000,
+
 					Duration:             5 * time.Second,
 					MemoryMaxBytes:       1024 * 1024 * 100, // 100MB
-					DaysPerSecond:        5.0,
+					StreamDaysPerSecond:  5.0,
 					RowsDeletedPerSecond: 200.0,
 				},
 			},
@@ -50,13 +50,13 @@ func TestAggregateResults(t *testing.T) {
 					Pattern:       PatternRandom,
 					Samples:       3,
 				},
-				Candidates:           50,
-				ProcessedDays:        25,
-				TotalDeletedRows:     1000,
-				TotalPreservedRows:   2000,
+				Candidates:       50,
+				ProcessedDays:    25,
+				TotalDeletedRows: 1000,
+
 				Duration:             5 * time.Second,
 				MemoryMaxBytes:       1024 * 1024 * 100, // 100MB
-				DaysPerSecond:        5.0,
+				StreamDaysPerSecond:  5.0,
 				RowsDeletedPerSecond: 200.0,
 			},
 		},
@@ -64,34 +64,34 @@ func TestAggregateResults(t *testing.T) {
 			name: "multiple_results_aggregation",
 			results: []DigestRunResult{
 				{
-					Candidates:           30,
-					ProcessedDays:        15,
-					TotalDeletedRows:     500,
-					TotalPreservedRows:   1000,
+					Candidates:       30,
+					ProcessedDays:    15,
+					TotalDeletedRows: 500,
+
 					Duration:             3 * time.Second,
 					MemoryMaxBytes:       50 * 1024 * 1024, // 50MB
-					DaysPerSecond:        5.0,
+					StreamDaysPerSecond:  5.0,
 					RowsDeletedPerSecond: 166.67,
 				},
 				{
-					Candidates:           20,
-					ProcessedDays:        10,
-					TotalDeletedRows:     300,
-					TotalPreservedRows:   800,
+					Candidates:       20,
+					ProcessedDays:    10,
+					TotalDeletedRows: 300,
+
 					Duration:             2 * time.Second,
 					MemoryMaxBytes:       75 * 1024 * 1024, // 75MB
-					DaysPerSecond:        5.0,
+					StreamDaysPerSecond:  5.0,
 					RowsDeletedPerSecond: 150.0,
 				},
 			},
 			expected: DigestRunResult{
-				Candidates:           50,               // 30 + 20
-				ProcessedDays:        25,               // 15 + 10
-				TotalDeletedRows:     800,              // 500 + 300
-				TotalPreservedRows:   1800,             // 1000 + 800
+				Candidates:       50,  // 30 + 20
+				ProcessedDays:    25,  // 15 + 10
+				TotalDeletedRows: 800, // 500 + 300
+
 				Duration:             5 * time.Second,  // 3 + 2
 				MemoryMaxBytes:       75 * 1024 * 1024, // max(50MB, 75MB)
-				DaysPerSecond:        5.0,              // 25 / 5
+				StreamDaysPerSecond:  5.0,              // 25 / 5
 				RowsDeletedPerSecond: 160.0,            // 800 / 5
 			},
 		},
@@ -109,14 +109,14 @@ func TestAggregateResults(t *testing.T) {
 			assert.Equal(t, tt.expected.Candidates, result.Candidates)
 			assert.Equal(t, tt.expected.ProcessedDays, result.ProcessedDays)
 			assert.Equal(t, tt.expected.TotalDeletedRows, result.TotalDeletedRows)
-			assert.Equal(t, tt.expected.TotalPreservedRows, result.TotalPreservedRows)
+
 			assert.Equal(t, tt.expected.Duration, result.Duration)
 			assert.Equal(t, tt.expected.MemoryMaxBytes, result.MemoryMaxBytes)
 
 			// Verify throughput calculations
 			if result.Duration.Seconds() > 0 {
-				expectedDaysPerSec := float64(result.ProcessedDays) / result.Duration.Seconds()
-				assert.InDelta(t, expectedDaysPerSec, result.DaysPerSecond, 0.1)
+				expectedStreamDaysPerSec := float64(result.ProcessedDays) / result.Duration.Seconds()
+				assert.InDelta(t, expectedStreamDaysPerSec, result.StreamDaysPerSecond, 0.1)
 
 				expectedRowsPerSec := float64(result.TotalDeletedRows) / result.Duration.Seconds()
 				assert.InDelta(t, expectedRowsPerSec, result.RowsDeletedPerSecond, 0.1)
@@ -197,13 +197,13 @@ func TestValidateBenchmarkCase(t *testing.T) {
 // TestValidateResult tests result validation used in benchmark execution.
 func TestValidateResult(t *testing.T) {
 	validResult := DigestRunResult{
-		Candidates:           50,
-		ProcessedDays:        25,
-		TotalDeletedRows:     1000,
-		TotalPreservedRows:   2000,
+		Candidates:       50,
+		ProcessedDays:    25,
+		TotalDeletedRows: 1000,
+
 		Duration:             5 * time.Second,
 		MemoryMaxBytes:       100 * 1024 * 1024,
-		DaysPerSecond:        5.0,
+		StreamDaysPerSecond:  5.0,
 		RowsDeletedPerSecond: 200.0,
 	}
 

--- a/internal/benchmark/digest/export.go
+++ b/internal/benchmark/digest/export.go
@@ -15,10 +15,10 @@ import (
 // SavedDigestResult represents a single row in the CSV export.
 // This structure uses JSON tags for CSV header generation and follows the existing benchexport pattern.
 type SavedDigestResult struct {
-	Streams           int     `json:"streams"`
-	DaysPerStream     int     `json:"days_per_stream"`
-	RecordsPerDay     int     `json:"records_per_day"`
-	BatchSize         int     `json:"batch_size"`
+	Streams       int `json:"streams"`
+	DaysPerStream int `json:"days_per_stream"`
+	RecordsPerDay int `json:"records_per_day"`
+
 	Pattern           string  `json:"pattern"`
 	Samples           int     `json:"samples"`
 	Candidates        int     `json:"candidates"`
@@ -41,9 +41,9 @@ func convertSavedResultToRunResult(saved SavedDigestResult) DigestRunResult {
 			Streams:       saved.Streams,
 			DaysPerStream: saved.DaysPerStream,
 			RecordsPerDay: saved.RecordsPerDay,
-			BatchSize:     saved.BatchSize,
-			Pattern:       saved.Pattern,
-			Samples:       saved.Samples,
+
+			Pattern: saved.Pattern,
+			Samples: saved.Samples,
 		},
 		Candidates:           saved.Candidates,
 		ProcessedDays:        saved.ProcessedDays,
@@ -61,10 +61,10 @@ func convertSavedResultToRunResult(saved SavedDigestResult) DigestRunResult {
 // This handles the transformation from internal types to export format.
 func ConvertToSavedResult(result DigestRunResult) SavedDigestResult {
 	saved := SavedDigestResult{
-		Streams:           result.Case.Streams,
-		DaysPerStream:     result.Case.DaysPerStream,
-		RecordsPerDay:     result.Case.RecordsPerDay,
-		BatchSize:         result.Case.BatchSize,
+		Streams:       result.Case.Streams,
+		DaysPerStream: result.Case.DaysPerStream,
+		RecordsPerDay: result.Case.RecordsPerDay,
+
 		Pattern:           result.Case.Pattern,
 		Samples:           result.Case.Samples,
 		Candidates:        result.Candidates,
@@ -185,7 +185,7 @@ func ExportResultsSummary(results []DigestRunResult, filePath string) error {
 			fmt.Sprintf("%d", result.Case.Streams),
 			fmt.Sprintf("%d", result.Case.DaysPerStream),
 			fmt.Sprintf("%d", result.Case.RecordsPerDay),
-			fmt.Sprintf("%d", result.Case.BatchSize),
+
 			result.Case.Pattern,
 			fmt.Sprintf("%d", result.Case.Samples),
 			fmt.Sprintf("%d", result.Candidates),
@@ -234,11 +234,10 @@ func ExportResultsSummary(results []DigestRunResult, filePath string) error {
 func countUniqueCases(results []DigestRunResult) int {
 	caseMap := make(map[string]bool)
 	for _, result := range results {
-		key := fmt.Sprintf("%d_%d_%d_%d_%s_%d",
+		key := fmt.Sprintf("%d_%d_%d_%s_%d",
 			result.Case.Streams,
 			result.Case.DaysPerStream,
 			result.Case.RecordsPerDay,
-			result.Case.BatchSize,
 			result.Case.Pattern,
 			result.Case.Samples,
 		)
@@ -353,9 +352,7 @@ func validateSavedResult(result SavedDigestResult) error {
 	if result.RecordsPerDay <= 0 {
 		return errors.New("records_per_day must be positive")
 	}
-	if result.BatchSize <= 0 {
-		return errors.New("batch_size must be positive")
-	}
+
 	if result.Samples <= 0 {
 		return errors.New("samples must be positive")
 	}

--- a/internal/benchmark/digest/export.go
+++ b/internal/benchmark/digest/export.go
@@ -93,14 +93,12 @@ func SaveDigestResultsCSV(results []DigestRunResult, filePath string) error {
 	}
 
 	// Reuse existing benchexport functionality
-	return saveOrAppendToCSVUsingBenchexport(savedResults, filePath)
+	return saveToCSVUsingBenchexport(savedResults, filePath)
 }
 
-// saveOrAppendToCSVUsingBenchexport saves data using gocsv for robust CSV handling.
+// saveToCSVUsingBenchexport saves data using gocsv for robust CSV handling.
 // This provides better error handling and automatic type conversion.
-func saveOrAppendToCSVUsingBenchexport(data []SavedDigestResult, filePath string) error {
-	// Open file in create/truncate mode for now (simplified approach)
-	// TODO: Implement proper append functionality when needed
+func saveToCSVUsingBenchexport(data []SavedDigestResult, filePath string) error {
 	file, err := os.Create(filePath)
 	if err != nil {
 		return errors.Wrapf(err, "error creating file %s", filePath)

--- a/internal/benchmark/digest/export.go
+++ b/internal/benchmark/digest/export.go
@@ -1,0 +1,520 @@
+package digest
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/gocarina/gocsv"
+	"github.com/montanaflynn/stats"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+)
+
+// SavedDigestResult represents a single row in the CSV export.
+// This structure uses JSON tags for CSV header generation and follows the existing benchexport pattern.
+type SavedDigestResult struct {
+	Streams           int     `json:"streams"`
+	DaysPerStream     int     `json:"days_per_stream"`
+	RecordsPerDay     int     `json:"records_per_day"`
+	BatchSize         int     `json:"batch_size"`
+	Pattern           string  `json:"pattern"`
+	Samples           int     `json:"samples"`
+	Candidates        int     `json:"candidates"`
+	ProcessedDays     int     `json:"processed_days"`
+	TotalDeleted      int     `json:"total_deleted"`
+	TotalPreserved    int     `json:"total_preserved"`
+	DurationMs        int64   `json:"duration_ms"`
+	DaysPerSec        float64 `json:"days_per_sec"`
+	RowsDeletedPerSec float64 `json:"rows_deleted_per_sec"`
+	MemoryMB          uint64  `json:"memory_mb"`
+	WalBytes          *int64  `json:"wal_bytes,omitempty"` // Optional WAL tracking
+	Timestamp         string  `json:"timestamp"`           // When the result was recorded
+}
+
+// convertSavedResultToRunResult converts a SavedDigestResult back to DigestRunResult.
+// This handles the reverse transformation from export format to internal types.
+func convertSavedResultToRunResult(saved SavedDigestResult) DigestRunResult {
+	return DigestRunResult{
+		Case: DigestBenchmarkCase{
+			Streams:       saved.Streams,
+			DaysPerStream: saved.DaysPerStream,
+			RecordsPerDay: saved.RecordsPerDay,
+			BatchSize:     saved.BatchSize,
+			Pattern:       saved.Pattern,
+			Samples:       saved.Samples,
+		},
+		Candidates:           saved.Candidates,
+		ProcessedDays:        saved.ProcessedDays,
+		TotalDeletedRows:     saved.TotalDeleted,
+		TotalPreservedRows:   saved.TotalPreserved,
+		Duration:             time.Duration(saved.DurationMs) * time.Millisecond,
+		MemoryMaxBytes:       saved.MemoryMB * 1024 * 1024, // Convert MB back to bytes
+		DaysPerSecond:        saved.DaysPerSec,
+		RowsDeletedPerSecond: saved.RowsDeletedPerSec,
+		WALBytes:             saved.WalBytes,
+	}
+}
+
+// ConvertToSavedResult converts a DigestRunResult to a SavedDigestResult for CSV export.
+// This handles the transformation from internal types to export format.
+func ConvertToSavedResult(result DigestRunResult) SavedDigestResult {
+	saved := SavedDigestResult{
+		Streams:           result.Case.Streams,
+		DaysPerStream:     result.Case.DaysPerStream,
+		RecordsPerDay:     result.Case.RecordsPerDay,
+		BatchSize:         result.Case.BatchSize,
+		Pattern:           result.Case.Pattern,
+		Samples:           result.Case.Samples,
+		Candidates:        result.Candidates,
+		ProcessedDays:     result.ProcessedDays,
+		TotalDeleted:      result.TotalDeletedRows,
+		TotalPreserved:    result.TotalPreservedRows,
+		DurationMs:        result.Duration.Milliseconds(),
+		DaysPerSec:        result.DaysPerSecond,
+		RowsDeletedPerSec: result.RowsDeletedPerSecond,
+		MemoryMB:          result.MemoryMaxBytes / 1024 / 1024, // Convert bytes to MB
+		WalBytes:          result.WALBytes,
+		Timestamp:         time.Now().Format(time.RFC3339),
+	}
+
+	return saved
+}
+
+// SaveDigestResultsCSV exports multiple DigestRunResult instances to a CSV file.
+// This reuses the existing benchexport pattern for consistency.
+func SaveDigestResultsCSV(results []DigestRunResult, filePath string) error {
+	if len(results) == 0 {
+		return errors.New("no results to save")
+	}
+
+	// Convert all results to saved format
+	var savedResults []SavedDigestResult
+	for _, result := range results {
+		savedResults = append(savedResults, ConvertToSavedResult(result))
+	}
+
+	// Reuse existing benchexport functionality
+	return saveOrAppendToCSVUsingBenchexport(savedResults, filePath)
+}
+
+// saveOrAppendToCSVUsingBenchexport saves data using gocsv for robust CSV handling.
+// This provides better error handling and automatic type conversion.
+func saveOrAppendToCSVUsingBenchexport(data []SavedDigestResult, filePath string) error {
+	// Open file in create/truncate mode for now (simplified approach)
+	// TODO: Implement proper append functionality when needed
+	file, err := os.Create(filePath)
+	if err != nil {
+		return errors.Wrapf(err, "error creating file %s", filePath)
+	}
+	defer file.Close()
+
+	// Write data with headers
+	if err := gocsv.MarshalFile(&data, file); err != nil {
+		return errors.Wrap(err, "error writing CSV data")
+	}
+
+	return nil
+}
+
+// LoadDigestResultsCSV loads SavedDigestResult instances from a CSV file.
+// This uses gocsv for robust CSV parsing with automatic type conversion.
+func LoadDigestResultsCSV(filePath string) ([]SavedDigestResult, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error opening CSV file %s", filePath)
+	}
+	defer file.Close()
+
+	var results []SavedDigestResult
+	if err := gocsv.UnmarshalFile(file, &results); err != nil {
+		return nil, errors.Wrapf(err, "error loading CSV file %s", filePath)
+	}
+
+	return results, nil
+}
+
+// ExportResultsSummary creates a summary report of benchmark results.
+// This generates a human-readable summary using tablewriter for better formatting.
+func ExportResultsSummary(results []DigestRunResult, filePath string) error {
+	if len(results) == 0 {
+		return errors.New("no results to summarize")
+	}
+
+	file, err := os.Create(filePath)
+	if err != nil {
+		return errors.Wrapf(err, "error creating summary file %s", filePath)
+	}
+	defer file.Close()
+
+	// Write summary header
+	fmt.Fprintf(file, "# Digest Benchmark Results Summary\n\n")
+	fmt.Fprintf(file, "Generated at: %s\n\n", time.Now().Format(time.RFC3339))
+
+	// Write summary statistics using tablewriter
+	fmt.Fprintf(file, "## Summary Statistics\n\n")
+
+	summaryTable := tablewriter.NewWriter(file)
+	summaryTable.SetHeader([]string{"Metric", "Value"})
+	summaryTable.SetBorder(false)
+	summaryTable.Append([]string{"Total Results", fmt.Sprintf("%d", len(results))})
+	summaryTable.Append([]string{"Unique Cases", fmt.Sprintf("%d", countUniqueCases(results))})
+	summaryTable.Append([]string{"Total Candidates", fmt.Sprintf("%d", sumCandidates(results))})
+	summaryTable.Append([]string{"Total Processed Days", fmt.Sprintf("%d", sumProcessedDays(results))})
+	summaryTable.Append([]string{"Total Deleted Rows", fmt.Sprintf("%d", sumDeletedRows(results))})
+	summaryTable.Append([]string{"Average Duration", averageDuration(results).String()})
+	summaryTable.Append([]string{"Peak Memory Usage", fmt.Sprintf("%d MB", peakMemoryMB(results))})
+	summaryTable.Render()
+
+	// Write per-case breakdown using tablewriter
+	fmt.Fprintf(file, "\n## Per-Case Breakdown\n\n")
+
+	caseTable := tablewriter.NewWriter(file)
+	caseTable.SetHeader([]string{
+		"Streams", "Days/Stream", "Records/Day", "Batch Size",
+		"Pattern", "Samples", "Candidates", "Duration", "Days/sec", "Memory MB",
+	})
+	caseTable.SetBorder(true)
+	caseTable.SetRowSeparator("-")
+	caseTable.SetColumnSeparator("|")
+	caseTable.SetCenterSeparator("+")
+
+	for _, result := range results {
+		caseTable.Append([]string{
+			fmt.Sprintf("%d", result.Case.Streams),
+			fmt.Sprintf("%d", result.Case.DaysPerStream),
+			fmt.Sprintf("%d", result.Case.RecordsPerDay),
+			fmt.Sprintf("%d", result.Case.BatchSize),
+			result.Case.Pattern,
+			fmt.Sprintf("%d", result.Case.Samples),
+			fmt.Sprintf("%d", result.Candidates),
+			result.Duration.String(),
+			fmt.Sprintf("%.2f", result.DaysPerSecond),
+			fmt.Sprintf("%d", result.MemoryMaxBytes/1024/1024),
+		})
+	}
+
+	caseTable.Render()
+
+	// Write performance analysis section
+	fmt.Fprintf(file, "\n## Performance Analysis\n\n")
+
+	// Calculate and display performance insights using lo functions
+	if len(results) > 0 {
+		durations := lo.Map(results, func(r DigestRunResult, _ int) time.Duration { return r.Duration })
+		minDuration := lo.Min(durations)
+		maxDuration := lo.Max(durations)
+		avgDuration := lo.Mean(lo.Map(durations, func(d time.Duration, _ int) float64 { return float64(d.Nanoseconds()) }))
+
+		throughputs := lo.Map(results, func(r DigestRunResult, _ int) float64 { return r.DaysPerSecond })
+		maxThroughput := lo.Max(throughputs)
+
+		fmt.Fprintf(file, "### Duration Statistics\n")
+		fmt.Fprintf(file, "- Min Duration: %v\n", minDuration)
+		fmt.Fprintf(file, "- Max Duration: %v\n", maxDuration)
+		fmt.Fprintf(file, "- Avg Duration: %v\n", time.Duration(avgDuration))
+		fmt.Fprintf(file, "- Max Throughput: %.2f days/sec\n", maxThroughput)
+
+		// Pattern performance comparison
+		patternGroups := lo.GroupBy(results, func(r DigestRunResult) string { return r.Case.Pattern })
+		if len(patternGroups) > 1 {
+			fmt.Fprintf(file, "\n### Pattern Performance Comparison\n")
+			for pattern, patternResults := range patternGroups {
+				avgThroughput := lo.Mean(lo.Map(patternResults, func(r DigestRunResult, _ int) float64 { return r.DaysPerSecond }))
+				fmt.Fprintf(file, "- %s: %.2f days/sec (avg)\n", pattern, avgThroughput)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Helper functions for summary statistics
+func countUniqueCases(results []DigestRunResult) int {
+	caseMap := make(map[string]bool)
+	for _, result := range results {
+		key := fmt.Sprintf("%d_%d_%d_%d_%s_%d",
+			result.Case.Streams,
+			result.Case.DaysPerStream,
+			result.Case.RecordsPerDay,
+			result.Case.BatchSize,
+			result.Case.Pattern,
+			result.Case.Samples,
+		)
+		caseMap[key] = true
+	}
+	return len(caseMap)
+}
+
+func sumCandidates(results []DigestRunResult) int {
+	total := 0
+	for _, result := range results {
+		total += result.Candidates
+	}
+	return total
+}
+
+func sumProcessedDays(results []DigestRunResult) int {
+	total := 0
+	for _, result := range results {
+		total += result.ProcessedDays
+	}
+	return total
+}
+
+func sumDeletedRows(results []DigestRunResult) int {
+	total := 0
+	for _, result := range results {
+		total += result.TotalDeletedRows
+	}
+	return total
+}
+
+func averageDuration(results []DigestRunResult) time.Duration {
+	if len(results) == 0 {
+		return 0
+	}
+	var total time.Duration
+	for _, result := range results {
+		total += result.Duration
+	}
+	return total / time.Duration(len(results))
+}
+
+func peakMemoryMB(results []DigestRunResult) uint64 {
+	var peak uint64
+	for _, result := range results {
+		if result.MemoryMaxBytes > peak {
+			peak = result.MemoryMaxBytes
+		}
+	}
+	return peak / 1024 / 1024
+}
+
+// MergeResultsFiles merges multiple CSV result files into a single file.
+// This is useful for combining results from multiple benchmark runs.
+func MergeResultsFiles(inputFiles []string, outputFile string) error {
+	if len(inputFiles) == 0 {
+		return errors.New("no input files provided")
+	}
+
+	var allResults []SavedDigestResult
+
+	// Load all results from input files
+	for _, file := range inputFiles {
+		results, err := LoadDigestResultsCSV(file)
+		if err != nil {
+			return errors.Wrapf(err, "error loading results from %s", file)
+		}
+		allResults = append(allResults, results...)
+	}
+
+	// Convert SavedDigestResult back to DigestRunResult for saving
+	var runResults []DigestRunResult
+	for _, saved := range allResults {
+		runResults = append(runResults, convertSavedResultToRunResult(saved))
+	}
+
+	// Save merged results
+	return SaveDigestResultsCSV(runResults, outputFile)
+}
+
+// ValidateCSVFile validates that a CSV file contains valid benchmark results.
+// This checks for required columns and data integrity.
+func ValidateCSVFile(filePath string) error {
+	results, err := LoadDigestResultsCSV(filePath)
+	if err != nil {
+		return errors.Wrap(err, "error loading CSV file")
+	}
+
+	if len(results) == 0 {
+		return errors.New("CSV file contains no results")
+	}
+
+	// Validate each result
+	for i, result := range results {
+		if err := validateSavedResult(result); err != nil {
+			return errors.Wrapf(err, "result %d validation failed", i)
+		}
+	}
+
+	return nil
+}
+
+// validateSavedResult validates a single SavedDigestResult for data integrity.
+func validateSavedResult(result SavedDigestResult) error {
+	if result.Streams <= 0 {
+		return errors.New("streams must be positive")
+	}
+	if result.DaysPerStream <= 0 {
+		return errors.New("days_per_stream must be positive")
+	}
+	if result.RecordsPerDay <= 0 {
+		return errors.New("records_per_day must be positive")
+	}
+	if result.BatchSize <= 0 {
+		return errors.New("batch_size must be positive")
+	}
+	if result.Samples <= 0 {
+		return errors.New("samples must be positive")
+	}
+	if result.Candidates < 0 {
+		return errors.New("candidates cannot be negative")
+	}
+	if result.ProcessedDays < 0 {
+		return errors.New("processed_days cannot be negative")
+	}
+	if result.DurationMs < 0 {
+		return errors.New("duration_ms cannot be negative")
+	}
+	if result.MemoryMB == 0 {
+		return errors.New("memory_mb should be measured")
+	}
+
+	return nil
+}
+
+// GenerateBenchmarkReport creates a comprehensive benchmark report using all new libraries.
+// This demonstrates the power of combining gocsv, tablewriter, and montanaflynn/stats.
+func GenerateBenchmarkReport(results []DigestRunResult, outputDir string) error {
+	if len(results) == 0 {
+		return errors.New("no results to report")
+	}
+
+	// Save raw results using gocsv
+	csvPath := fmt.Sprintf("%s/benchmark_results.csv", outputDir)
+	if err := SaveDigestResultsCSV(results, csvPath); err != nil {
+		return errors.Wrap(err, "failed to save CSV results")
+	}
+
+	// Generate summary report using tablewriter
+	summaryPath := fmt.Sprintf("%s/benchmark_summary.md", outputDir)
+	if err := ExportResultsSummary(results, summaryPath); err != nil {
+		return errors.Wrap(err, "failed to generate summary report")
+	}
+
+	// Generate statistical analysis report
+	statsPath := fmt.Sprintf("%s/statistical_analysis.md", outputDir)
+	if err := GenerateStatisticalAnalysisReport(results, statsPath); err != nil {
+		return errors.Wrap(err, "failed to generate statistical analysis")
+	}
+
+	return nil
+}
+
+// GenerateStatisticalAnalysisReport creates detailed statistical analysis using montanaflynn/stats.
+func GenerateStatisticalAnalysisReport(results []DigestRunResult, filePath string) error {
+	file, err := os.Create(filePath)
+	if err != nil {
+		return errors.Wrapf(err, "error creating analysis file %s", filePath)
+	}
+	defer file.Close()
+
+	fmt.Fprintf(file, "# Statistical Analysis Report\n\n")
+	fmt.Fprintf(file, "Generated at: %s\n\n", time.Now().Format(time.RFC3339))
+
+	// Extract metrics for statistical analysis
+	durations := lo.Map(results, func(r DigestRunResult, _ int) float64 { return float64(r.Duration.Milliseconds()) })
+	throughputs := lo.Map(results, func(r DigestRunResult, _ int) float64 { return r.DaysPerSecond })
+	memoryUsages := lo.Map(results, func(r DigestRunResult, _ int) float64 { return float64(r.MemoryMaxBytes) / 1024 / 1024 })
+
+	// Duration statistics
+	fmt.Fprintf(file, "## Duration Analysis (milliseconds)\n\n")
+	if mean, err := stats.Mean(durations); err == nil {
+		fmt.Fprintf(file, "- Mean: %.2f ms\n", mean)
+	}
+	if median, err := stats.Median(durations); err == nil {
+		fmt.Fprintf(file, "- Median: %.2f ms\n", median)
+	}
+	if stdDev, err := stats.StandardDeviation(durations); err == nil {
+		fmt.Fprintf(file, "- Standard Deviation: %.2f ms\n", stdDev)
+	}
+	if p95, err := stats.Percentile(durations, 95); err == nil {
+		fmt.Fprintf(file, "- 95th Percentile: %.2f ms\n", p95)
+	}
+	if p99, err := stats.Percentile(durations, 99); err == nil {
+		fmt.Fprintf(file, "- 99th Percentile: %.2f ms\n", p99)
+	}
+
+	// Throughput statistics
+	fmt.Fprintf(file, "\n## Throughput Analysis (days/second)\n\n")
+	if mean, err := stats.Mean(throughputs); err == nil {
+		fmt.Fprintf(file, "- Mean: %.2f days/sec\n", mean)
+	}
+	if max, err := stats.Max(throughputs); err == nil {
+		fmt.Fprintf(file, "- Maximum: %.2f days/sec\n", max)
+	}
+	if min, err := stats.Min(throughputs); err == nil {
+		fmt.Fprintf(file, "- Minimum: %.2f days/sec\n", min)
+	}
+
+	// Memory usage statistics
+	fmt.Fprintf(file, "\n## Memory Usage Analysis (MB)\n\n")
+	if mean, err := stats.Mean(memoryUsages); err == nil {
+		fmt.Fprintf(file, "- Mean: %.2f MB\n", mean)
+	}
+	if max, err := stats.Max(memoryUsages); err == nil {
+		fmt.Fprintf(file, "- Peak: %.2f MB\n", max)
+	}
+
+	// Pattern comparison using lo.GroupBy
+	fmt.Fprintf(file, "\n## Pattern Performance Comparison\n\n")
+	patternGroups := lo.GroupBy(results, func(r DigestRunResult) string { return r.Case.Pattern })
+
+	patternTable := tablewriter.NewWriter(file)
+	patternTable.SetHeader([]string{"Pattern", "Count", "Avg Throughput", "Avg Duration", "Peak Memory"})
+	patternTable.SetBorder(true)
+
+	for pattern, patternResults := range patternGroups {
+		patternThroughputs := lo.Map(patternResults, func(r DigestRunResult, _ int) float64 { return r.DaysPerSecond })
+		patternDurations := lo.Map(patternResults, func(r DigestRunResult, _ int) float64 { return float64(r.Duration.Milliseconds()) })
+		patternMemories := lo.Map(patternResults, func(r DigestRunResult, _ int) float64 { return float64(r.MemoryMaxBytes) / 1024 / 1024 })
+
+		avgThroughput, _ := stats.Mean(patternThroughputs)
+		avgDuration, _ := stats.Mean(patternDurations)
+		peakMemory, _ := stats.Max(patternMemories)
+
+		patternTable.Append([]string{
+			pattern,
+			fmt.Sprintf("%d", len(patternResults)),
+			fmt.Sprintf("%.2f", avgThroughput),
+			fmt.Sprintf("%.2f ms", avgDuration),
+			fmt.Sprintf("%.2f MB", peakMemory),
+		})
+	}
+
+	patternTable.Render()
+
+	// Performance insights
+	fmt.Fprintf(file, "\n## Performance Insights\n\n")
+
+	// Identify best performing pattern
+	bestPattern := ""
+	bestThroughput := 0.0
+	for pattern, patternResults := range patternGroups {
+		avgThroughput, _ := stats.Mean(lo.Map(patternResults, func(r DigestRunResult, _ int) float64 { return r.DaysPerSecond }))
+		if avgThroughput > bestThroughput {
+			bestThroughput = avgThroughput
+			bestPattern = pattern
+		}
+	}
+
+	fmt.Fprintf(file, "- **Best Pattern**: %s (%.2f days/sec average)\n", bestPattern, bestThroughput)
+
+	// Duration variability analysis
+	if stdDev, err := stats.StandardDeviation(durations); err == nil {
+		if mean, err := stats.Mean(durations); err == nil {
+			coefficientOfVariation := stdDev / mean
+			if coefficientOfVariation > 0.5 {
+				fmt.Fprintf(file, "- **Duration Variability**: High (%.2f%%) - Consider investigating sources of variance\n", coefficientOfVariation*100)
+			} else if coefficientOfVariation > 0.2 {
+				fmt.Fprintf(file, "- **Duration Variability**: Moderate (%.2f%%) - Performance is reasonably consistent\n", coefficientOfVariation*100)
+			} else {
+				fmt.Fprintf(file, "- **Duration Variability**: Low (%.2f%%) - Excellent performance consistency\n", coefficientOfVariation*100)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/benchmark/digest/export.go
+++ b/internal/benchmark/digest/export.go
@@ -3,6 +3,7 @@ package digest
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gocarina/gocsv"
@@ -99,6 +100,12 @@ func SaveDigestResultsCSV(results []DigestRunResult, filePath string) error {
 // saveToCSVUsingBenchexport saves data using gocsv for robust CSV handling.
 // This provides better error handling and automatic type conversion.
 func saveToCSVUsingBenchexport(data []SavedDigestResult, filePath string) error {
+	// Ensure the directory exists
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return errors.Wrapf(err, "error creating directory %s", dir)
+	}
+
 	file, err := os.Create(filePath)
 	if err != nil {
 		return errors.Wrapf(err, "error creating file %s", filePath)
@@ -135,6 +142,12 @@ func LoadDigestResultsCSV(filePath string) ([]SavedDigestResult, error) {
 func ExportResultsSummary(results []DigestRunResult, filePath string) error {
 	if len(results) == 0 {
 		return errors.New("no results to summarize")
+	}
+
+	// Ensure the directory exists
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return errors.Wrapf(err, "error creating directory %s", dir)
 	}
 
 	file, err := os.Create(filePath)

--- a/internal/benchmark/digest/export.go
+++ b/internal/benchmark/digest/export.go
@@ -172,7 +172,7 @@ func ExportResultsSummary(results []DigestRunResult, filePath string) error {
 
 	caseTable := tablewriter.NewWriter(file)
 	caseTable.SetHeader([]string{
-		"Streams", "Days/Stream", "Records/Day", "Batch Size",
+		"Streams", "Days/Stream", "Records/Day", "Delete Cap",
 		"Pattern", "Samples", "Candidates", "Duration", "Days/sec", "Memory MB",
 	})
 	caseTable.SetBorder(true)
@@ -185,6 +185,7 @@ func ExportResultsSummary(results []DigestRunResult, filePath string) error {
 			fmt.Sprintf("%d", result.Case.Streams),
 			fmt.Sprintf("%d", result.Case.DaysPerStream),
 			fmt.Sprintf("%d", result.Case.RecordsPerDay),
+			fmt.Sprintf("%d", result.Case.DeleteCap),
 
 			result.Case.Pattern,
 			fmt.Sprintf("%d", result.Case.Samples),

--- a/internal/benchmark/digest/helpers.go
+++ b/internal/benchmark/digest/helpers.go
@@ -1,0 +1,89 @@
+package digest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/trufnetwork/kwil-db/common"
+	kwilTesting "github.com/trufnetwork/kwil-db/testing"
+	util "github.com/trufnetwork/sdk-go/core/util"
+)
+
+// GetDeployerOrDefault returns the deployer EthereumAddress from the platform,
+// falling back to a deterministic default test address when unavailable.
+func GetDeployerOrDefault(platform *kwilTesting.Platform) (util.EthereumAddress, error) {
+	// Try to create from bytes first
+	deployer, err := util.NewEthereumAddressFromBytes(platform.Deployer)
+	if err == nil {
+		return deployer, nil
+	}
+
+	// Fallback: deterministic default
+	defaultAddr := make([]byte, 20)
+	for i := range defaultAddr {
+		defaultAddr[i] = byte(i % 256)
+	}
+	return util.NewEthereumAddressFromBytes(defaultAddr)
+}
+
+// NewTxContext builds a standard TxContext for engine calls/queries.
+func NewTxContext(ctx context.Context, platform *kwilTesting.Platform, signer util.EthereumAddress) *common.TxContext {
+	return &common.TxContext{
+		Ctx:          ctx,
+		BlockContext: &common.BlockContext{Height: 1},
+		Signer:       signer.Bytes(),
+		Caller:       signer.Address(),
+		TxID:         platform.Txid(),
+	}
+}
+
+// AnalyzeTables performs ANALYZE on the provided table names in the default schema.
+// Tables are analyzed individually to avoid hanging on non-existent or large tables.
+func AnalyzeTables(ctx context.Context, platform *kwilTesting.Platform, tables []string) error {
+	if len(tables) == 0 {
+		return nil
+	}
+
+	var errors []string
+
+	// Analyze each table individually to avoid hanging on problematic tables
+	for _, table := range tables {
+		if err := analyzeSingleTable(ctx, platform, table); err != nil {
+			// Log the error but continue with other tables
+			errors = append(errors, fmt.Sprintf("failed to analyze %s: %v", table, err))
+		}
+	}
+
+	// If all tables failed, return an error
+	if len(errors) == len(tables) {
+		return fmt.Errorf("all table analyses failed: %s", strings.Join(errors, "; "))
+	}
+
+	// If some tables failed, log warnings but don't fail the entire operation
+	if len(errors) > 0 {
+		fmt.Printf("Warning: Some tables could not be analyzed: %s\n", strings.Join(errors, "; "))
+	}
+
+	return nil
+}
+
+// analyzeSingleTable analyzes a single table with timeout protection.
+func analyzeSingleTable(ctx context.Context, platform *kwilTesting.Platform, table string) error {
+	// Create a timeout context for the ANALYZE operation
+	analyzeCtx, cancel := context.WithTimeout(ctx, 30*time.Second) // 30 second timeout
+	defer cancel()
+
+	// Build fully qualified table name
+	fullQualified := fmt.Sprintf("%s.%s", DefaultSchema, table)
+
+	query := fmt.Sprintf("ANALYZE %s;", fullQualified)
+
+	_, err := platform.DB.Execute(analyzeCtx, query)
+	if err != nil {
+		return fmt.Errorf("error analyzing table %s: %w", fullQualified, err)
+	}
+
+	return nil
+}

--- a/internal/benchmark/digest/runner.go
+++ b/internal/benchmark/digest/runner.go
@@ -1,0 +1,790 @@
+package digest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/trufnetwork/kwil-db/common"
+	kwilTesting "github.com/trufnetwork/kwil-db/testing"
+	benchutil "github.com/trufnetwork/node/internal/benchmark/util"
+)
+
+// SliceCandidates splits large candidate arrays into optimal batch sizes.
+// This prevents UNNEST + WITH RECURSIVE degradation by keeping batches manageable.
+func SliceCandidates(streamRefs []int, dayIdxs []int, batchSize int) []CandidateBatch {
+	if len(streamRefs) != len(dayIdxs) {
+		// Handle error case - arrays must be same length
+		return nil
+	}
+
+	if len(streamRefs) == 0 {
+		return []CandidateBatch{}
+	}
+
+	var batches []CandidateBatch
+
+	for i := 0; i < len(streamRefs); i += batchSize {
+		end := i + batchSize
+		if end > len(streamRefs) {
+			end = len(streamRefs)
+		}
+
+		batch := CandidateBatch{
+			StreamRefs: streamRefs[i:end],
+			DayIdxs:    dayIdxs[i:end],
+		}
+
+		batches = append(batches, batch)
+	}
+
+	return batches
+}
+
+// RunBatchDigestOnce executes batch_digest for a single batch of candidates.
+// Returns processed days, deleted rows, and preserved rows counts.
+func RunBatchDigestOnce(ctx context.Context, platform interface{}, streamRefs []int, dayIdxs []int) (processedDays, totalDeleted, totalPreserved int, err error) {
+	kwilPlatform, ok := platform.(*kwilTesting.Platform)
+	if !ok {
+		return 0, 0, 0, errors.New("invalid platform type")
+	}
+
+	// Get the deployer for signing via shared helper
+	dep, err := GetDeployerOrDefault(kwilPlatform)
+	if err != nil {
+		return 0, 0, 0, errors.Wrap(err, "failed to get deployer")
+	}
+
+	// Create transaction context
+	txContext := NewTxContext(ctx, kwilPlatform, dep)
+
+	engineContext := &common.EngineContext{
+		TxContext: txContext,
+	}
+
+	// Call the batch_digest action
+	r, err := kwilPlatform.Engine.Call(engineContext, kwilPlatform.DB, "", "batch_digest", []any{
+		streamRefs,
+		dayIdxs,
+	}, func(row *common.Row) error {
+		if len(row.Values) != 3 {
+			return errors.Errorf("expected 3 columns, got %d", len(row.Values))
+		}
+
+		// Parse the results
+		var processed, deleted, preserved int
+		if processedVal, ok := row.Values[0].(int64); ok {
+			processed = int(processedVal)
+		}
+		if deletedVal, ok := row.Values[1].(int64); ok {
+			deleted = int(deletedVal)
+		}
+		if preservedVal, ok := row.Values[2].(int64); ok {
+			preserved = int(preservedVal)
+		}
+
+		processedDays = processed
+		totalDeleted = deleted
+		totalPreserved = preserved
+
+		return nil
+	})
+
+	if err != nil {
+		return 0, 0, 0, errors.Wrap(err, "error calling batch_digest")
+	}
+	if r.Error != nil {
+		return 0, 0, 0, errors.Wrap(r.Error, "batch_digest procedure error")
+	}
+
+	return processedDays, totalDeleted, totalPreserved, nil
+}
+
+// MeasureBatchDigest measures performance metrics for a batch_digest execution.
+// Returns a DigestRunResult with timing, memory, and throughput metrics.
+// The collector parameter can be nil if memory monitoring is disabled.
+func MeasureBatchDigest(ctx context.Context, platform interface{}, streamRefs []int, dayIdxs []int, collector *benchutil.DockerMemoryCollector) (DigestRunResult, error) {
+	kwilPlatform, ok := platform.(*kwilTesting.Platform)
+	if !ok {
+		return DigestRunResult{}, errors.New("invalid platform type")
+	}
+
+	// Execute the batch digest and measure timing
+	startTime := time.Now()
+	processedDays, totalDeleted, totalPreserved, err := RunBatchDigestOnce(ctx, kwilPlatform, streamRefs, dayIdxs)
+	duration := time.Since(startTime)
+
+	if err != nil {
+		return DigestRunResult{}, errors.Wrap(err, "batch digest execution failed")
+	}
+
+	// Get memory usage (0 if monitoring is disabled)
+	var maxMemory uint64
+	if collector != nil {
+		var err error
+		maxMemory, err = collector.GetMaxMemoryUsage()
+		if err != nil {
+			// Log error but don't fail the entire benchmark
+			fmt.Printf("Warning: failed to get memory usage: %v\n", err)
+		}
+	}
+
+	// Calculate throughput metrics
+	var daysPerSecond, rowsDeletedPerSecond float64
+	if duration.Seconds() > 0 {
+		daysPerSecond = float64(processedDays) / duration.Seconds()
+		rowsDeletedPerSecond = float64(totalDeleted) / duration.Seconds()
+	}
+
+	// Create result
+	result := DigestRunResult{
+		Candidates:           len(streamRefs),
+		ProcessedDays:        processedDays,
+		TotalDeletedRows:     totalDeleted,
+		TotalPreservedRows:   totalPreserved,
+		Duration:             duration,
+		MemoryMaxBytes:       maxMemory,
+		DaysPerSecond:        daysPerSecond,
+		RowsDeletedPerSecond: rowsDeletedPerSecond,
+		WALBytes:             nil, // TODO: Implement WAL tracking
+	}
+
+	return result, nil
+}
+
+// RunCase executes a complete benchmark case with multiple samples.
+// Returns all run results for statistical analysis.
+func RunCase(ctx context.Context, platform interface{}, c DigestBenchmarkCase) ([]DigestRunResult, error) {
+	// Validate the benchmark case first
+	if err := ValidateBenchmarkCase(c); err != nil {
+		return nil, errors.Wrap(err, "invalid benchmark case")
+	}
+
+	var results []DigestRunResult
+
+	// Generate all candidates for this case
+	streamRefs := make([]int, c.Streams*c.DaysPerStream)
+	dayIdxs := make([]int, c.Streams*c.DaysPerStream)
+
+	// Fill arrays with all possible combinations
+	idx := 0
+	for stream := 1; stream <= c.Streams; stream++ {
+		for day := 0; day < c.DaysPerStream; day++ {
+			streamRefs[idx] = stream
+			dayIdxs[idx] = day
+			idx++
+		}
+	}
+
+	// Slice candidates into optimal batches
+	batches := SliceCandidates(streamRefs, dayIdxs, c.BatchSize)
+
+	for sample := 0; sample < c.Samples; sample++ {
+		var sampleResults []DigestRunResult
+
+		// Start memory monitoring for this sample (shared across all batches in the sample)
+		var collector *benchutil.DockerMemoryCollector
+		if enableMemoryMonitoring := os.Getenv("ENABLE_MEMORY_MONITORING"); enableMemoryMonitoring != "false" {
+			fmt.Printf("Attempting to start Docker memory monitoring for container '%s' (sample %d/%d)...\n", DockerPostgresContainer, sample+1, c.Samples)
+
+			var err error
+			collector, err = benchutil.StartDockerMemoryCollector(DockerPostgresContainer)
+			if err != nil {
+				// Log the error but continue without memory monitoring
+				fmt.Printf("Warning: failed to start memory collector: %v\n", err)
+				fmt.Println("Continuing without memory monitoring...")
+				fmt.Println("Tip: Set ENABLE_MEMORY_MONITORING=false to disable this warning")
+			} else {
+				// Wait for the collector to receive at least one stats sample with shorter timeout
+				sampleTimeout := 5 * time.Second // Reduced from 10 seconds
+				if timeoutEnv := os.Getenv("DOCKER_STATS_TIMEOUT"); timeoutEnv != "" {
+					if parsed, err := time.ParseDuration(timeoutEnv); err == nil {
+						sampleTimeout = parsed
+					}
+				}
+
+				sampleCtx, cancel := context.WithTimeout(context.Background(), sampleTimeout)
+				defer cancel()
+
+				// Create a channel to signal completion
+				done := make(chan error, 1)
+				go func() {
+					done <- collector.WaitForFirstSample()
+				}()
+
+				select {
+				case err := <-done:
+					if err != nil {
+						// Log the error but continue without memory monitoring
+						fmt.Printf("Warning: failed to get first memory sample: %v\n", err)
+						fmt.Println("Continuing without memory monitoring...")
+						collector.Stop()
+						collector = nil
+					} else {
+						fmt.Println("Memory monitoring started successfully")
+						defer collector.Stop()
+					}
+				case <-sampleCtx.Done():
+					fmt.Printf("Warning: Docker stats collection timed out after %v\n", sampleTimeout)
+					fmt.Println("Continuing without memory monitoring...")
+					collector.Stop()
+					collector = nil
+				}
+			}
+		} else {
+			fmt.Println("Memory monitoring disabled via ENABLE_MEMORY_MONITORING=false")
+		}
+
+		// Run each batch in the sample (without individual memory collectors)
+		for _, candidateBatch := range batches {
+			result, err := MeasureBatchDigest(ctx, platform, candidateBatch.StreamRefs, candidateBatch.DayIdxs, collector)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to measure batch for sample %d", sample)
+			}
+
+			// Update result with case information
+			result.Case = c
+			result.Candidates = len(candidateBatch.StreamRefs)
+
+			sampleResults = append(sampleResults, result)
+		}
+
+		// Aggregate results for this sample
+		if len(sampleResults) > 0 {
+			aggregatedResult := AggregateResults(sampleResults)
+			aggregatedResult.Case = c
+			results = append(results, aggregatedResult)
+		}
+	}
+
+	return results, nil
+}
+
+// VerifyDigestStats performs spot checks to verify digest correctness.
+// Compares before/after record counts and validates OHLC preservation.
+func VerifyDigestStats(ctx context.Context, platform interface{}, sampleSize int) (bool, error) {
+	kwilPlatform, ok := platform.(*kwilTesting.Platform)
+	if !ok {
+		return false, errors.New("invalid platform type")
+	}
+
+	// Get the deployer for signing queries via helper
+	deployer, err := GetDeployerOrDefault(kwilPlatform)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get deployer")
+	}
+
+	// Create transaction context for queries
+	txContext := NewTxContext(ctx, kwilPlatform, deployer)
+
+	engineContext := &common.EngineContext{
+		TxContext: txContext,
+	}
+
+	// Query for pending prune days to verify they exist
+	var pendingCount int
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		SQLCountPendingPruneDays,
+		map[string]any{},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if count, ok := row.Values[0].(int64); ok {
+					pendingCount = int(count)
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return false, errors.Wrap(err, "error querying pending_prune_days")
+	}
+
+	// Check that there are pending days to process
+	if pendingCount == 0 {
+		return true, nil // No pending work is valid
+	}
+
+	// Query for primitive events to verify they exist
+	var eventCount int
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		SQLCountPrimitiveEvents,
+		map[string]any{},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if count, ok := row.Values[0].(int64); ok {
+					eventCount = int(count)
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return false, errors.Wrap(err, "error querying primitive_events")
+	}
+
+	// Basic sanity checks
+	if eventCount == 0 && pendingCount > 0 {
+		return false, errors.New("pending prune days exist but no primitive events found")
+	}
+
+	// TODO: Add more sophisticated verification checks
+	// - Verify OHLC preservation for digested days
+	// - Check primitive_event_type table population
+	// - Validate record counts before/after
+
+	return true, nil
+}
+
+// VerifyIdempotency checks that re-running digest returns 0 changes.
+// This validates the idempotent behavior of the digest system.
+func VerifyIdempotency(ctx context.Context, platform interface{}, c DigestBenchmarkCase) (bool, error) {
+	kwilPlatform, ok := platform.(*kwilTesting.Platform)
+	if !ok {
+		return false, errors.New("invalid platform type")
+	}
+
+	// Generate candidates for idempotency test
+	streamRefs := make([]int, c.Streams*c.DaysPerStream)
+	dayIdxs := make([]int, c.Streams*c.DaysPerStream)
+
+	idx := 0
+	for stream := 1; stream <= c.Streams; stream++ {
+		for day := 0; day < c.DaysPerStream; day++ {
+			streamRefs[idx] = stream
+			dayIdxs[idx] = day
+			idx++
+		}
+	}
+
+	// Run digest once
+	firstProcessed, firstDeleted, firstPreserved, err := RunBatchDigestOnce(ctx, kwilPlatform, streamRefs, dayIdxs)
+	if err != nil {
+		return false, errors.Wrap(err, "error in first digest run")
+	}
+
+	// Run digest again on the same candidates
+	secondProcessed, secondDeleted, secondPreserved, err := RunBatchDigestOnce(ctx, kwilPlatform, streamRefs, dayIdxs)
+	if err != nil {
+		return false, errors.Wrap(err, "error in second digest run")
+	}
+
+	// Verify idempotency: second run should process 0 days and delete 0 rows
+	if secondProcessed != 0 {
+		return false, fmt.Errorf("second run processed %d days, expected 0", secondProcessed)
+	}
+	if secondDeleted != 0 {
+		return false, fmt.Errorf("second run deleted %d rows, expected 0", secondDeleted)
+	}
+	if secondPreserved != 0 {
+		return false, fmt.Errorf("second run preserved %d rows, expected 0", secondPreserved)
+	}
+
+	fmt.Printf("Idempotency verified: first run (%d processed, %d deleted, %d preserved), second run (0, 0, 0)\n",
+		firstProcessed, firstDeleted, firstPreserved)
+
+	return true, nil
+}
+
+// AggregateResults combines multiple DigestRunResult instances into a single aggregated result.
+// This is useful for combining results from multiple batches within a sample.
+func AggregateResults(results []DigestRunResult) DigestRunResult {
+	if len(results) == 0 {
+		return DigestRunResult{}
+	}
+
+	aggregated := DigestRunResult{
+		Case:                 results[0].Case,
+		Duration:             0,
+		MemoryMaxBytes:       0,
+		DaysPerSecond:        0,
+		RowsDeletedPerSecond: 0,
+	}
+
+	totalDuration := time.Duration(0)
+	var maxMemory uint64
+
+	for _, result := range results {
+		// Aggregate counts
+		aggregated.Candidates += result.Candidates
+		aggregated.ProcessedDays += result.ProcessedDays
+		aggregated.TotalDeletedRows += result.TotalDeletedRows
+		aggregated.TotalPreservedRows += result.TotalPreservedRows
+
+		// Aggregate timing
+		totalDuration += result.Duration
+
+		// Track peak memory usage
+		if result.MemoryMaxBytes > maxMemory {
+			maxMemory = result.MemoryMaxBytes
+		}
+
+		// Aggregate WAL if present
+		if result.WALBytes != nil {
+			if aggregated.WALBytes == nil {
+				walValue := int64(0)
+				aggregated.WALBytes = &walValue
+			}
+			*aggregated.WALBytes += *result.WALBytes
+		}
+	}
+
+	aggregated.Duration = totalDuration
+	aggregated.MemoryMaxBytes = maxMemory
+
+	// Calculate throughput metrics
+	if aggregated.Duration.Seconds() > 0 {
+		aggregated.DaysPerSecond = float64(aggregated.ProcessedDays) / aggregated.Duration.Seconds()
+		aggregated.RowsDeletedPerSecond = float64(aggregated.TotalDeletedRows) / aggregated.Duration.Seconds()
+	}
+
+	return aggregated
+}
+
+// CalculateThroughputMetrics calculates derived throughput metrics for a result.
+// This includes days/second, rows deleted/second, and memory efficiency metrics.
+func CalculateThroughputMetrics(result *DigestRunResult) {
+	if result.Duration.Seconds() > 0 {
+		result.DaysPerSecond = float64(result.ProcessedDays) / result.Duration.Seconds()
+		result.RowsDeletedPerSecond = float64(result.TotalDeletedRows) / result.Duration.Seconds()
+	}
+}
+
+// ValidateResult performs validation checks on a benchmark result.
+// Ensures the result contains reasonable values and required metrics.
+func ValidateResult(result DigestRunResult) error {
+	if result.Candidates < 0 {
+		return errors.New("candidates cannot be negative")
+	}
+	if result.ProcessedDays < 0 {
+		return errors.New("processed_days cannot be negative")
+	}
+	if result.TotalDeletedRows < 0 {
+		return errors.New("total_deleted_rows cannot be negative")
+	}
+	if result.TotalPreservedRows < 0 {
+		return errors.New("total_preserved_rows cannot be negative")
+	}
+	if result.Duration < 0 {
+		return errors.New("duration cannot be negative")
+	}
+	if result.MemoryMaxBytes == 0 {
+		return errors.New("memory usage should be measured")
+	}
+
+	// Validate throughput metrics make sense
+	if result.DaysPerSecond < 0 {
+		return errors.New("days_per_second cannot be negative")
+	}
+	if result.RowsDeletedPerSecond < 0 {
+		return errors.New("rows_deleted_per_second cannot be negative")
+	}
+
+	return nil
+}
+
+// BenchmarkRunner coordinates the execution of multiple benchmark cases.
+// This is the main entry point for running digest benchmarks.
+type BenchmarkRunner struct {
+	Platform interface{} // *kwilTesting.Platform
+	Logger   interface{} // *testing.T
+}
+
+// NewBenchmarkRunner creates a new benchmark runner instance.
+func NewBenchmarkRunner(platform interface{}, logger interface{}) *BenchmarkRunner {
+	return &BenchmarkRunner{
+		Platform: platform,
+		Logger:   logger,
+	}
+}
+
+// RunBenchmarkCase executes a single benchmark case and returns the results.
+func (r *BenchmarkRunner) RunBenchmarkCase(ctx context.Context, c DigestBenchmarkCase) ([]DigestRunResult, error) {
+	// Log the start of the benchmark case
+	r.logInfo("Starting benchmark case: %+v", c)
+
+	startTime := time.Now()
+	results, err := RunCase(ctx, r.Platform, c)
+	duration := time.Since(startTime)
+
+	if err != nil {
+		r.logError("Benchmark case failed after %v: %v", duration, err)
+		return nil, err
+	}
+
+	r.logInfo("Benchmark case completed in %v, produced %d results", duration, len(results))
+
+	// Validate all results
+	for i, result := range results {
+		if err := ValidateResult(result); err != nil {
+			return nil, errors.Wrapf(err, "result %d validation failed", i)
+		}
+	}
+
+	return results, nil
+}
+
+// RunMultipleCases executes multiple benchmark cases and aggregates the results.
+func (r *BenchmarkRunner) RunMultipleCases(ctx context.Context, cases []DigestBenchmarkCase) (map[string][]DigestRunResult, error) {
+	results := make(map[string][]DigestRunResult)
+
+	for _, c := range cases {
+		caseKey := fmt.Sprintf("streams_%d_days_%d_records_%d_batch_%d_pattern_%s",
+			c.Streams, c.DaysPerStream, c.RecordsPerDay, c.BatchSize, c.Pattern)
+
+		r.logInfo("Running case: %s", caseKey)
+
+		caseResults, err := r.RunBenchmarkCase(ctx, c)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to run case %s", caseKey)
+		}
+
+		results[caseKey] = caseResults
+	}
+
+	return results, nil
+}
+
+// logInfo logs an informational message if a logger is available.
+func (r *BenchmarkRunner) logInfo(format string, args ...interface{}) {
+	if r.Logger != nil {
+		// Use reflection to call the logger's Logf method if available
+		loggerValue := reflect.ValueOf(r.Logger)
+		logfMethod := loggerValue.MethodByName("Logf")
+		if logfMethod.IsValid() {
+			// Format the message first, then pass it as a simple %s format
+			final := fmt.Sprintf(format, args...)
+			logfMethod.Call([]reflect.Value{
+				reflect.ValueOf("%s"),
+				reflect.ValueOf(final),
+			})
+		}
+	}
+}
+
+// logError logs an error message if a logger is available.
+func (r *BenchmarkRunner) logError(format string, args ...interface{}) {
+	if r.Logger != nil {
+		// Use reflection to call the logger's Errorf method if available
+		loggerValue := reflect.ValueOf(r.Logger)
+		errorfMethod := loggerValue.MethodByName("Errorf")
+		if errorfMethod.IsValid() {
+			// Format the message first, then pass it as a simple %s format
+			final := fmt.Sprintf(format, args...)
+			errorfMethod.Call([]reflect.Value{
+				reflect.ValueOf("%s"),
+				reflect.ValueOf(final),
+			})
+		}
+	}
+}
+
+// WarmupQueryPlanner performs query planner warm-up before measurements.
+// This ensures consistent query execution times by analyzing relevant tables.
+func WarmupQueryPlanner(ctx context.Context, platform interface{}) error {
+	kwilPlatform, ok := platform.(*kwilTesting.Platform)
+	if !ok {
+		return errors.New("invalid platform type")
+	}
+
+	// Define tables that need query planner optimization for digest operations
+	return warmupQueryPlanner(ctx, kwilPlatform, DigestTables)
+}
+
+// warmupQueryPlanner performs ANALYZE on specified tables for query optimization
+func warmupQueryPlanner(ctx context.Context, platform *kwilTesting.Platform, tables []string) error {
+	// Use the improved AnalyzeTables function from helpers
+	return AnalyzeTables(ctx, platform, tables)
+}
+
+// CleanupAfterBenchmark performs cleanup operations after benchmark execution.
+// This includes stopping collectors and resetting any modified state.
+func CleanupAfterBenchmark(ctx context.Context, platform interface{}) error {
+	kwilPlatform, ok := platform.(*kwilTesting.Platform)
+	if !ok {
+		return errors.New("invalid platform type")
+	}
+
+	// Clean up any temporary data created during benchmark
+	// This could include:
+	// - Clearing pending_prune_days for streams used in benchmark
+	// - Cleaning up test streams if needed
+	// - Resetting any modified configuration
+
+	// For now, just log that cleanup was performed
+	fmt.Printf("Benchmark cleanup completed for platform (deployer: %x)\n", kwilPlatform.Deployer)
+
+	return nil
+}
+
+// GetDigestStats retrieves current digest system statistics.
+// This is useful for monitoring the state of the digest system.
+func GetDigestStats(ctx context.Context, platform interface{}) (map[string]interface{}, error) {
+	kwilPlatform, ok := platform.(*kwilTesting.Platform)
+	if !ok {
+		return nil, errors.New("invalid platform type")
+	}
+
+	// Get the deployer for signing queries via helper
+	deployer, err := GetDeployerOrDefault(kwilPlatform)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get deployer")
+	}
+
+	// Create transaction context for queries
+	txContext := NewTxContext(ctx, kwilPlatform, deployer)
+
+	engineContext := &common.EngineContext{
+		TxContext: txContext,
+	}
+
+	stats := make(map[string]interface{})
+
+	// Query pending prune days count
+	var pendingCount int64
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		SQLCountPendingPruneDays,
+		map[string]any{},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if count, ok := row.Values[0].(int64); ok {
+					pendingCount = count
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error querying pending_prune_days count")
+	}
+	stats["pending_prune_days_count"] = pendingCount
+
+	// Query primitive events count
+	var eventCount int64
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		SQLCountPrimitiveEvents,
+		map[string]any{},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if count, ok := row.Values[0].(int64); ok {
+					eventCount = count
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error querying primitive_events count")
+	}
+	stats["primitive_events_count"] = eventCount
+
+	// Query primitive event type count
+	var typeCount int64
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		SQLCountPrimitiveEventType,
+		map[string]any{},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if count, ok := row.Values[0].(int64); ok {
+					typeCount = count
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error querying primitive_event_type count")
+	}
+	stats["primitive_event_type_count"] = typeCount
+
+	return stats, nil
+}
+
+// MeasureWALGrowth measures Write-Ahead Log growth during digest operations.
+// This provides insights into the I/O impact of digest operations.
+func MeasureWALGrowth(ctx context.Context, platform interface{}, operation func() error) (int64, error) {
+	kwilPlatform, ok := platform.(*kwilTesting.Platform)
+	if !ok {
+		return 0, errors.New("invalid platform type")
+	}
+
+	// Get the deployer for signing queries via helper
+	deployer, err := GetDeployerOrDefault(kwilPlatform)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get deployer")
+	}
+
+	// Create transaction context for queries
+	txContext := NewTxContext(ctx, kwilPlatform, deployer)
+
+	engineContext := &common.EngineContext{
+		TxContext: txContext,
+	}
+
+	// Get WAL position before operation
+	var beforeLSN string
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		SQLWalGetLSN,
+		map[string]any{},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if lsn, ok := row.Values[0].(string); ok {
+					beforeLSN = lsn
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return 0, errors.Wrap(err, "error getting WAL LSN before operation")
+	}
+
+	// Execute the operation
+	err = operation()
+	if err != nil {
+		return 0, errors.Wrap(err, "error executing operation for WAL measurement")
+	}
+
+	// Get WAL position after operation
+	var afterLSN string
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		SQLWalGetLSN,
+		map[string]any{},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if lsn, ok := row.Values[0].(string); ok {
+					afterLSN = lsn
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return 0, errors.Wrap(err, "error getting WAL LSN after operation")
+	}
+
+	// Calculate WAL growth difference
+	var walGrowth int64
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		SQLWalDiff,
+		map[string]any{
+			"$after_lsn":  afterLSN,
+			"$before_lsn": beforeLSN,
+		},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if growth, ok := row.Values[0].(int64); ok {
+					walGrowth = growth
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return 0, errors.Wrap(err, "error calculating WAL growth difference")
+	}
+
+	return walGrowth, nil
+}

--- a/internal/benchmark/digest/setup.go
+++ b/internal/benchmark/digest/setup.go
@@ -1,0 +1,992 @@
+package digest
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/montanaflynn/stats"
+	"github.com/pkg/errors"
+	"github.com/samber/lo"
+	"github.com/trufnetwork/kwil-db/common"
+	kwilTesting "github.com/trufnetwork/kwil-db/testing"
+	"github.com/trufnetwork/node/tests/streams/utils/setup"
+	"github.com/trufnetwork/sdk-go/core/types"
+	"github.com/trufnetwork/sdk-go/core/util"
+)
+
+// SetupDataProvider registers a data provider for the benchmark.
+// This is the entry point for setting up the testing environment.
+func SetupDataProvider(ctx context.Context, platform *kwilTesting.Platform, dataProviderAddr string) error {
+	kwilPlatform := platform
+
+	// Use the existing setup pattern from the codebase
+	return setup.CreateDataProvider(ctx, kwilPlatform, dataProviderAddr)
+}
+
+// GenerateRandomRecords creates random data records for a given day.
+// This implements the "random" pattern with uniform random values.
+func GenerateRandomRecords(dayStart int64, records int) []InsertRecordInput {
+	return NewRandomPattern().GenerateRecords(dayStart, records)
+}
+
+// GeneratePatternRecords creates records based on the specified pattern.
+// This is a factory method that delegates to specific pattern implementations.
+func GeneratePatternRecords(pattern string, dayStart int64, records int) []InsertRecordInput {
+	var generator DigestBenchmarkPattern
+
+	switch pattern {
+	case "random":
+		generator = NewRandomPattern()
+	case "dups50":
+		generator = NewDups50Pattern()
+	case "monotonic":
+		generator = NewMonotonicPattern()
+	case "equal":
+		generator = NewEqualPattern()
+	case "time_dup":
+		generator = NewTimeDupPattern()
+	default:
+		// Default to random pattern
+		generator = NewRandomPattern()
+	}
+
+	return generator.GenerateRecords(dayStart, records)
+}
+
+// InsertPrimitiveDataInBatches inserts primitive data in batches for memory efficiency.
+// This processes batches sequentially to avoid connection pool exhaustion.
+func InsertPrimitiveDataInBatches(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator, records []InsertRecordInput) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	// Split records into batches for efficient processing
+	batchSize := DefaultBatchSize
+	batches := lo.Chunk(records, batchSize)
+
+	// Process batches sequentially to avoid connection pool exhaustion
+	for i, batch := range batches {
+		if err := insertBatch(ctx, platform, locator, batch, i); err != nil {
+			return errors.Wrapf(err, "failed to insert batch %d", i)
+		}
+	}
+
+	return nil
+}
+
+// insertBatch inserts a single batch of records (helper for InsertPrimitiveDataInBatches)
+func insertBatch(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator, records []InsertRecordInput, batchIndex int) error {
+	kwilPlatform := platform
+	streamLocator := locator
+
+	// Convert records to the format expected by the batch insertion function
+	var insertInputs []setup.InsertRecordInput
+	for _, record := range records {
+		insertInputs = append(insertInputs, setup.InsertRecordInput{
+			EventTime: record.EventTime,
+			Value:     record.Value,
+		})
+	}
+
+	// Create the primitive stream with data
+	primitiveStream := setup.PrimitiveStreamWithData{
+		PrimitiveStreamDefinition: setup.PrimitiveStreamDefinition{
+			StreamLocator: streamLocator,
+		},
+		Data: insertInputs,
+	}
+
+	// Use the existing batch insertion function
+	input := setup.InsertPrimitiveDataInput{
+		Platform:        kwilPlatform,
+		Height:          1, // Default height for testing
+		PrimitiveStream: primitiveStream,
+	}
+
+	return setup.InsertPrimitiveDataBatch(ctx, input)
+}
+
+// InsertPendingPruneDays queues days for digest processing by inserting into pending_prune_days table.
+func InsertPendingPruneDays(ctx context.Context, platform *kwilTesting.Platform, streamRefs []int, dayIdxs []int) error {
+	kwilPlatform := platform
+
+	if len(streamRefs) != len(dayIdxs) {
+		return errors.New("streamRefs and dayIdxs must have the same length")
+	}
+
+	// Get the deployer for signing via helper
+	deployer, err := GetDeployerOrDefault(kwilPlatform)
+	if err != nil {
+		return errors.Wrap(err, "failed to get deployer")
+	}
+
+	// Batch insert all pending days using UNNEST for better performance
+	if len(streamRefs) > 0 {
+		err = batchInsertPendingDays(ctx, kwilPlatform, streamRefs, dayIdxs, deployer)
+		if err != nil {
+			return errors.Wrap(err, "error batch inserting pending days")
+		}
+	}
+
+	return nil
+}
+
+// insertPendingDay inserts a single day into the pending_prune_days queue
+func insertPendingDay(ctx context.Context, platform *kwilTesting.Platform, streamRef int, dayIndex int64, signer util.EthereumAddress) error {
+	// Create transaction context
+	txContext := &common.TxContext{
+		Ctx:          ctx,
+		BlockContext: &common.BlockContext{Height: 1},
+		Signer:       signer.Bytes(),
+		Caller:       signer.Address(),
+		TxID:         platform.Txid(),
+	}
+
+	engineContext := &common.EngineContext{
+		TxContext: txContext,
+	}
+
+	// Execute the insert using the existing pattern
+	err := platform.Engine.Execute(engineContext, platform.DB,
+		"INSERT INTO pending_prune_days (stream_ref, day_index) VALUES ($stream_ref, $day_index) ON CONFLICT DO NOTHING",
+		map[string]any{
+			"$stream_ref": streamRef,
+			"$day_index":  dayIndex,
+		},
+		func(row *common.Row) error {
+			return nil
+		})
+
+	if err != nil {
+		return errors.Wrap(err, "error executing pending_prune_days insert")
+	}
+
+	return nil
+}
+
+// getStreamRefs retrieves the actual stream refs from the database for the most recently created streams.
+func getStreamRefs(ctx context.Context, platform *kwilTesting.Platform, expectedCount int) ([]int, error) {
+	kwilPlatform := platform
+
+	// Get the deployer for signing queries
+	var deployer util.EthereumAddress
+	var err error
+
+	// Try to create from bytes first
+	deployer, err = util.NewEthereumAddressFromBytes(kwilPlatform.Deployer)
+	if err != nil {
+		// Use a default test address as fallback
+		defaultAddr := make([]byte, 20)
+		for i := range defaultAddr {
+			defaultAddr[i] = byte(i % 256)
+		}
+		deployer, err = util.NewEthereumAddressFromBytes(defaultAddr)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating default deployer address")
+		}
+	}
+
+	// Create transaction context for queries
+	txContext := &common.TxContext{
+		Ctx:          ctx,
+		BlockContext: &common.BlockContext{Height: 1},
+		Signer:       deployer.Bytes(),
+		Caller:       deployer.Address(),
+		TxID:         kwilPlatform.Txid(),
+	}
+
+	engineContext := &common.EngineContext{
+		TxContext:     txContext,
+		OverrideAuthz: true, // Override authorization for system operations in tests
+	}
+
+	var streamRefs []int
+
+	// Query for the most recently created streams for this data provider
+	// Get the actual id column from the streams table
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		`SELECT id FROM streams
+		 WHERE data_provider = $data_provider
+		 ORDER BY created_at DESC
+		 LIMIT $limit`,
+		map[string]any{
+			"$data_provider": deployer.Address(),
+			"$limit":         expectedCount,
+		},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if streamId, ok := row.Values[0].(int64); ok {
+					streamRefs = append(streamRefs, int(streamId))
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error querying stream refs")
+	}
+
+	if len(streamRefs) != expectedCount {
+		return nil, errors.Errorf("expected %d stream refs, got %d", expectedCount, len(streamRefs))
+	}
+
+	// Reverse to get them in ascending order (they were ordered DESC in query)
+	for i, j := 0, len(streamRefs)-1; i < j; i, j = i+1, j-1 {
+		streamRefs[i], streamRefs[j] = streamRefs[j], streamRefs[i]
+	}
+
+	return streamRefs, nil
+}
+
+// getStreamRefsUpTo retrieves up to maxCount most recently created stream refs for the current data provider.
+// Unlike getStreamRefs, this function does not error if fewer than maxCount streams are available.
+func getStreamRefsUpTo(ctx context.Context, platform *kwilTesting.Platform, maxCount int) ([]int, error) {
+	kwilPlatform := platform
+
+	// Get the deployer for signing queries
+	var deployer util.EthereumAddress
+	var err error
+
+	// Try to create from bytes first
+	deployer, err = util.NewEthereumAddressFromBytes(kwilPlatform.Deployer)
+	if err != nil {
+		// Fallback: use a default test address
+		defaultAddr := make([]byte, 20)
+		for i := range defaultAddr {
+			defaultAddr[i] = byte(i % 256)
+		}
+		deployer, err = util.NewEthereumAddressFromBytes(defaultAddr)
+		if err != nil {
+			return nil, errors.Wrap(err, "error creating default deployer address")
+		}
+	}
+
+	// Create transaction context for queries
+	txContext := &common.TxContext{
+		Ctx:          ctx,
+		BlockContext: &common.BlockContext{Height: 1},
+		Signer:       deployer.Bytes(),
+		Caller:       deployer.Address(),
+		TxID:         kwilPlatform.Txid(),
+	}
+
+	engineContext := &common.EngineContext{
+		TxContext:     txContext,
+		OverrideAuthz: true, // Override authorization for system operations in tests
+	}
+
+	var streamRefs []int
+
+	// Query for the most recently created streams for this data provider
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		`SELECT id FROM streams
+         WHERE data_provider = $data_provider
+         ORDER BY created_at DESC
+         LIMIT $limit`,
+		map[string]any{
+			"$data_provider": deployer.Address(),
+			"$limit":         maxCount,
+		},
+		func(row *common.Row) error {
+			if len(row.Values) > 0 {
+				if streamId, ok := row.Values[0].(int64); ok {
+					streamRefs = append(streamRefs, int(streamId))
+				}
+			}
+			return nil
+		})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "error querying stream refs")
+	}
+
+	// Reverse to get them in ascending order (they were ordered DESC in query)
+	for i, j := 0, len(streamRefs)-1; i < j; i, j = i+1, j-1 {
+		streamRefs[i], streamRefs[j] = streamRefs[j], streamRefs[i]
+	}
+
+	return streamRefs, nil
+}
+
+// batchInsertPendingDays efficiently inserts multiple pending days using PostgreSQL UNNEST.
+// This replaces individual inserts with a single batch operation for better performance.
+func batchInsertPendingDays(ctx context.Context, platform *kwilTesting.Platform, streamRefs []int, dayIdxs []int, signer util.EthereumAddress) error {
+	// Create transaction context
+	txContext := &common.TxContext{
+		Ctx:          ctx,
+		BlockContext: &common.BlockContext{Height: 1},
+		Signer:       signer.Bytes(),
+		Caller:       signer.Address(),
+		TxID:         platform.Txid(),
+	}
+
+	engineContext := &common.EngineContext{
+		TxContext:     txContext,
+		OverrideAuthz: true, // Override authorization for system operations in tests
+	}
+
+	// Convert slices to the format expected by the database
+	// PostgreSQL UNNEST expects arrays
+	streamRefArray := make([]int64, len(streamRefs))
+	dayIndexArray := make([]int64, len(dayIdxs))
+
+	for i := 0; i < len(streamRefs); i++ {
+		streamRefArray[i] = int64(streamRefs[i])
+		dayIndexArray[i] = int64(dayIdxs[i])
+	}
+
+	// Execute the batch insert using UNNEST
+	err := platform.Engine.Execute(engineContext, platform.DB,
+		`INSERT INTO pending_prune_days (stream_ref, day_index)
+		 SELECT * FROM UNNEST($stream_refs, $day_indices) AS t(stream_ref, day_index)
+		 ON CONFLICT (stream_ref, day_index) DO NOTHING`,
+		map[string]any{
+			"$stream_refs": streamRefArray,
+			"$day_indices": dayIndexArray,
+		},
+		func(row *common.Row) error {
+			return nil
+		})
+
+	if err != nil {
+		return errors.Wrap(err, "error executing batch pending_prune_days insert")
+	}
+
+	return nil
+}
+
+// ClearPendingPruneDays removes all entries from pending_prune_days.
+// Useful to prepare a clean slate when reusing a global dataset across cases.
+func ClearPendingPruneDays(ctx context.Context, platform *kwilTesting.Platform) error {
+	kwilPlatform := platform
+
+	// Get the deployer for signing queries
+	deployer, err := GetDeployerOrDefault(kwilPlatform)
+	if err != nil {
+		return errors.Wrap(err, "failed to get deployer")
+	}
+
+	// Create transaction context for queries
+	txContext := &common.TxContext{
+		Ctx:          ctx,
+		BlockContext: &common.BlockContext{Height: 1},
+		Signer:       deployer.Bytes(),
+		Caller:       deployer.Address(),
+		TxID:         kwilPlatform.Txid(),
+	}
+
+	engineContext := &common.EngineContext{
+		TxContext:     txContext,
+		OverrideAuthz: true,
+	}
+
+	err = kwilPlatform.Engine.Execute(engineContext, kwilPlatform.DB,
+		`DELETE FROM pending_prune_days`,
+		map[string]any{},
+		func(row *common.Row) error { return nil },
+	)
+	if err != nil {
+		return errors.Wrap(err, "error clearing pending_prune_days")
+	}
+	return nil
+}
+
+// AnalyzeDigestTables performs query planner optimization for digest-related tables.
+// This reuses the existing updateQueryPlanner utility.
+func AnalyzeDigestTables(ctx context.Context, platform *kwilTesting.Platform) error {
+	kwilPlatform := platform
+
+	// Define the digest-related tables that need query planner optimization
+	digestTables := []string{
+		"primitive_events",
+		"primitive_event_type",
+		"pending_prune_days",
+		"streams", // Also include streams for foreign key relationships
+	}
+
+	return analyzeTables(ctx, kwilPlatform, digestTables)
+}
+
+// analyzeTables performs ANALYZE on the specified tables for query optimization
+func analyzeTables(ctx context.Context, platform *kwilTesting.Platform, tables []string) error {
+	// Use the improved AnalyzeTables function from helpers
+	return AnalyzeTables(ctx, platform, tables)
+}
+
+// RandomPattern implements the "random" data generation pattern.
+// Generates uniform random values across each day.
+type RandomPattern struct{}
+
+// NewRandomPattern creates a new random pattern generator.
+func NewRandomPattern() *RandomPattern {
+	return &RandomPattern{}
+}
+
+// GenerateRecords generates random records for the random pattern.
+func (r *RandomPattern) GenerateRecords(dayStart int64, records int) []InsertRecordInput {
+	result := make([]InsertRecordInput, records)
+
+	for i := 0; i < records; i++ {
+		// Generate random event time within the day
+		eventTime := dayStart + rand.Int63n(DaySeconds)
+
+		// Generate random value between 0 and 1000
+		value := rand.Float64() * 1000
+
+		// Generate random created_at for tie-breaking (within reasonable range)
+		createdAt := time.Now().Unix() + rand.Int63n(HourSeconds)
+
+		result[i] = InsertRecordInput{
+			EventTime: eventTime,
+			Value:     value,
+			CreatedAt: createdAt,
+		}
+	}
+
+	return result
+}
+
+// GetPatternName returns the pattern name identifier.
+func (r *RandomPattern) GetPatternName() string {
+	return "random"
+}
+
+// Dups50Pattern implements the "dups50" data generation pattern.
+// Generates data with 50% duplicate values to stress high/low selection.
+type Dups50Pattern struct{}
+
+// NewDups50Pattern creates a new dups50 pattern generator.
+func NewDups50Pattern() *Dups50Pattern {
+	return &Dups50Pattern{}
+}
+
+// GenerateRecords generates records with 50% duplicate values.
+func (d *Dups50Pattern) GenerateRecords(dayStart int64, records int) []InsertRecordInput {
+	result := make([]InsertRecordInput, records)
+
+	// Pre-generate unique values for duplicates
+	uniqueValues := make([]float64, records/2)
+	for i := range uniqueValues {
+		uniqueValues[i] = rand.Float64() * 1000
+	}
+
+	for i := 0; i < records; i++ {
+		eventTime := dayStart + rand.Int63n(DaySeconds)
+		createdAt := time.Now().Unix() + rand.Int63n(HourSeconds)
+
+		var value float64
+		if i%2 == 0 {
+			// Use unique value
+			value = uniqueValues[i/2]
+		} else {
+			// Use duplicate of previous unique value
+			value = uniqueValues[(i-1)/2]
+		}
+
+		result[i] = InsertRecordInput{
+			EventTime: eventTime,
+			Value:     value,
+			CreatedAt: createdAt,
+		}
+	}
+
+	return result
+}
+
+// GetPatternName returns the pattern name identifier.
+func (d *Dups50Pattern) GetPatternName() string {
+	return "dups50"
+}
+
+// MonotonicPattern implements the "monotonic" data generation pattern.
+// Generates strictly increasing or decreasing values.
+type MonotonicPattern struct {
+	increasing bool
+}
+
+// NewMonotonicPattern creates a new monotonic pattern generator.
+func NewMonotonicPattern() *MonotonicPattern {
+	return &MonotonicPattern{increasing: rand.Intn(2) == 0}
+}
+
+// GenerateRecords generates monotonic records.
+func (m *MonotonicPattern) GenerateRecords(dayStart int64, records int) []InsertRecordInput {
+	result := make([]InsertRecordInput, records)
+	baseValue := rand.Float64() * 100
+
+	for i := 0; i < records; i++ {
+		eventTime := dayStart + int64(i)*DaySeconds/int64(records) // Spread across day
+		createdAt := time.Now().Unix() + rand.Int63n(HourSeconds)
+
+		var value float64
+		if m.increasing {
+			value = baseValue + float64(i)*10 // Increasing
+		} else {
+			value = baseValue + float64(records-i)*10 // Decreasing
+		}
+
+		result[i] = InsertRecordInput{
+			EventTime: eventTime,
+			Value:     value,
+			CreatedAt: createdAt,
+		}
+	}
+
+	return result
+}
+
+// GetPatternName returns the pattern name identifier.
+func (m *MonotonicPattern) GetPatternName() string {
+	return "monotonic"
+}
+
+// EqualPattern implements the "equal" data generation pattern.
+// Generates all values identical to test combined flags.
+type EqualPattern struct{}
+
+// NewEqualPattern creates a new equal pattern generator.
+func NewEqualPattern() *EqualPattern {
+	return &EqualPattern{}
+}
+
+// GenerateRecords generates records with identical values.
+func (e *EqualPattern) GenerateRecords(dayStart int64, records int) []InsertRecordInput {
+	result := make([]InsertRecordInput, records)
+	value := rand.Float64() * 1000 // Same value for all records
+
+	for i := 0; i < records; i++ {
+		eventTime := dayStart + int64(i)*DaySeconds/int64(records) // Spread across day
+		createdAt := time.Now().Unix() + rand.Int63n(HourSeconds)
+
+		result[i] = InsertRecordInput{
+			EventTime: eventTime,
+			Value:     value,
+			CreatedAt: createdAt,
+		}
+	}
+
+	return result
+}
+
+// GetPatternName returns the pattern name identifier.
+func (e *EqualPattern) GetPatternName() string {
+	return "equal"
+}
+
+// TimeDupPattern implements the "time_dup" data generation pattern.
+// Generates records with same event_time but different created_at for tie-break testing.
+type TimeDupPattern struct{}
+
+// NewTimeDupPattern creates a new time_dup pattern generator.
+func NewTimeDupPattern() *TimeDupPattern {
+	return &TimeDupPattern{}
+}
+
+// GenerateRecords generates records with duplicate timestamps but different created_at.
+func (t *TimeDupPattern) GenerateRecords(dayStart int64, records int) []InsertRecordInput {
+	result := make([]InsertRecordInput, records)
+
+	// Generate unique event times
+	uniqueTimes := records / 2
+	if uniqueTimes == 0 {
+		uniqueTimes = 1
+	}
+
+	for i := 0; i < records; i++ {
+		// Each event time will be used twice with different created_at
+		eventTime := dayStart + int64(i%uniqueTimes)*DaySeconds/int64(uniqueTimes)
+		value := rand.Float64() * 1000
+
+		// Vary created_at to test tie-breaking
+		var createdAt int64
+		if i%2 == 0 {
+			createdAt = time.Now().Unix() + 1000 // Earlier
+		} else {
+			createdAt = time.Now().Unix() + 2000 // Later
+		}
+
+		result[i] = InsertRecordInput{
+			EventTime: eventTime,
+			Value:     value,
+			CreatedAt: createdAt,
+		}
+	}
+
+	return result
+}
+
+// GetPatternName returns the pattern name identifier.
+func (t *TimeDupPattern) GetPatternName() string {
+	return "time_dup"
+}
+
+// InsertDataForMultipleStreams efficiently inserts data for multiple streams in parallel batches.
+// This optimizes performance by processing multiple streams simultaneously rather than sequentially.
+func InsertDataForMultipleStreams(ctx context.Context, platform *kwilTesting.Platform, streamLocators []types.StreamLocator, daysPerStream, recordsPerDay int, pattern string) error {
+	if len(streamLocators) == 0 {
+		return nil
+	}
+
+	// Group streams into batches to avoid overwhelming the database
+	const streamsPerBatch = 50 // Process 50 streams at a time
+	streamBatches := lo.Chunk(streamLocators, streamsPerBatch)
+
+	totalProcessed := 0
+	for batchIdx, streamBatch := range streamBatches {
+		batchStart := time.Now()
+
+		// Prepare data for all streams in this batch
+		streamData := make([]struct {
+			Locator types.StreamLocator
+			Records []InsertRecordInput
+		}, len(streamBatch))
+
+		// Generate data for all streams in parallel
+		for i, stream := range streamBatch {
+			var allRecords []InsertRecordInput
+			for day := 0; day < daysPerStream; day++ {
+				dayStart := int64(day * DaySeconds)
+				records := GeneratePatternRecords(pattern, dayStart, recordsPerDay)
+				allRecords = append(allRecords, records...)
+			}
+			streamData[i] = struct {
+				Locator types.StreamLocator
+				Records []InsertRecordInput
+			}{
+				Locator: stream,
+				Records: allRecords,
+			}
+		}
+
+		// Insert data for all streams in this batch simultaneously
+		if err := insertBatchForMultipleStreams(ctx, platform, streamData); err != nil {
+			return errors.Wrapf(err, "failed to insert batch %d", batchIdx)
+		}
+
+		batchDuration := time.Since(batchStart)
+		fmt.Printf("    Batch %d/%d: %d streams, %d total records inserted in %v\n",
+			batchIdx+1, len(streamBatches), len(streamBatch),
+			len(streamBatch)*daysPerStream*recordsPerDay, batchDuration)
+
+		totalProcessed += len(streamBatch)
+		fmt.Printf("    Progress: %d/%d streams processed\n", totalProcessed, len(streamLocators))
+	}
+
+	return nil
+}
+
+// insertBatchForMultipleStreams inserts data for multiple streams in a single batch operation.
+func insertBatchForMultipleStreams(ctx context.Context, platform *kwilTesting.Platform, streamData []struct {
+	Locator types.StreamLocator
+	Records []InsertRecordInput
+}) error {
+	// Create primitive streams with data
+	var streams []setup.PrimitiveStreamWithData
+
+	for _, data := range streamData {
+		// Split records into batches for each stream
+		recordBatches := lo.Chunk(data.Records, DefaultBatchSize)
+
+		for _, batch := range recordBatches {
+			// Convert records to setup format
+			var records []setup.InsertRecordInput
+			for _, record := range batch {
+				records = append(records, setup.InsertRecordInput{
+					EventTime: record.EventTime,
+					Value:     record.Value,
+				})
+			}
+
+			// Create primitive stream with data
+			primitiveStream := setup.PrimitiveStreamWithData{
+				PrimitiveStreamDefinition: setup.PrimitiveStreamDefinition{
+					StreamLocator: data.Locator,
+				},
+				Data: records,
+			}
+
+			streams = append(streams, primitiveStream)
+		}
+	}
+
+	// Use the new multi-stream batch function
+	multiInput := setup.InsertMultiPrimitiveDataInput{
+		Platform: platform,
+		Height:   1,
+		Streams:  streams,
+	}
+
+	return setup.InsertPrimitiveDataMultiBatch(ctx, multiInput)
+}
+
+// SetupBenchmarkData is the main setup function that orchestrates the entire data setup process.
+// This function follows the Single Responsibility Principle by delegating to specialized functions.
+func SetupBenchmarkData(ctx context.Context, input DigestSetupInput) error {
+	totalStart := time.Now()
+	defer func() {
+		fmt.Printf("Total SetupBenchmarkData completed in %v\n", time.Since(totalStart))
+	}()
+
+	// 1. Setup data provider
+	var dataProviderAddr string
+	if input.DataProvider != nil {
+		if addr, ok := input.DataProvider.(util.EthereumAddress); ok {
+			dataProviderAddr = addr.Address()
+		} else {
+			// Fallback: use a default test address
+			dataProviderAddr = "0x1234567890123456789012345678901234567890"
+		}
+	} else {
+		// Use default test address if no data provider specified
+		dataProviderAddr = "0x1234567890123456789012345678901234567890"
+	}
+
+	platform, ok := input.Platform.(*kwilTesting.Platform)
+	if !ok {
+		return errors.New("invalid platform type")
+	}
+
+	fmt.Printf("Step 1: Setting up data provider...\n")
+	setupStart := time.Now()
+	if err := SetupDataProvider(ctx, platform, dataProviderAddr); err != nil {
+		return errors.Wrap(err, "failed to setup data provider")
+	}
+	fmt.Printf("Step 1 completed in %v\n", time.Since(setupStart))
+
+	// 2. Create primitive streams (using batch creation for efficiency)
+	fmt.Printf("Step 2: Creating %d primitive streams...\n", input.Case.Streams)
+	streamStart := time.Now()
+
+	// Get the deployer for signing
+	deployer, err := GetDeployerOrDefault(platform)
+	if err != nil {
+		return errors.Wrap(err, "failed to get deployer")
+	}
+
+	var streamInfos []setup.StreamInfo
+	var streamLocators []types.StreamLocator
+
+	// Create stream locators with unique IDs per test run
+	// Use timestamp and random component to avoid conflicts between test runs
+	timestamp := time.Now().Unix()
+	randomSuffix := rand.Intn(10000)
+	for i := 0; i < input.Case.Streams; i++ {
+		streamId := util.GenerateStreamId(fmt.Sprintf("digest_test_stream_%d_%d_%d", timestamp, randomSuffix, i))
+
+		streamLocator := types.StreamLocator{
+			DataProvider: deployer,
+			StreamId:     streamId,
+		}
+
+		streamInfos = append(streamInfos, setup.StreamInfo{
+			Locator: streamLocator,
+			Type:    setup.ContractTypePrimitive,
+		})
+
+		streamLocators = append(streamLocators, streamLocator)
+	}
+
+	// Create all streams in a single batch operation
+	err = setup.CreateStreams(ctx, platform, streamInfos)
+	if err != nil {
+		return errors.Wrap(err, "error creating primitive streams")
+	}
+
+	fmt.Printf("Step 2 completed in %v (%d streams created)\n", time.Since(streamStart), len(streamLocators))
+
+	// 3. Generate and insert data for all streams in parallel batches
+	fmt.Printf("Step 3: Generating and inserting data for %d streams (parallel batch processing)...\n", len(streamLocators))
+	dataStart := time.Now()
+
+	// Use batch insertion for multiple streams simultaneously
+	if err := InsertDataForMultipleStreams(ctx, platform, streamLocators, input.Case.DaysPerStream, input.Case.RecordsPerDay, input.Case.Pattern); err != nil {
+		return errors.Wrap(err, "failed to insert data for multiple streams")
+	}
+
+	totalRecords := len(streamLocators) * input.Case.DaysPerStream * input.Case.RecordsPerDay
+
+	fmt.Printf("Step 3 completed in %v (%d total records)\n", time.Since(dataStart), totalRecords)
+
+	// 4. Setup pending prune days
+	fmt.Printf("Step 4: Setting up pending prune days...\n")
+	pruneStart := time.Now()
+
+	// Get actual stream refs from the database instead of assuming they start at 1
+	actualStreamRefs, err := getStreamRefs(ctx, platform, len(streamLocators))
+	if err != nil {
+		return errors.Wrap(err, "failed to get actual stream refs")
+	}
+
+	// Create pairs for every (stream, day) combination
+	totalCandidates := len(actualStreamRefs) * input.Case.DaysPerStream
+	streamRefs := make([]int, totalCandidates)
+	dayIdxs := make([]int, totalCandidates)
+
+	// Fill stream refs and day indices for all combinations
+	idx := 0
+	for _, streamRef := range actualStreamRefs {
+		for day := 0; day < input.Case.DaysPerStream; day++ {
+			streamRefs[idx] = streamRef
+			dayIdxs[idx] = day
+			idx++
+		}
+	}
+
+	fmt.Printf("  Inserting %d pending prune day entries...\n", totalCandidates)
+	if err := InsertPendingPruneDays(ctx, platform, streamRefs, dayIdxs); err != nil {
+		return errors.Wrap(err, "failed to insert pending prune days")
+	}
+
+	fmt.Printf("Step 4 completed in %v\n", time.Since(pruneStart))
+
+	// 5. Analyze tables for query optimization (optional)
+	fmt.Printf("Step 5: Analyzing tables for query optimization...\n")
+	analyzeStart := time.Now()
+	if err := AnalyzeDigestTables(ctx, platform); err != nil {
+		fmt.Printf("Step 5 failed (non-critical): %v\n", err)
+	} else {
+		fmt.Printf("Step 5 completed in %v\n", time.Since(analyzeStart))
+	}
+
+	return nil
+}
+
+// ValidateBenchmarkCase validates the benchmark case configuration for correctness.
+func ValidateBenchmarkCase(c DigestBenchmarkCase) error {
+	if c.Streams <= 0 {
+		return errors.New("streams must be positive")
+	}
+	if c.DaysPerStream <= 0 {
+		return errors.New("days_per_stream must be positive")
+	}
+	if c.RecordsPerDay <= 0 {
+		return errors.New("records_per_day must be positive")
+	}
+	if c.BatchSize <= 0 {
+		return errors.New("batch_size must be positive")
+	}
+	if c.Samples <= 0 {
+		return errors.New("samples must be positive")
+	}
+
+	validPatterns := map[string]bool{
+		"random":    true,
+		"dups50":    true,
+		"monotonic": true,
+		"equal":     true,
+		"time_dup":  true,
+	}
+
+	if !validPatterns[c.Pattern] {
+		return fmt.Errorf("invalid pattern: %s", c.Pattern)
+	}
+
+	return nil
+}
+
+// CalculateExpectedCandidates calculates the expected number of candidates for a benchmark case.
+func CalculateExpectedCandidates(c DigestBenchmarkCase) int {
+	return c.Streams * c.DaysPerStream
+}
+
+// CalculateExpectedRecords calculates the expected total records for a benchmark case.
+func CalculateExpectedRecords(c DigestBenchmarkCase) int {
+	return c.Streams * c.DaysPerStream * c.RecordsPerDay
+}
+
+// EstimateMemoryUsage estimates the memory usage for a benchmark case.
+func EstimateMemoryUsage(c DigestBenchmarkCase) int64 {
+	// Rough estimation: each record ~100 bytes + overhead
+	bytesPerRecord := int64(100)
+	totalRecords := int64(CalculateExpectedRecords(c))
+
+	// Add overhead for processing and temporary data structures
+	overheadFactor := float64(1.5)
+
+	return int64(float64(totalRecords*bytesPerRecord) * overheadFactor)
+}
+
+// AnalyzeDataPatterns analyzes the statistical properties of generated data patterns.
+// This uses the stats library for robust statistical analysis.
+func AnalyzeDataPatterns(records []InsertRecordInput) (map[string]float64, error) {
+	if len(records) == 0 {
+		return nil, errors.New("no records to analyze")
+	}
+
+	// Extract values for statistical analysis
+	values := lo.Map(records, func(r InsertRecordInput, _ int) float64 { return r.Value })
+
+	// Calculate comprehensive statistics using montanaflynn/stats
+	analysis := make(map[string]float64)
+
+	// Basic statistics
+	if mean, err := stats.Mean(values); err == nil {
+		analysis["mean"] = mean
+	}
+	if median, err := stats.Median(values); err == nil {
+		analysis["median"] = median
+	}
+	if stdDev, err := stats.StandardDeviation(values); err == nil {
+		analysis["std_dev"] = stdDev
+	}
+	if min, err := stats.Min(values); err == nil {
+		analysis["min"] = min
+	}
+	if max, err := stats.Max(values); err == nil {
+		analysis["max"] = max
+	}
+
+	// Percentiles for performance analysis
+	if p95, err := stats.Percentile(values, 95); err == nil {
+		analysis["p95"] = p95
+	}
+	if p99, err := stats.Percentile(values, 99); err == nil {
+		analysis["p99"] = p99
+	}
+
+	// Distribution analysis
+	// Note: Skewness and Kurtosis not available in montanaflynn/stats package
+
+	// Uniqueness analysis (important for OHLC testing)
+	uniqueValues := lo.Uniq(values)
+	analysis["unique_ratio"] = float64(len(uniqueValues)) / float64(len(values))
+
+	return analysis, nil
+}
+
+// OptimizeBatchSize suggests optimal batch sizes based on data analysis.
+// This uses statistical analysis to recommend efficient processing parameters.
+func OptimizeBatchSize(c DigestBenchmarkCase, analysis map[string]float64) int {
+	baseBatchSize := 50
+
+	// Adjust based on data uniqueness (more unique values = larger batches)
+	if uniqueRatio, exists := analysis["unique_ratio"]; exists {
+		if uniqueRatio > 0.8 {
+			// High uniqueness - can use larger batches
+			baseBatchSize = 200
+		} else if uniqueRatio < 0.3 {
+			// Low uniqueness - use smaller batches for better memory efficiency
+			baseBatchSize = 25
+		}
+	}
+
+	// Adjust based on standard deviation (more variation = smaller batches for precision)
+	if stdDev, exists := analysis["std_dev"]; exists && analysis["mean"] > 0 {
+		coefficientOfVariation := stdDev / analysis["mean"]
+		if coefficientOfVariation > 1.0 {
+			// High variation - smaller batches for better control
+			baseBatchSize = int(float64(baseBatchSize) * 0.7)
+		}
+	}
+
+	// Ensure reasonable bounds
+	if baseBatchSize < 10 {
+		baseBatchSize = 10
+	} else if baseBatchSize > 500 {
+		baseBatchSize = 500
+	}
+
+	return baseBatchSize
+}

--- a/internal/benchmark/digest/setup.go
+++ b/internal/benchmark/digest/setup.go
@@ -1053,6 +1053,10 @@ func ValidateBenchmarkCase(c DigestBenchmarkCase) error {
 		return errors.New("records_per_day must be positive")
 	}
 
+	if c.DeleteCap <= 0 {
+		return errors.New("delete_cap must be positive")
+	}
+
 	if c.Samples <= 0 {
 		return errors.New("samples must be positive")
 	}

--- a/internal/benchmark/digest/types.go
+++ b/internal/benchmark/digest/types.go
@@ -16,7 +16,7 @@ type DigestBenchmarkCase struct {
 	// RecordsPerDay specifies the number of records to generate per stream per day
 	RecordsPerDay int
 
-	// DeleteCap specifies the maximum number of rows that can be deleted in a single batch_digest call
+	// DeleteCap specifies the maximum number of rows that can be deleted in a single auto_digest call
 	DeleteCap int
 
 	// Pattern specifies the data pattern to generate ("random", "dups50", "monotonic", "equal", "time_dup")
@@ -47,7 +47,7 @@ type DigestRunResult struct {
 	// TotalPreservedRows contains the total number of rows preserved (OHLC records)
 	TotalPreservedRows int
 
-	// Duration contains the total execution time for the batch_digest operation
+	// Duration contains the total execution time for the auto_digest operation
 	Duration time.Duration
 
 	// MemoryMaxBytes contains the peak memory usage in bytes during execution

--- a/internal/benchmark/digest/types.go
+++ b/internal/benchmark/digest/types.go
@@ -16,9 +16,6 @@ type DigestBenchmarkCase struct {
 	// RecordsPerDay specifies the number of records to generate per stream per day
 	RecordsPerDay int
 
-	// BatchSize specifies the number of candidates to process in each batch_digest call
-	BatchSize int
-
 	// DeleteCap specifies the maximum number of rows that can be deleted in a single batch_digest call
 	DeleteCap int
 
@@ -64,16 +61,6 @@ type DigestRunResult struct {
 
 	// WALBytes contains the WAL (Write-Ahead Log) growth in bytes (optional metric)
 	WALBytes *int64
-}
-
-// CandidateBatch represents a batch of candidates to be processed together.
-// This structure helps optimize batch processing by grouping related candidates.
-type CandidateBatch struct {
-	// StreamRefs contains the stream reference IDs for this batch
-	StreamRefs []int
-
-	// DayIdxs contains the day indices for this batch
-	DayIdxs []int
 }
 
 // DigestBenchmarkPattern defines the interface for different data generation patterns.

--- a/internal/benchmark/digest/types.go
+++ b/internal/benchmark/digest/types.go
@@ -1,0 +1,145 @@
+package digest
+
+import (
+	"time"
+)
+
+// DigestBenchmarkCase defines the configuration for a single digest benchmark test case.
+// It encapsulates all parameters needed to generate test data and execute the benchmark.
+type DigestBenchmarkCase struct {
+	// Streams specifies the number of primitive streams to create for the benchmark
+	Streams int
+
+	// DaysPerStream specifies the number of days of data to generate per stream
+	DaysPerStream int
+
+	// RecordsPerDay specifies the number of records to generate per stream per day
+	RecordsPerDay int
+
+	// BatchSize specifies the number of candidates to process in each batch_digest call
+	BatchSize int
+
+	// Pattern specifies the data pattern to generate ("random", "dups50", "monotonic", "equal", "time_dup")
+	Pattern string
+
+	// Samples specifies the number of times to repeat the measurement for statistical accuracy
+	Samples int
+
+	// IdempotencyCheck specifies whether to verify that re-running digest returns 0 changes
+	IdempotencyCheck bool
+}
+
+// DigestRunResult contains the results and metrics from a single benchmark execution.
+// It captures both input parameters and measured performance characteristics.
+type DigestRunResult struct {
+	// Case contains the original benchmark case configuration
+	Case DigestBenchmarkCase
+
+	// Candidates contains the total number of candidates submitted for processing
+	Candidates int
+
+	// ProcessedDays contains the actual number of days that were processed
+	ProcessedDays int
+
+	// TotalDeletedRows contains the total number of rows deleted during digest processing
+	TotalDeletedRows int
+
+	// TotalPreservedRows contains the total number of rows preserved (OHLC records)
+	TotalPreservedRows int
+
+	// Duration contains the total execution time for the batch_digest operation
+	Duration time.Duration
+
+	// MemoryMaxBytes contains the peak memory usage in bytes during execution
+	MemoryMaxBytes uint64
+
+	// DaysPerSecond contains the throughput metric: processed_days per second
+	DaysPerSecond float64
+
+	// RowsDeletedPerSecond contains the throughput metric: deleted_rows per second
+	RowsDeletedPerSecond float64
+
+	// WALBytes contains the WAL (Write-Ahead Log) growth in bytes (optional metric)
+	WALBytes *int64
+}
+
+// CandidateBatch represents a batch of candidates to be processed together.
+// This structure helps optimize batch processing by grouping related candidates.
+type CandidateBatch struct {
+	// StreamRefs contains the stream reference IDs for this batch
+	StreamRefs []int
+
+	// DayIdxs contains the day indices for this batch
+	DayIdxs []int
+}
+
+// DigestBenchmarkPattern defines the interface for different data generation patterns.
+// This follows the Strategy pattern to allow for different data generation strategies.
+type DigestBenchmarkPattern interface {
+	// GenerateRecords generates a slice of records based on the pattern's logic
+	GenerateRecords(dayStart int64, records int) []InsertRecordInput
+
+	// GetPatternName returns the string identifier for this pattern
+	GetPatternName() string
+}
+
+// InsertRecordInput represents a single primitive event record to be inserted.
+// This structure matches the expected input format for primitive data insertion.
+type InsertRecordInput struct {
+	// EventTime specifies the timestamp for this record
+	EventTime int64
+
+	// Value specifies the numeric value for this record
+	Value float64
+
+	// CreatedAt specifies the creation timestamp (for tie-breaking in OHLC calculations)
+	CreatedAt int64
+}
+
+// DigestSetupInput encapsulates all parameters needed for setting up benchmark data.
+// This structure centralizes setup configuration to avoid parameter sprawl.
+type DigestSetupInput struct {
+	// Platform provides access to the testing platform and database
+	Platform interface{} // *kwilTesting.Platform
+
+	// Case contains the benchmark case configuration
+	Case DigestBenchmarkCase
+
+	// DataProvider contains the Ethereum address of the data provider
+	DataProvider interface{} // util.EthereumAddress
+}
+
+// DigestVerificationInput contains parameters for verifying digest correctness.
+// This structure groups verification parameters for consistency checking.
+type DigestVerificationInput struct {
+	// Platform provides access to the testing platform and database
+	Platform interface{} // *kwilTesting.Platform
+
+	// StreamRef specifies which stream to verify
+	StreamRef int
+
+	// DayIndex specifies which day to verify
+	DayIndex int64
+
+	// ExpectedRecords contains the expected record count before digest
+	ExpectedRecords int
+
+	// SampleSize specifies how many records to sample for correctness verification
+	SampleSize int
+}
+
+// DigestMeasurementInput contains parameters for measuring digest performance.
+// This structure encapsulates timing and resource measurement configuration.
+type DigestMeasurementInput struct {
+	// Platform provides access to the testing platform and database
+	Platform interface{} // *kwilTesting.Platform
+
+	// StreamRefs contains the stream references to process
+	StreamRefs []int
+
+	// DayIdxs contains the day indices to process
+	DayIdxs []int
+
+	// Collector provides memory monitoring functionality
+	Collector interface{} // *benchutil.DockerMemoryCollector
+}

--- a/internal/benchmark/digest/types.go
+++ b/internal/benchmark/digest/types.go
@@ -44,17 +44,14 @@ type DigestRunResult struct {
 	// TotalDeletedRows contains the total number of rows deleted during digest processing
 	TotalDeletedRows int
 
-	// TotalPreservedRows contains the total number of rows preserved (OHLC records)
-	TotalPreservedRows int
-
 	// Duration contains the total execution time for the auto_digest operation
 	Duration time.Duration
 
 	// MemoryMaxBytes contains the peak memory usage in bytes during execution
 	MemoryMaxBytes uint64
 
-	// DaysPerSecond contains the throughput metric: processed_days per second
-	DaysPerSecond float64
+	// StreamDaysPerSecond contains the throughput metric: processed stream-days per second
+	StreamDaysPerSecond float64
 
 	// RowsDeletedPerSecond contains the throughput metric: deleted_rows per second
 	RowsDeletedPerSecond float64

--- a/internal/benchmark/digest/types.go
+++ b/internal/benchmark/digest/types.go
@@ -19,6 +19,9 @@ type DigestBenchmarkCase struct {
 	// BatchSize specifies the number of candidates to process in each batch_digest call
 	BatchSize int
 
+	// DeleteCap specifies the maximum number of rows that can be deleted in a single batch_digest call
+	DeleteCap int
+
 	// Pattern specifies the data pattern to generate ("random", "dups50", "monotonic", "equal", "time_dup")
 	Pattern string
 

--- a/internal/benchmark/load_test.go
+++ b/internal/benchmark/load_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Cache verification configuration
-const enableCacheCheck = true // Set to false to disable cache verification
+const enableCacheCheck = false // Set to false to disable cache verification
 
 // -----------------------------------------------------------------------------
 // Main benchmark test function

--- a/internal/migrations/001-common-actions.sql
+++ b/internal/migrations/001-common-actions.sql
@@ -81,16 +81,12 @@ CREATE OR REPLACE ACTION create_streams(
         ERROR('Stream IDs and stream types arrays must have the same length');
     }
 
-    -- Iterate through each stream ID and type, checking if they have a valid format
-    for $i in 1..array_length($stream_ids) {
-        $stream_id := $stream_ids[$i];
-        $stream_type := $stream_types[$i];
-        if NOT check_stream_id_format($stream_id) {
-            ERROR('Invalid stream_id format. Must start with "st" followed by 30 lowercase alphanumeric characters: ' || $stream_id);
-        }
-        if $stream_type != 'primitive' AND $stream_type != 'composed' {
-            ERROR('Invalid stream type. Must be "primitive" or "composed": ' || $stream_type);
-        }
+    -- Unified batch validation for both stream IDs and types
+    -- This returns only invalid entries with specific error reasons
+    for $validation_result in validate_stream_creation_batch($stream_ids, $stream_types) {
+        ERROR('Stream at position ' || $validation_result.index_position || ' is invalid: ' ||
+              $validation_result.stream_id || ' (' || $validation_result.stream_type || ') - ' ||
+              $validation_result.error_reason);
     }
 
     $base_uuid := uuid_generate_kwil('create_streams_' || @txid);
@@ -110,136 +106,19 @@ CREATE OR REPLACE ACTION create_streams(
         ERROR('Data provider not found: ' || $data_provider);
     }
     
-    -- Create the streams
-    WITH RECURSIVE 
-    indexes AS (
-        SELECT 1 AS idx
-        UNION ALL
-        SELECT idx + 1 FROM indexes
-        WHERE idx < array_length($stream_ids)
-    ),
-    stream_arrays AS (
-        SELECT 
-            $stream_ids AS stream_ids,
-            $stream_types AS stream_types
-    ),
-    arguments AS (
-      SELECT 
-          idx,
-          stream_arrays.stream_ids[idx] AS stream_id,
-          stream_arrays.stream_types[idx] AS stream_type
-      FROM indexes
-      JOIN stream_arrays ON 1=1
-    ),
-    sequential_ids AS (
-        SELECT 
-            idx,
-            stream_id,
-            stream_type,
-            ROW_NUMBER() OVER (ORDER BY idx) + COALESCE((SELECT MAX(id) FROM streams), 0) AS id
-        FROM arguments
-    )
+    -- Create the streams using UNNEST for optimal performance
     INSERT INTO streams (id, data_provider_id, data_provider, stream_id, stream_type, created_at)
     SELECT
-        id,
+        ROW_NUMBER() OVER (ORDER BY t.stream_id) + COALESCE((SELECT MAX(id) FROM streams), 0) AS id,
         $data_provider_id,
         $data_provider,
-        stream_id, 
-        stream_type, 
+        t.stream_id,
+        t.stream_type,
         @height
-    FROM sequential_ids;
+    FROM UNNEST($stream_ids, $stream_types) AS t(stream_id, stream_type);
  
-    -- Create metadata for the streams
-    WITH RECURSIVE 
-    indexes AS (
-        SELECT 1 AS idx
-        UNION ALL
-        SELECT idx + 1 FROM indexes
-        WHERE idx < array_length($stream_ids)
-    ),
-    stream_arrays AS (
-        SELECT 
-            $stream_ids AS stream_ids,
-            $stream_types AS stream_types
-    ),
-    stream_metadata AS (
-        SELECT 
-            stream_arrays.stream_ids[idx] AS stream_id,
-            stream_arrays.stream_types[idx] AS stream_type
-        FROM indexes
-        JOIN stream_arrays ON 1=1
-    ),
-    metadata_arguments AS (
-        -- Don't add type metadata here, we will add it when we join both tables
-        SELECT
-            'stream_owner' AS metadata_key,
-            NULL::TEXT AS value_s,
-            NULL::INT AS value_i,
-            LOWER($data_provider) AS value_ref
-        UNION ALL
-        SELECT
-            'read_visibility' AS metadata_key,
-            NULL::TEXT AS value_s,    
-            0::INT AS value_i, -- 0 = public, 1 = private
-            NULL::TEXT AS value_ref
-        UNION ALL
-        SELECT
-            'readonly_key' AS metadata_key,
-            'stream_owner' AS value_s,
-            NULL::INT AS value_i,
-            NULL::TEXT AS value_ref
-        UNION ALL
-        SELECT
-            'readonly_key' AS metadata_key,
-            'readonly_key' AS value_s,
-            NULL::INT AS value_i,
-            NULL::TEXT AS value_ref
-    ),
-    -- Cross join the stream_metadata and metadata_arguments
-    all_arguments AS (
-        SELECT 
-            sm.stream_id,
-            sm.stream_type,
-            ma.metadata_key,
-            ma.value_s,
-            ma.value_i,
-            ma.value_ref
-        FROM stream_metadata sm
-        JOIN metadata_arguments ma ON 1=1
-
-        UNION ALL
-
-        SELECT
-            stream_metadata.stream_id,
-            stream_metadata.stream_type,
-            'type' AS metadata_key,
-            stream_metadata.stream_type AS value_s,
-            NULL::INT AS value_i,
-            NULL::TEXT AS value_ref
-        FROM stream_metadata
-    ),
-    -- Add row number to be able to create deterministic UUIDs
-    args_with_row_number AS (
-        SELECT all_arguments.*, row_number() OVER () AS row_number
-        FROM all_arguments
-    ),
-    args AS (
-        SELECT 
-            uuid_generate_v5($base_uuid, 'metadata' || $data_provider || arg.stream_id || arg.metadata_key || arg.row_number::TEXT)::UUID as row_id,
-            $data_provider AS data_provider,
-            arg.stream_id,
-            arg.metadata_key,
-            arg.value_s,
-            arg.value_i,
-            arg.value_ref,
-            @height AS created_at,
-            s.id AS stream_ref
-        FROM args_with_row_number arg
-        JOIN data_providers dp ON dp.address = $data_provider
-        JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = arg.stream_id
-    )
-    -- catched a bug where it's expected to have the same order of columns
-    -- as the table definition
+    -- Create metadata for the streams using UNNEST for optimal performance
+    -- Insert stream_owner metadata
     INSERT INTO metadata (
         row_id,
         metadata_key,
@@ -252,38 +131,135 @@ CREATE OR REPLACE ACTION create_streams(
         disabled_at,
         stream_ref
     )
-    SELECT 
-        row_id::UUID,
+    SELECT
+        uuid_generate_v5($base_uuid, 'metadata' || $data_provider || t.stream_id || 'stream_owner' || '1')::UUID,
+        'stream_owner'::TEXT,
+        NULL::INT,
+        NULL::NUMERIC(36,18),
+        NULL::BOOL,
+        NULL::TEXT,
+        LOWER($data_provider)::TEXT,
+        @height,
+        NULL::INT,
+        s.id
+    FROM UNNEST($stream_ids, $stream_types) AS t(stream_id, stream_type)
+    JOIN data_providers dp ON dp.address = $data_provider
+    JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id;
+
+    -- Insert read_visibility metadata
+    INSERT INTO metadata (
+        row_id,
         metadata_key,
         value_i,
-        NULL::NUMERIC(36,18),
-        NULL::BOOLEAN,
+        value_f,
+        value_b,
         value_s,
         value_ref,
         created_at,
-        NULL::INT8,
+        disabled_at,
         stream_ref
-    FROM args;
+    )
+    SELECT
+        uuid_generate_v5($base_uuid, 'metadata' || $data_provider || t.stream_id || 'read_visibility' || '2')::UUID,
+        'read_visibility'::TEXT,
+        0::INT,
+        NULL::NUMERIC(36,18),
+        NULL::BOOL,
+        NULL::TEXT,
+        NULL::TEXT,
+        @height,
+        NULL::INT,
+        s.id
+    FROM UNNEST($stream_ids, $stream_types) AS t(stream_id, stream_type)
+    JOIN data_providers dp ON dp.address = $data_provider
+    JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id;
+
+    -- Insert readonly_key metadata (stream_owner)
+    INSERT INTO metadata (
+        row_id,
+        metadata_key,
+        value_i,
+        value_f,
+        value_b,
+        value_s,
+        value_ref,
+        created_at,
+        disabled_at,
+        stream_ref
+    )
+    SELECT
+        uuid_generate_v5($base_uuid, 'metadata' || $data_provider || t.stream_id || 'readonly_key' || '3')::UUID,
+        'readonly_key'::TEXT,
+        NULL::INT,
+        NULL::NUMERIC(36,18),
+        NULL::BOOL,
+        'stream_owner'::TEXT,
+        NULL::TEXT,
+        @height,
+        NULL::INT,
+        s.id
+    FROM UNNEST($stream_ids, $stream_types) AS t(stream_id, stream_type)
+    JOIN data_providers dp ON dp.address = $data_provider
+    JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id;
+
+    -- Insert readonly_key metadata (readonly_key)
+    INSERT INTO metadata (
+        row_id,
+        metadata_key,
+        value_i,
+        value_f,
+        value_b,
+        value_s,
+        value_ref,
+        created_at,
+        disabled_at,
+        stream_ref
+    )
+    SELECT
+        uuid_generate_v5($base_uuid, 'metadata' || $data_provider || t.stream_id || 'readonly_key' || '4')::UUID,
+        'readonly_key'::TEXT,
+        NULL::INT,
+        NULL::NUMERIC(36,18),
+        NULL::BOOL,
+        'readonly_key'::TEXT,
+        NULL::TEXT,
+        @height,
+        NULL::INT,
+        s.id
+    FROM UNNEST($stream_ids, $stream_types) AS t(stream_id, stream_type)
+    JOIN data_providers dp ON dp.address = $data_provider
+    JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id;
+
+    -- Insert type metadata
+    INSERT INTO metadata (
+        row_id,
+        metadata_key,
+        value_i,
+        value_f,
+        value_b,
+        value_s,
+        value_ref,
+        created_at,
+        disabled_at,
+        stream_ref
+    )
+    SELECT
+        uuid_generate_v5($base_uuid, 'metadata' || $data_provider || t.stream_id || 'type' || '5')::UUID,
+        'type'::TEXT,
+        NULL::INT,
+        NULL::NUMERIC(36,18),
+        NULL::BOOL,
+        t.stream_type,
+        NULL::TEXT,
+        @height,
+        NULL::INT,
+        s.id
+    FROM UNNEST($stream_ids, $stream_types) AS t(stream_id, stream_type)
+    JOIN data_providers dp ON dp.address = $data_provider
+    JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id;
+
 };
 
-CREATE OR REPLACE ACTION get_stream_id(
-  $data_provider_address TEXT,
-  $stream_id TEXT
-) PUBLIC returns (id INT) {
-  $id INT;
-  $found BOOL := false;
-  FOR $stream_row IN SELECT s.id
-      FROM streams s
-      JOIN data_providers dp ON s.data_provider_id = dp.id
-      WHERE s.stream_id = $stream_id 
-      AND dp.address = $data_provider_address
-      LIMIT 1 {
-      $found := true;
-      $id := $stream_row.id;
-  }
-
-  return $id;
-};
 
 /**
  * insert_metadata: Adds metadata to a stream.
@@ -454,6 +430,75 @@ CREATE OR REPLACE ACTION check_stream_id_format(
 };
 
 /**
+ * validate_stream_ids_format_batch: Validates multiple stream ID formats efficiently.
+ * Returns all stream IDs with their validation status and error details.
+ */
+CREATE OR REPLACE ACTION validate_stream_ids_format_batch(
+    $stream_ids TEXT[]
+) PUBLIC view returns table(
+    stream_id TEXT,
+    is_valid BOOL,
+    error_reason TEXT
+) {
+    -- Pure SQL validation using supported functions only
+    RETURN SELECT
+        t.stream_id,
+        CASE
+            WHEN LENGTH(t.stream_id) != 32 THEN false
+            WHEN substring(t.stream_id, 1, 2) != 'st' THEN false
+            -- Check characters 3-32 are lowercase alphanumeric using basic string functions
+            WHEN LENGTH(trim(lower(substring(t.stream_id, 3, 30)), '0123456789abcdefghijklmnopqrstuvwxyz')) != 0 THEN false
+            ELSE true
+        END AS is_valid,
+        CASE
+            WHEN LENGTH(t.stream_id) != 32 THEN 'Invalid length (must be 32 characters)'
+            WHEN substring(t.stream_id, 1, 2) != 'st' THEN 'Must start with "st"'
+            -- Check characters 3-32 are lowercase alphanumeric using basic string functions
+            WHEN LENGTH(trim(lower(substring(t.stream_id, 3, 30)), '0123456789abcdefghijklmnopqrstuvwxyz')) != 0 THEN 'Characters 3-32 must be lowercase alphanumeric'
+            ELSE NULL
+        END AS error_reason
+    FROM UNNEST($stream_ids) AS t(stream_id);
+};
+
+/**
+ * validate_stream_creation_batch: Validates both stream IDs and types for creation.
+ * Returns invalid entries with specific error reasons.
+ */
+CREATE OR REPLACE ACTION validate_stream_creation_batch(
+    $stream_ids TEXT[],
+    $stream_types TEXT[]
+) PUBLIC view returns table(
+    index_position INT,
+    stream_id TEXT,
+    stream_type TEXT,
+    error_reason TEXT
+) {
+    -- Pure SQL validation using supported functions only
+    for $row in SELECT
+        ROW_NUMBER() OVER () AS index_position,
+        t.stream_id,
+        t.stream_type,
+        CASE
+            WHEN LENGTH(t.stream_id) != 32 THEN 'Stream ID: Invalid length (must be 32 characters)'
+            WHEN substring(t.stream_id, 1, 2) != 'st' THEN 'Stream ID: Must start with "st"'
+            -- Check characters 3-32 are lowercase alphanumeric using basic string functions
+            WHEN LENGTH(trim(lower(substring(t.stream_id, 3, 30)), '0123456789abcdefghijklmnopqrstuvwxyz')) != 0 THEN 'Stream ID: Characters 3-32 must be lowercase alphanumeric'
+            WHEN t.stream_type != 'primitive' AND t.stream_type != 'composed' THEN 'Stream Type: Must be "primitive" or "composed"'
+            ELSE ''
+        END AS error_reason
+    FROM UNNEST($stream_ids, $stream_types) AS t(stream_id, stream_type)
+    WHERE LENGTH(t.stream_id) != 32
+       OR substring(t.stream_id, 1, 2) != 'st'
+       -- Check characters 3-32 are lowercase alphanumeric using basic string functions
+       OR LENGTH(trim(lower(substring(t.stream_id, 3, 30)), '0123456789abcdefghijklmnopqrstuvwxyz')) != 0
+       OR (t.stream_type != 'primitive' AND t.stream_type != 'composed') {
+        RETURN NEXT $row.index_position, $row.stream_id, $row.stream_type, $row.error_reason;
+    }
+};
+
+
+
+/**
  * check_ethereum_address: Validates Ethereum address format.
  */
 CREATE OR REPLACE ACTION check_ethereum_address(
@@ -570,55 +615,21 @@ CREATE OR REPLACE ACTION is_stream_owner_batch(
     }
     $lowercase_wallet TEXT := LOWER($wallet);
 
-    -- Use WITH RECURSIVE to unnest all pairs, then find unique pairs to check
-    -- This is much more efficient than checking every single pair from input arrays
-    WITH RECURSIVE 
-    indexes AS (
-        SELECT 1 AS idx
-        UNION ALL
-        SELECT idx + 1 FROM indexes
-        WHERE idx < array_length($data_providers)
-    ),
-    stream_arrays AS (
-        SELECT 
-            $data_providers AS data_providers,
-            $stream_ids AS stream_ids
-    ),
-    all_pairs AS (
-        SELECT 
-            stream_arrays.data_providers[idx] AS data_provider,
-            stream_arrays.stream_ids[idx] AS stream_id
-        FROM indexes
-        JOIN stream_arrays ON 1=1
-    ),
-    unique_pairs AS (
-        SELECT DISTINCT data_provider, stream_id
-        FROM all_pairs
-    ),
-    -- Check which unique streams are owned by the wallet
-    unique_ownership_check AS (
-        SELECT 
-            up.data_provider,
-            up.stream_id,
-            CASE WHEN m.value_ref IS NOT NULL AND m.value_ref = $lowercase_wallet THEN true ELSE false END AS is_owner
-        FROM unique_pairs up
-        LEFT JOIN (
-          SELECT dp.address as data_provider, s.stream_id, md.value_ref
-          FROM metadata md
-          JOIN streams s ON md.stream_ref = s.id
-          JOIN data_providers dp ON s.data_provider_id = dp.id
-          WHERE md.metadata_key = 'stream_owner'
-            AND md.disabled_at IS NULL
-          ORDER BY md.created_at DESC
-        ) m ON up.data_provider = m.data_provider AND up.stream_id = m.stream_id
-    )
-    -- Map the ownership status back to all original pairs
-    SELECT 
-        ap.data_provider,
-        ap.stream_id,
-        uoc.is_owner
-    FROM all_pairs ap
-    JOIN unique_ownership_check uoc ON ap.data_provider = uoc.data_provider AND ap.stream_id = uoc.stream_id;
+    -- Use UNNEST for optimal performance - direct array processing without recursion
+    SELECT
+        t.data_provider,
+        t.stream_id,
+        CASE WHEN m.value_ref IS NOT NULL AND m.value_ref = $lowercase_wallet THEN true ELSE false END AS is_owner
+    FROM UNNEST($data_providers, $stream_ids) AS t(data_provider, stream_id)
+    LEFT JOIN (
+        SELECT dp.address as data_provider, s.stream_id, md.value_ref
+        FROM metadata md
+        JOIN streams s ON md.stream_ref = s.id
+        JOIN data_providers dp ON s.data_provider_id = dp.id
+        WHERE md.metadata_key = 'stream_owner'
+          AND md.disabled_at IS NULL
+        ORDER BY md.created_at DESC
+    ) m ON t.data_provider = m.data_provider AND t.stream_id = m.stream_id;
 };
 
 /**
@@ -659,49 +670,14 @@ CREATE OR REPLACE ACTION is_primitive_stream_batch(
         ERROR('Data providers and stream IDs arrays must have the same length');
     }
 
-    -- Use WITH RECURSIVE to unnest all pairs, then find unique pairs to check
-    -- This is much more efficient than checking every single pair from input arrays
-    WITH RECURSIVE 
-    indexes AS (
-        SELECT 1 AS idx
-        UNION ALL
-        SELECT idx + 1 FROM indexes
-        WHERE idx < array_length($data_providers)
-    ),
-    stream_arrays AS (
-        SELECT 
-            $data_providers AS data_providers,
-            $stream_ids AS stream_ids
-    ),
-    all_pairs AS (
-        SELECT
-            stream_arrays.data_providers[idx] AS data_provider,
-            stream_arrays.stream_ids[idx] AS stream_id
-        FROM indexes
-        JOIN stream_arrays ON 1=1
-    ),
-    unique_pairs AS (
-        SELECT DISTINCT data_provider, stream_id
-        FROM all_pairs
-    ),
-    unique_status AS (
-        -- This JOIN to streams table is now only performed on unique pairs
-        SELECT 
-            up.data_provider,
-            up.stream_id,
-            COALESCE(s.stream_type = 'primitive', false) AS is_primitive
-        FROM unique_pairs up
-        LEFT JOIN streams s ON s.data_provider_id = (
-            SELECT id FROM data_providers WHERE address = up.data_provider
-        ) AND s.stream_id = up.stream_id
-    )
-    -- Map the primitive status back to all original pairs
-    SELECT 
-        ap.data_provider,
-        ap.stream_id,
-        us.is_primitive
-    FROM all_pairs ap
-    JOIN unique_status us ON ap.data_provider = us.data_provider AND ap.stream_id = us.stream_id;
+    -- Use UNNEST for optimal performance - direct array processing without recursion
+    SELECT
+        t.data_provider,
+        t.stream_id,
+        COALESCE(s.stream_type = 'primitive', false) AS is_primitive
+    FROM UNNEST($data_providers, $stream_ids) AS t(data_provider, stream_id)
+    LEFT JOIN data_providers dp ON dp.address = t.data_provider
+    LEFT JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id;
 };
 
 /**
@@ -1197,35 +1173,19 @@ CREATE OR REPLACE ACTION stream_exists_batch_core(
 CREATE OR REPLACE ACTION is_primitive_stream_batch_core(
     $stream_refs INT[]
 ) PRIVATE VIEW RETURNS (result BOOL) {
-    for $row in WITH RECURSIVE
-    idx AS (
-        SELECT 1 AS i
-        UNION ALL
-        SELECT i + 1 FROM idx
-        WHERE i < array_length($stream_refs)
-    ),
-    arr AS (
-        SELECT $stream_refs AS refs
-    ),
-    unique_refs AS (
-        SELECT DISTINCT arr.refs[i] AS stream_ref
-        FROM idx
-        JOIN arr ON 1=1
-        WHERE arr.refs[i] IS NOT NULL
-    )
-    -- Return false if any nulls exist, otherwise return primitive check result
-    SELECT CASE
+    -- Use UNNEST for optimal performance - direct array processing without recursion
+    for $row in SELECT CASE
         WHEN EXISTS (
             SELECT 1
-            FROM idx
-            JOIN arr ON 1=1
-            WHERE arr.refs[i] IS NULL
+            FROM UNNEST($stream_refs) AS t(stream_ref)
+            WHERE t.stream_ref IS NULL
         ) THEN false
         ELSE NOT EXISTS (
             SELECT 1
-            FROM unique_refs u
-            JOIN streams s ON s.id = u.stream_ref
+            FROM UNNEST($stream_refs) AS t(stream_ref)
+            JOIN streams s ON s.id = t.stream_ref
             WHERE s.stream_type != 'primitive'
+              AND t.stream_ref IS NOT NULL
         )
     END AS result
     FROM (SELECT 1) dummy {
@@ -1254,48 +1214,14 @@ CREATE OR REPLACE ACTION stream_exists_batch(
         ERROR('Data providers and stream IDs arrays must have the same length');
     }
 
-    -- Use WITH RECURSIVE to unnest all pairs, then find unique pairs to check
-    -- This is much more efficient than checking every single pair from input arrays
-    RETURN WITH RECURSIVE 
-    indexes AS (
-        SELECT 1 AS idx
-        UNION ALL
-        SELECT idx + 1 FROM indexes
-        WHERE idx < array_length($data_providers)
-    ),
-    stream_arrays AS (
-        SELECT 
-            $data_providers AS data_providers,
-            $stream_ids AS stream_ids
-    ),
-    all_pairs AS (
-        SELECT 
-            stream_arrays.data_providers[idx] AS data_provider,
-            stream_arrays.stream_ids[idx] AS stream_id
-        FROM indexes
-        JOIN stream_arrays ON 1=1
-    ),
-    unique_pairs AS (
-        SELECT DISTINCT data_provider, stream_id
-        FROM all_pairs
-    ),
-    unique_existence AS (
-        -- This JOIN to streams table is now only performed on unique pairs
-        SELECT 
-            up.data_provider,
-            up.stream_id,
-            CASE WHEN s.data_provider IS NOT NULL THEN true ELSE false END AS stream_exists
-        FROM unique_pairs up
-        LEFT JOIN data_providers dp ON dp.address = up.data_provider
-        LEFT JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = up.stream_id
-    )
-    -- Map the existence status back to all original pairs
-    SELECT 
-        ap.data_provider,
-        ap.stream_id,
-        ue.stream_exists
-    FROM all_pairs ap
-    JOIN unique_existence ue ON ap.data_provider = ue.data_provider AND ap.stream_id = ue.stream_id;
+    -- Use UNNEST for optimal performance - direct array processing without recursion
+    RETURN SELECT
+        t.data_provider,
+        t.stream_id,
+        CASE WHEN s.data_provider IS NOT NULL THEN true ELSE false END AS stream_exists
+    FROM UNNEST($data_providers, $stream_ids) AS t(data_provider, stream_id)
+    LEFT JOIN data_providers dp ON dp.address = t.data_provider
+    LEFT JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id;
 };
 
 CREATE OR REPLACE ACTION transfer_stream_ownership(

--- a/internal/migrations/001-common-actions.sql
+++ b/internal/migrations/001-common-actions.sql
@@ -91,8 +91,10 @@ CREATE OR REPLACE ACTION create_streams(
 
     -- Validate stream types using dedicated private function
     for $validation_result in validate_stream_types_batch($stream_types) {
-        ERROR('Invalid stream type at position ' || $validation_result.position || ': ' ||
-              $validation_result.stream_type || ' - ' || $validation_result.error_reason);
+        IF $validation_result.error_reason != '' {
+            ERROR('Invalid stream type at position ' || $validation_result.position || ': ' ||
+                  $validation_result.stream_type || ' - ' || $validation_result.error_reason);
+        }
     }
 
     $base_uuid := uuid_generate_kwil('create_streams_' || @txid);

--- a/internal/migrations/002-authorization.sql
+++ b/internal/migrations/002-authorization.sql
@@ -840,7 +840,7 @@ CREATE OR REPLACE ACTION is_wallet_allowed_to_write_batch(
     RETURN SELECT
         t.data_provider,
         t.stream_id,
-        (o.owner = $wallet) OR (p.has_perm) AS is_allowed
+        COALESCE(o.owner = $wallet, false) OR COALESCE(p.has_perm, false) AS is_allowed
     FROM UNNEST($data_providers, $stream_ids) AS t(data_provider, stream_id)
     LEFT JOIN (
         -- Precompute the latest owner per stream_ref

--- a/internal/migrations/002-authorization.sql
+++ b/internal/migrations/002-authorization.sql
@@ -735,66 +735,37 @@ CREATE OR REPLACE ACTION wallet_write_batch_core(
     $wallet TEXT
 ) PRIVATE VIEW RETURNS (result BOOL) {
     $lowercase_wallet TEXT := LOWER($wallet);
-    for $row in WITH RECURSIVE
-    idx AS (
-        SELECT 1 AS i
-        UNION ALL
-        SELECT i + 1 FROM idx
-        WHERE i < array_length($stream_refs)
-    ),
-    arr AS (
-        SELECT $stream_refs AS refs
-    ),
-    unique_refs AS (
-        SELECT DISTINCT arr.refs[i] AS stream_ref
-        FROM idx
-        JOIN arr ON 1=1
-        WHERE arr.refs[i] IS NOT NULL
-    ),
-    latest_owner_time AS (
-        SELECT m.stream_ref, MAX(m.created_at) AS created_at
-        FROM metadata m
-        JOIN unique_refs u ON u.stream_ref = m.stream_ref
-        WHERE m.metadata_key = 'stream_owner' AND m.disabled_at IS NULL
-        GROUP BY m.stream_ref
-    ),
-    owners AS (
-        SELECT m.stream_ref, m.value_ref AS owner
-        FROM metadata m
-        JOIN latest_owner_time lo
-          ON lo.stream_ref = m.stream_ref AND lo.created_at = m.created_at
-        WHERE m.metadata_key = 'stream_owner'
-    ),
-    allowed_by_perm AS (
-        SELECT DISTINCT m.stream_ref
-        FROM metadata m
-        JOIN unique_refs u ON u.stream_ref = m.stream_ref
-        WHERE m.metadata_key = 'allow_write_wallet'
-          AND m.disabled_at IS NULL
-          -- do not use LOWER on value_ref, or it will break the index lookup
-          AND m.value_ref = $lowercase_wallet
-    ),
-    allowed AS (
-        SELECT u.stream_ref,
-               CASE WHEN o.owner = $lowercase_wallet THEN 1
-                    WHEN ap.stream_ref IS NOT NULL THEN 1
-                    ELSE 0 END AS can_write
-        FROM unique_refs u
-        LEFT JOIN owners o ON o.stream_ref = u.stream_ref
-        LEFT JOIN allowed_by_perm ap ON ap.stream_ref = u.stream_ref
-    )
-    -- Return false if any nulls exist, otherwise return write permission check result
-    SELECT CASE
+
+    -- Use UNNEST for efficient batch processing
+    for $row in SELECT CASE
         WHEN EXISTS (
-            SELECT 1
-            FROM idx
-            JOIN arr ON 1=1
-            WHERE arr.refs[i] IS NULL
+            SELECT 1 FROM UNNEST($stream_refs) AS t(stream_ref) WHERE t.stream_ref IS NULL
         ) THEN false
         ELSE NOT EXISTS (
             SELECT 1
-            FROM allowed
-            WHERE can_write = 0
+            FROM UNNEST($stream_refs) AS t(stream_ref)
+            LEFT JOIN (
+                SELECT m.stream_ref, m.value_ref AS owner
+                FROM metadata m
+                WHERE m.metadata_key = 'stream_owner'
+                  AND m.disabled_at IS NULL
+                  AND m.created_at = (
+                      SELECT MAX(m2.created_at)
+                      FROM metadata m2
+                      WHERE m2.stream_ref = m.stream_ref
+                        AND m2.metadata_key = 'stream_owner'
+                        AND m2.disabled_at IS NULL
+                  )
+            ) o ON o.stream_ref = t.stream_ref
+            LEFT JOIN (
+                SELECT DISTINCT m.stream_ref
+                FROM metadata m
+                WHERE m.metadata_key = 'allow_write_wallet'
+                  AND m.disabled_at IS NULL
+                  AND m.value_ref = $lowercase_wallet
+            ) ap ON ap.stream_ref = t.stream_ref
+            WHERE t.stream_ref IS NOT NULL
+              AND NOT (o.owner = $lowercase_wallet OR ap.stream_ref IS NOT NULL)
         )
     END AS result
     FROM (SELECT 1) dummy {
@@ -862,86 +833,40 @@ CREATE OR REPLACE ACTION is_wallet_allowed_to_write_batch(
         RETURN; -- Return empty table
      }
 
-    -- BEST PRACTICE: Use RETURN WITH RECURSIVE to perform all logic in one SQL batch operation.
-     RETURN WITH RECURSIVE
-     -- 1. Generate indexes 1 to N
-    indexes AS (
-        SELECT 1 AS idx
-        UNION ALL
-        SELECT idx + 1 FROM indexes
-        WHERE idx < array_length($data_providers)
-    ),
-    arguments AS (
-        SELECT
-            $data_providers AS data_providers,
-            $stream_ids AS stream_ids
-    ),
-     -- 2. Unnest the input arrays into pairs, keeping original index for order/duplicates
-    all_pairs AS (
-        SELECT
-            idx,
-            LOWER(arguments.data_providers[idx]) AS data_provider,
-            arguments.stream_ids[idx] AS stream_id
-        FROM indexes
-        JOIN arguments ON 1=1
-    ),
-    -- 3. Get unique pairs to check metadata efficiently
-    unique_pairs AS (
-      SELECT DISTINCT data_provider, stream_id
-      FROM all_pairs
-    ),
-    -- 4. Check both ownership AND permission for each unique pair using subqueries
-    unique_check_results AS (
-      SELECT
-            up.data_provider,
-            up.stream_id,
-            -- Combine the two checks:
-            -- COALESCE handles cases where a subquery might return NULL instead of FALSE
-            COALESCE(
-                -- Check 1: Is the wallet the LATEST valid owner?
-                (SELECT m_own.value_ref
-                  FROM metadata m_own
-                  JOIN streams s_own ON m_own.stream_ref = s_own.id
-                  JOIN data_providers dp_own ON s_own.data_provider_id = dp_own.id
-                  WHERE dp_own.address = up.data_provider
-                    AND s_own.stream_id = up.stream_id
-                    AND m_own.metadata_key = 'stream_owner'
-                    AND m_own.disabled_at IS NULL
-                  ORDER BY m_own.created_at DESC -- Get the latest owner record
-                  LIMIT 1
-                ) = $wallet -- This comparison (NULL = $wallet) results in NULL if no owner found
-              , FALSE) -- COALESCE NULL to FALSE
-            OR -- Logical OR
-            COALESCE(
-                -- Check 2: Does ANY active permission record exist for the wallet?
-                EXISTS (
-                    SELECT 1
-                    FROM metadata m_perm
-                    JOIN streams s_perm ON m_perm.stream_ref = s_perm.id
-                    JOIN data_providers dp_perm ON s_perm.data_provider_id = dp_perm.id
-                    WHERE dp_perm.address = up.data_provider
-                      AND s_perm.stream_id = up.stream_id
-                      AND m_perm.metadata_key = 'allow_write_wallet'
-                      AND m_perm.value_ref = $wallet
-                      AND m_perm.disabled_at IS NULL
-                    -- No ORDER BY/LIMIT needed, just checking for existence of any record
-                )
-            , FALSE) -- COALESCE NULL to FALSE
-            as is_allowed
-      FROM unique_pairs up
-      -- Note: We query metadata table via subqueries, not via LEFT JOIN + GROUP BY
-    )
-    -- 5. Final SELECT: Map the results from unique checks back to all original pairs
-    SELECT
-        ap.data_provider,
-        ap.stream_id,
-        -- JOIN ensures is_allowed is not NULL, but COALESCE is safe
-        COALESCE(ucr.is_allowed, FALSE) AS is_allowed
-    FROM all_pairs ap
-    -- JOIN back to the results calculated for the unique pairs
-    -- this will not return any rows for streams that don't exist
-    JOIN unique_check_results ucr ON ap.data_provider = ucr.data_provider AND ap.stream_id = ucr.stream_id
-    ORDER BY ap.idx; -- Preserve the original input order
+    -- Use UNNEST for efficient batch processing
+    RETURN SELECT
+        t.data_provider,
+        t.stream_id,
+        COALESCE(
+            -- Check 1: Is the wallet the LATEST valid owner?
+            (SELECT m_own.value_ref
+              FROM metadata m_own
+              JOIN streams s_own ON m_own.stream_ref = s_own.id
+              JOIN data_providers dp_own ON s_own.data_provider_id = dp_own.id
+              WHERE dp_own.address = t.data_provider
+                AND s_own.stream_id = t.stream_id
+                AND m_own.metadata_key = 'stream_owner'
+                AND m_own.disabled_at IS NULL
+              ORDER BY m_own.created_at DESC
+              LIMIT 1
+            ) = $wallet
+        , FALSE)
+        OR
+        COALESCE(
+            -- Check 2: Does ANY active permission record exist for the wallet?
+            EXISTS (
+                SELECT 1
+                FROM metadata m_perm
+                JOIN streams s_perm ON m_perm.stream_ref = s_perm.id
+                JOIN data_providers dp_perm ON s_perm.data_provider_id = dp_perm.id
+                WHERE dp_perm.address = t.data_provider
+                  AND s_perm.stream_id = t.stream_id
+                  AND m_perm.metadata_key = 'allow_write_wallet'
+                  AND m_perm.value_ref = $wallet
+                  AND m_perm.disabled_at IS NULL
+            )
+        , FALSE) AS is_allowed
+    FROM UNNEST($data_providers, $stream_ids) AS t(data_provider, stream_id);
 };
 
 /**
@@ -958,8 +883,7 @@ CREATE OR REPLACE ACTION has_write_permission_batch(
     stream_id TEXT,
     has_permission BOOL
 ) {
-    -- Use helper function to avoid expensive for-loop roundtrips
-    $data_providers := helper_lowercase_array($data_providers);
+    -- Lowercase wallet once
     $wallet := LOWER($wallet);
 
     -- Check that arrays have the same length
@@ -967,11 +891,8 @@ CREATE OR REPLACE ACTION has_write_permission_batch(
         ERROR('Data providers and stream IDs arrays must have the same length');
     }
 
-    $lowercase_wallet TEXT := LOWER($wallet);
-
-    -- Use UNNEST for optimal performance - direct array processing without recursion
-    RETURN
-    SELECT
+    -- Use UNNEST for optimal performance with direct array processing
+    RETURN SELECT
         t.data_provider,
         t.stream_id,
         CASE WHEN m.value_ref IS NOT NULL THEN true ELSE false END AS has_permission
@@ -982,8 +903,8 @@ CREATE OR REPLACE ACTION has_write_permission_batch(
         JOIN streams s ON m.stream_ref = s.id
         JOIN data_providers dp ON s.data_provider_id = dp.id
         WHERE m.metadata_key = 'allow_write_wallet'
-          AND m.value_ref = $lowercase_wallet
+          AND m.value_ref = $wallet
           AND m.disabled_at IS NULL
         ORDER BY m.created_at DESC
-    ) m ON t.data_provider = m.data_provider AND t.stream_id = m.stream_id;
+    ) m ON LOWER(t.data_provider) = m.data_provider AND t.stream_id = m.stream_id;
 };

--- a/internal/migrations/003-primitive-insertion.sql
+++ b/internal/migrations/003-primitive-insertion.sql
@@ -65,7 +65,8 @@ CREATE OR REPLACE ACTION insert_records(
         NULL,
         unnested.stream_ref
     FROM UNNEST($event_time, $value, $stream_refs) AS unnested(event_time, value, stream_ref)
-    WHERE unnested.value != 0::NUMERIC(36,18);
+    WHERE unnested.value != 0::NUMERIC(36,18)
+    ORDER BY unnested.stream_ref, unnested.event_time, $current_block;  -- matches (stream_ref, event_time, created_at)
 
     -- Enqueue days for pruning using helper (idempotent, distinct per day)
     helper_enqueue_prune_days(

--- a/internal/migrations/004-composed-taxonomy.sql
+++ b/internal/migrations/004-composed-taxonomy.sql
@@ -32,14 +32,12 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     if $num_children IS NULL {
        $num_children := 0;
     }
-    -- Validate that all child arrays have the same length.
-    if $num_children == 0 OR $num_children != array_length($child_data_providers) OR $num_children != array_length($weights) {
-        error('All child arrays must be of the same length');
+    if $num_children != array_length($child_data_providers) OR $num_children != array_length($weights) {
+        ERROR('All child arrays must be of the same length');
     }
-
-    -- ensure there is at least 1 child, otherwise we might have silent bugs, with the user thinking he added something
+    -- ensure there is at least 1 child, otherwise we might have silent bugs
     if $num_children == 0 {
-        error('There must be at least 1 child');
+        ERROR('There must be at least 1 child');
     }
 
     -- Default start time to 0 if not provided
@@ -51,12 +49,8 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     $new_group_sequence := get_current_group_sequence($data_provider, $stream_id, true) + 1;
     
     $stream_ref := get_stream_id($data_provider, $stream_id);
-
-    for $i in 1..$num_children {
-        $child_data_provider_value := $child_data_providers[$i];
-        $child_stream_id_value := $child_stream_ids[$i];
-        $child_stream_ref := get_stream_id($child_data_provider_value, $child_stream_id_value);
-        $weight_value := $weights[$i];
+    if $stream_ref IS NULL {
+        ERROR('parent stream does not exist: ' || $data_provider || ':' || $stream_id);
     }
 
     FOR $i IN 1..$num_children {

--- a/internal/migrations/004-composed-taxonomy.sql
+++ b/internal/migrations/004-composed-taxonomy.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     $weights NUMERIC(36,18)[],      -- The weights of the child streams.
     $start_date INT                 -- The start date of the taxonomy.
 ) PUBLIC {
-    $data_provider := LOWER($data_provider);
+     $data_provider := LOWER($data_provider);
     for $i in 1..array_length($child_data_providers) {
         $child_data_providers[$i] := LOWER($child_data_providers[$i]);
     }
@@ -51,6 +51,13 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     $new_group_sequence := get_current_group_sequence($data_provider, $stream_id, true) + 1;
     
     $stream_ref := get_stream_id($data_provider, $stream_id);
+
+    for $i in 1..$num_children {
+        $child_data_provider_value := $child_data_providers[$i];
+        $child_stream_id_value := $child_stream_ids[$i];
+        $child_stream_ref := get_stream_id($child_data_provider_value, $child_stream_id_value);
+        $weight_value := $weights[$i];
+    }
 
     FOR $i IN 1..$num_children {
         $child_data_provider_value := $child_data_providers[$i];

--- a/internal/migrations/016-taxonomy-query-actions.sql
+++ b/internal/migrations/016-taxonomy-query-actions.sql
@@ -253,17 +253,17 @@ CREATE OR REPLACE ACTION get_taxonomies_for_streams(
             s.stream_id,
             dpc.address AS child_data_provider,
             sc.stream_id AS child_stream_id,
-            t.weight,
-            t.created_at,
-            t.group_sequence,
-            t.start_time
+            tax.weight,
+            tax.created_at,
+            tax.group_sequence,
+            tax.start_time
         FROM UNNEST($data_providers, $stream_ids) AS t(data_provider, stream_id)
         JOIN data_providers dp ON dp.address = LOWER(t.data_provider)
         JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id
-        JOIN taxonomies t ON t.stream_ref = s.id
-        JOIN streams sc ON sc.id = t.child_stream_ref
+        JOIN taxonomies tax ON tax.stream_ref = s.id
+        JOIN streams sc ON sc.id = tax.child_stream_ref
         JOIN data_providers dpc ON dpc.id = sc.data_provider_id
-        WHERE t.disabled_at IS NULL
-        ORDER BY t.created_at ASC, t.group_sequence ASC;
+        WHERE tax.disabled_at IS NULL
+        ORDER BY tax.created_at ASC, tax.group_sequence ASC;
     }
 };

--- a/internal/migrations/016-taxonomy-query-actions.sql
+++ b/internal/migrations/016-taxonomy-query-actions.sql
@@ -80,7 +80,7 @@ CREATE OR REPLACE ACTION list_taxonomies_by_height(
     if $from_height IS NULL AND $to_height IS NULL {
         -- Special case: return latest set of taxonomies
         -- Use a reasonable lookback window to find recent taxonomies
-        $effective_from := $current_block - 1000;
+        $effective_from := GREATEST($current_block - 1000, 0);
         $effective_to := $current_block;
     } else {
         $effective_from := COALESCE($from_height, 0);
@@ -196,7 +196,7 @@ CREATE OR REPLACE ACTION get_taxonomies_for_streams(
         $latest_only := false;
     }
 
-    if array_length($data_providers) != array_length($stream_ids) {
+    if COALESCE(array_length($data_providers), 0) != COALESCE(array_length($stream_ids), 0) {
         ERROR('Data providers and stream IDs arrays must have the same length');
     }
 

--- a/internal/migrations/016-taxonomy-query-actions.sql
+++ b/internal/migrations/016-taxonomy-query-actions.sql
@@ -190,8 +190,7 @@ CREATE OR REPLACE ACTION get_taxonomies_for_streams(
     group_sequence INT8,
     start_time INT8
 ) {
-    -- Normalize inputs
-    $data_providers := helper_lowercase_array($data_providers);
+    -- Data providers will be lowercased directly in queries using LOWER()
 
     if $latest_only IS NULL {
         $latest_only := false;
@@ -202,38 +201,15 @@ CREATE OR REPLACE ACTION get_taxonomies_for_streams(
     }
 
     if $latest_only {
-        RETURN WITH RECURSIVE 
-        indexes AS (
-            SELECT 1 AS idx
-            UNION ALL
-            SELECT idx + 1 FROM indexes
-            WHERE idx < array_length($data_providers)
-        ),
-        stream_arrays AS (
-            SELECT 
-                $data_providers AS data_providers,
-                $stream_ids AS stream_ids
-        ),
-        all_pairs AS (
-            SELECT 
-                stream_arrays.data_providers[idx] AS data_provider,
-                stream_arrays.stream_ids[idx] AS stream_id
-            FROM indexes
-            JOIN stream_arrays ON 1=1
-        ),
-        unique_pairs AS (
-            SELECT DISTINCT data_provider, stream_id
-            FROM all_pairs
-        ),
-        target_streams AS (
-            SELECT 
+        RETURN WITH target_streams AS (
+            SELECT DISTINCT
                 s.id AS stream_ref
-            FROM unique_pairs up
-            JOIN data_providers dp ON dp.address = up.data_provider
-            JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = up.stream_id
+            FROM UNNEST($data_providers, $stream_ids) AS t(data_provider, stream_id)
+            JOIN data_providers dp ON dp.address = LOWER(t.data_provider)
+            JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id
         ),
         stream_latest_info AS (
-            SELECT 
+            SELECT
                 t.stream_ref,
                 MAX(t.created_at) as max_created_at
             FROM taxonomies t
@@ -242,17 +218,17 @@ CREATE OR REPLACE ACTION get_taxonomies_for_streams(
             GROUP BY t.stream_ref
         ),
         stream_latest_group AS (
-            SELECT 
+            SELECT
                 sli.stream_ref,
                 sli.max_created_at,
                 MAX(t.group_sequence) as max_group_sequence
             FROM stream_latest_info sli
-            JOIN taxonomies t ON t.stream_ref = sli.stream_ref 
+            JOIN taxonomies t ON t.stream_ref = sli.stream_ref
                               AND t.created_at = sli.max_created_at
             WHERE t.disabled_at IS NULL
             GROUP BY sli.stream_ref, sli.max_created_at
         )
-        SELECT 
+        SELECT
             dp.address AS data_provider,
             s.stream_id,
             dpc.address AS child_data_provider,
@@ -262,9 +238,9 @@ CREATE OR REPLACE ACTION get_taxonomies_for_streams(
             t.group_sequence,
             t.start_time
         FROM stream_latest_group slg
-        JOIN taxonomies t 
-          ON t.stream_ref = slg.stream_ref 
-         AND t.created_at = slg.max_created_at 
+        JOIN taxonomies t
+          ON t.stream_ref = slg.stream_ref
+         AND t.created_at = slg.max_created_at
          AND t.group_sequence = slg.max_group_sequence
         JOIN streams s ON s.id = t.stream_ref
         JOIN data_providers dp ON dp.id = s.data_provider_id
@@ -272,30 +248,7 @@ CREATE OR REPLACE ACTION get_taxonomies_for_streams(
         JOIN data_providers dpc ON dpc.id = sc.data_provider_id
         WHERE t.disabled_at IS NULL;
     } else {
-        RETURN WITH RECURSIVE 
-        indexes AS (
-            SELECT 1 AS idx
-            UNION ALL
-            SELECT idx + 1 FROM indexes
-            WHERE idx < array_length($data_providers)
-        ),
-        stream_arrays AS (
-            SELECT 
-                $data_providers AS data_providers,
-                $stream_ids AS stream_ids
-        ),
-        all_pairs AS (
-            SELECT 
-                stream_arrays.data_providers[idx] AS data_provider,
-                stream_arrays.stream_ids[idx] AS stream_id
-            FROM indexes
-            JOIN stream_arrays ON 1=1
-        ),
-        unique_pairs AS (
-            SELECT DISTINCT data_provider, stream_id
-            FROM all_pairs
-        )
-        SELECT DISTINCT
+        RETURN SELECT DISTINCT
             dp.address AS data_provider,
             s.stream_id,
             dpc.address AS child_data_provider,
@@ -304,9 +257,9 @@ CREATE OR REPLACE ACTION get_taxonomies_for_streams(
             t.created_at,
             t.group_sequence,
             t.start_time
-        FROM unique_pairs up
-        JOIN data_providers dp ON dp.address = up.data_provider
-        JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = up.stream_id
+        FROM UNNEST($data_providers, $stream_ids) AS t(data_provider, stream_id)
+        JOIN data_providers dp ON dp.address = LOWER(t.data_provider)
+        JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id
         JOIN taxonomies t ON t.stream_ref = s.id
         JOIN streams sc ON sc.id = t.child_stream_ref
         JOIN data_providers dpc ON dpc.id = sc.data_provider_id

--- a/internal/migrations/018-fix-array-ordering-get-stream-ids.sql
+++ b/internal/migrations/018-fix-array-ordering-get-stream-ids.sql
@@ -2,9 +2,15 @@ CREATE OR REPLACE ACTION get_stream_ids(
   $data_providers TEXT[],
   $stream_ids     TEXT[]
 ) PUBLIC VIEW RETURNS (stream_ids INT[]) {
-  IF array_length($data_providers) != array_length($stream_ids) {
-    ERROR('array lengths mismatch');
-  }
+  -- Check that arrays have the same length
+  IF COALESCE(array_length($data_providers), 0) != COALESCE(array_length($stream_ids), 0) {  
+    ERROR(  
+      'array lengths mismatch: data_providers='  
+      || COALESCE(array_length($data_providers), 0)::TEXT  
+      || ', stream_ids='  
+      || COALESCE(array_length($stream_ids), 0)::TEXT  
+    );  
+  }  
 
   RETURN
   WITH idx AS (

--- a/internal/migrations/018-fix-array-ordering-get-stream-ids.sql
+++ b/internal/migrations/018-fix-array-ordering-get-stream-ids.sql
@@ -1,21 +1,32 @@
 CREATE OR REPLACE ACTION get_stream_ids(
   $data_providers TEXT[],
-  $stream_ids TEXT[]
+  $stream_ids     TEXT[]
 ) PUBLIC VIEW RETURNS (stream_ids INT[]) {
   IF array_length($data_providers) != array_length($stream_ids) {
     ERROR('array lengths mismatch');
   }
 
   RETURN
-  WITH joined AS (
-    SELECT gs.idx, s.id AS stream_id_resolved
-    FROM generate_subscripts($data_providers) AS gs(idx)
-    LEFT JOIN data_providers d ON d.address = LOWER($data_providers[gs.idx])
-    LEFT JOIN streams s ON s.data_provider_id = d.id AND s.stream_id = $stream_ids[gs.idx]
+  WITH idx AS (
+    SELECT
+      ord AS idx,
+      LOWER(dp) AS dp,   -- compute once
+      sid       AS sid
+    FROM unnest($data_providers, $stream_ids) WITH ORDINALITY AS u(dp, sid, ord)
+  ),
+  joined AS (
+    SELECT i.idx, s.id AS stream_id_resolved
+    FROM idx i
+    LEFT JOIN data_providers d
+      ON d.address = i.dp
+    LEFT JOIN streams s
+      ON s.data_provider_id = d.id
+     AND s.stream_id       = i.sid
   )
-  SELECT array_agg(stream_id_resolved ORDER BY idx)
+  SELECT COALESCE(array_agg(stream_id_resolved ORDER BY idx), ARRAY[]::INT[])
   FROM joined;
 };
+
 
 CREATE OR REPLACE ACTION get_stream_id(
   $data_provider_address TEXT,

--- a/internal/migrations/020-digest-actions.sql
+++ b/internal/migrations/020-digest-actions.sql
@@ -453,7 +453,7 @@ CREATE OR REPLACE ACTION batch_digest(
                     SELECT
                         u.stream_ref,
                         u.day_index
-                    FROM UNNEST($agg_stream_refs, $agg_day_indexes) AS u(stream_ref, day_index)
+                    FROM UNNEST($valid_stream_refs, $valid_day_indexes) AS u(stream_ref, day_index)
                 )
                 DELETE FROM pending_prune_days
                 WHERE EXISTS (

--- a/tests/streams/utils/setup/primitive.go
+++ b/tests/streams/utils/setup/primitive.go
@@ -321,6 +321,10 @@ func InsertPrimitiveDataMultiBatch(ctx context.Context, input InsertMultiPrimiti
 
 	// Execute one call per provider group with correct signer
 	for provider, g := range byProvider {
+		if len(g.dataProviders) != len(g.streamIds) || len(g.streamIds) != len(g.eventTimes) || len(g.eventTimes) != len(g.values) {
+			return errors.Errorf("array length mismatch for provider %s: dp=%d sid=%d ts=%d val=%d",
+				provider, len(g.dataProviders), len(g.streamIds), len(g.eventTimes), len(g.values))
+		}
 		signerAddr := util.Unsafe_NewEthereumAddressFromString(provider)
 
 		txContext := &common.TxContext{


### PR DESCRIPTION
## TL;DR
- **Performance-critical SQL change**: Removed array-append inside aggregates in favor of pure aggregation with `UNNEST`/`ARRAY_AGG`. Array appends during aggregation are a performance killer at our scale; this change reduces CPU and memory pressure and improves planner choices. This also affects other old actions (insert is a lot faster)
- **Benchmarks at a glance**:
  - **Excess candidates (large scale)**: avg ~0.99s/run, peak ~4.77 GB RAM; max ~4,232 stream-days/s and ~102k records/s
  - **Exact fit (moderate scale)**: avg ~421ms/run, peak ~379 MB RAM; max ~6,198 stream-days/s and ~149k records/s
- **Concern**: Excess scenario is notably slower than exact fit. This matches expectations (more filtering/ordering/aggregation), but we will validate on testnet-scale workloads. Also note: production/testnet scale is much larger than this "excess" scenario. Yet, this suite is a solid baseline for development.

## Description
- **Benchmarks**:
  - Added `internal/benchmark/digest` suite with runner, setup, export, helpers, constants, and types
  - Added benchmark and unit tests covering digest workflows
  - Integrated delete-cap handling into export/runner flows for controlled pruning scenarios
- **SQL and actions**:
  - Optimized digest SQL actions by replacing helper functions with direct `UNNEST` and `ARRAY_AGG`
  - Removed array-append inside aggregates in favor of pure aggregation paths; array appends within aggregation are a known performance killer at our scales
  - Streamlined `batch_digest` and `auto_digest`; added return fields (e.g., `has_more_to_delete`) for clearer control and observability
  - Updated related migrations to align with new logic and performance improvements
- **Tests and utilities**:
  - Updated digest action tests and fixtures; improved primitive insertion for multi‑stream support
  - Minor improvements to memory collector and benchmark setup utilities
- **Dependencies**:
  - Updated `go.mod`/`go.sum`

## Related Problem
- fix #1124 

## How Has This Been Tested?
- New unit tests under `internal/benchmark/digest` and comprehensive digest benchmarks
- Updated existing tests in `tests/streams/digest` and load tests
- Local benchmark runs validate delete-cap integration and new return flags

<details>
<summary>Digest benchmark — with excess candidates (large scale)</summary>

- Streams: 25,000; Days/stream: 12; Records/day: 24; Pattern: random
- Delete caps tested: 1k, 10k, 100k (3 samples each)
- Total results: 9; Unique cases: 1; Candidates: 2,700,000; Processed days: 20,811
- Avg duration: 0.99s (min 0.644s, max 1.631s)
- Peak memory: ~4.77 GB
- Throughput (max): 4,232 stream-days/s; 101,576 records/s

</details>

<details>
<summary>Digest benchmark — exact fit (moderate scale)</summary>

- Streams: 347; Days/stream: 12; Records/day: 24; Pattern: random
- Delete caps tested: 10k, 100k (3 samples each)
- Total results: 6; Unique cases: 1; Candidates: 24,984; Processed days: 14,367
- Avg duration: 421ms (min 130ms, max 697ms)
- Peak memory: ~379 MB
- Throughput (max): 6,198 stream-days/s; 148,753 records/s

</details>

<details>
<summary>Analysis and observations</summary>

- Exact-fit runs are faster and use far less memory because selected candidates approximately match the delete cap. This minimizes ranking/filtering and reduces aggregation overhead.
- Excess runs select many more candidates than can be deleted per pass, requiring additional filtering/ordering/aggregation. Combined with 25k streams, this increases memory pressure and CPU time.
- Concern: excess is significantly slower than exact fit at this scale (~0.99s vs ~421ms) and peaks at ~4.77 GB RAM. This aligns with increased candidate volume and cardinality, but remains a point to watch.
- Throughput figures are not directly comparable due to scale differences; the smaller exact-fit case naturally achieves higher per-second rates.

Although the behavior seems reasonable, the "with excess" scenario is still a subset of our production/testnet scale (much larger). We will validate performance on testnet-scale workloads before concluding whether it is acceptable in practice. This benchmark suite remains a solid baseline for development iteration.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Digest now returns a "more remaining" flag and supports configurable delete-cap/expected-records; daily OHLC can use digest markers.
  - CSV export/import/merge and Markdown reporting for digest benchmark results.

- Refactor
  - Large batch SQL flows rewritten for set-based performance; primitive ingestion moved to multi-batch/multi-stream; memory sampling made more robust.

- Tests
  - Complete digest benchmark suite, unit/aggregation tests, and updated digest action tests.

- Chores
  - Dependency bumps and benchmark results directory ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->