### PR TITLE
chore: enable leader check & retrigger digest

### DIFF
--- a/extensions/tn_digest/engine_ops_integration_test.go
+++ b/extensions/tn_digest/engine_ops_integration_test.go
@@ -36,7 +36,7 @@ func TestBuildAndBroadcastAutoDigestTx_VerifiesTxBuildSignAndDBEffect(t *testing
 				// Create accounts service
 				accts, err := accounts.InitializeAccountStore(ctx, platform.DB, log.New())
 				require.NoError(t, err)
-				
+
 				// Prepare EngineOperations
 				ops := internal.NewEngineOperations(platform.Engine, platform.DB, accts, log.New())
 
@@ -67,7 +67,7 @@ func TestBuildAndBroadcastAutoDigestTx_VerifiesTxBuildSignAndDBEffect(t *testing
 					_, execErr := platform.Engine.Call(engCtx, platform.DB, "main", "auto_digest", []any{}, func(_ *common.Row) error { return nil })
 					require.NoError(t, execErr)
 
-					return types.Hash{}, &types.TxResult{Code: uint32(types.CodeOk)}, nil
+					return types.Hash{}, &types.TxResult{Code: uint32(types.CodeOk), Log: "auto_digest:{\"processed_days\":1,\"total_deleted_rows\":0,\"has_more_to_delete\":false}"}, nil
 				}
 
 				// Build and broadcast via ops

--- a/extensions/tn_digest/internal/engine_ops.go
+++ b/extensions/tn_digest/internal/engine_ops.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/trufnetwork/kwil-db/common"
@@ -11,6 +12,13 @@ import (
 	ktypes "github.com/trufnetwork/kwil-db/core/types"
 	sql "github.com/trufnetwork/kwil-db/node/types/sql"
 )
+
+// DigestTxResult represents the parsed result from an auto_digest transaction
+type DigestTxResult struct {
+	ProcessedDays    int
+	TotalDeletedRows int
+	HasMoreToDelete  bool
+}
 
 // EngineOperations wraps engine calls needed by the digest extension.
 type EngineOperations struct {
@@ -98,8 +106,189 @@ func (e *EngineOperations) BuildAndBroadcastAutoDigestTx(ctx context.Context, ch
 	if err := tx.Sign(signer); err != nil {
 		return fmt.Errorf("sign tx: %w", err)
 	}
-	if _, _, err := broadcaster(ctx, tx, 0); err != nil {
+	hash, txResult, err := broadcaster(ctx, tx, 1)
+	if err != nil {
 		return fmt.Errorf("broadcast tx: %w", err)
 	}
+
+	// Check transaction result code before parsing logs
+	if txResult.Code != uint32(ktypes.CodeOk) {
+		return fmt.Errorf("transaction failed with code %d (expected %d): %s",
+			txResult.Code, uint32(ktypes.CodeOk), txResult.Log)
+	}
+
+	// Parse the digest result from the transaction log
+	result, err := parseDigestResultFromTxLog(txResult.Log)
+	if err != nil {
+		return fmt.Errorf("failed to parse digest result: %w", err)
+	}
+
+	e.logger.Info("auto_digest completed",
+		"processed_days", result.ProcessedDays,
+		"deleted_rows", result.TotalDeletedRows,
+		"has_more", result.HasMoreToDelete,
+		"tx_hash", hash.String())
+
 	return nil
+}
+
+// BroadcastAutoDigestWithArgsAndParse builds an ActionExecution tx for auto_digest with args and broadcasts it,
+// then parses the result from the transaction log
+func (e *EngineOperations) BroadcastAutoDigestWithArgsAndParse(
+	ctx context.Context,
+	chainID string,
+	signer auth.Signer,
+	broadcaster func(context.Context, *ktypes.Transaction, uint8) (ktypes.Hash, *ktypes.TxResult, error),
+	deleteCap, expectedRecords, preserveDays int,
+) (*DigestTxResult, error) {
+	// Get the signer account ID
+	signerAccountID, err := ktypes.GetSignerAccount(signer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get signer account: %w", err)
+	}
+
+	// Get account information using the accounts service directly on database
+	account, err := e.accounts.GetAccount(ctx, e.db, signerAccountID)
+	var nextNonce uint64
+	if err != nil {
+		// Account doesn't exist yet - use nonce 1 for first transaction
+		e.logger.Info("DEBUG: Account not found, using nonce 1 for first transaction", "account", fmt.Sprintf("%x", signerAccountID.Identifier), "error", err)
+		nextNonce = uint64(1)
+	} else {
+		// Account exists - use next nonce
+		nextNonce = uint64(account.Nonce + 1)
+		e.logger.Info("DEBUG: Account found, using next nonce", "account", fmt.Sprintf("%x", signerAccountID.Identifier), "currentNonce", account.Nonce, "nextNonce", nextNonce, "balance", account.Balance)
+	}
+
+	// Encode arguments
+	deleteCapArg, err := ktypes.EncodeValue(int64(deleteCap))
+	if err != nil {
+		return nil, fmt.Errorf("encode deleteCap: %w", err)
+	}
+	expectedRecordsArg, err := ktypes.EncodeValue(int64(expectedRecords))
+	if err != nil {
+		return nil, fmt.Errorf("encode expectedRecords: %w", err)
+	}
+	preserveDaysArg, err := ktypes.EncodeValue(int64(preserveDays))
+	if err != nil {
+		return nil, fmt.Errorf("encode preserveDays: %w", err)
+	}
+
+	payload := &ktypes.ActionExecution{
+		Namespace: "main",
+		Action:    "auto_digest",
+		Arguments: [][]*ktypes.EncodedValue{{
+			deleteCapArg, expectedRecordsArg, preserveDaysArg,
+		}},
+	}
+
+	// Create transaction with proper nonce
+	tx, err := ktypes.CreateNodeTransaction(payload, chainID, nextNonce)
+	if err != nil {
+		return nil, fmt.Errorf("create tx: %w", err)
+	}
+	if err := tx.Sign(signer); err != nil {
+		return nil, fmt.Errorf("sign tx: %w", err)
+	}
+
+	hash, txResult, err := broadcaster(ctx, tx, 1)
+	if err != nil {
+		return nil, fmt.Errorf("broadcast tx: %w", err)
+	}
+
+	// Check transaction result code before parsing logs
+	if txResult.Code != uint32(ktypes.CodeOk) {
+		return nil, fmt.Errorf("transaction failed with code %d (expected %d): %s",
+			txResult.Code, uint32(ktypes.CodeOk), txResult.Log)
+	}
+
+	// Parse the digest result from the transaction log
+	result, err := parseDigestResultFromTxLog(txResult.Log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse digest result: %w", err)
+	}
+
+	e.logger.Info("auto_digest with args completed",
+		"processed_days", result.ProcessedDays,
+		"deleted_rows", result.TotalDeletedRows,
+		"has_more", result.HasMoreToDelete,
+		"tx_hash", hash.String(),
+		"delete_cap", deleteCap,
+		"expected_records", expectedRecords,
+		"preserve_days", preserveDays)
+
+	return result, nil
+}
+
+// parseDigestResultFromTxLog parses the digest result from transaction log output
+// The digest action outputs log entries like: "auto_digest:{...json...}"
+func parseDigestResultFromTxLog(logOutput string) (*DigestTxResult, error) {
+	if logOutput == "" {
+		return nil, fmt.Errorf("empty log output")
+	}
+
+	// Split log into lines and look for auto_digest entries
+	lines := strings.Split(logOutput, "\n")
+	var digestJSON string
+
+	// Find the last auto_digest line
+	for _, line := range lines {
+		if strings.Contains(line, "auto_digest:") {
+			// Extract JSON part after "auto_digest:"
+			parts := strings.SplitN(line, "auto_digest:", 2)
+			if len(parts) == 2 {
+				digestJSON = strings.TrimSpace(parts[1])
+			}
+		}
+	}
+
+	if digestJSON == "" {
+		return nil, fmt.Errorf("no auto_digest log entry found")
+	}
+
+	// Parse the JSON (simple parsing since we know the expected structure)
+	result := &DigestTxResult{}
+
+	// Remove surrounding quotes if present
+	digestJSON = strings.Trim(digestJSON, `"`)
+
+	// Extract processed_days
+	if start := strings.Index(digestJSON, `"processed_days":`); start != -1 {
+		start += len(`"processed_days":`)
+		if end := strings.Index(digestJSON[start:], ","); end != -1 {
+			if val, err := strconv.Atoi(digestJSON[start : start+end]); err == nil {
+				result.ProcessedDays = val
+			}
+		} else if end := strings.Index(digestJSON[start:], "}"); end != -1 {
+			if val, err := strconv.Atoi(digestJSON[start : start+end]); err == nil {
+				result.ProcessedDays = val
+			}
+		}
+	}
+
+	// Extract total_deleted_rows
+	if start := strings.Index(digestJSON, `"total_deleted_rows":`); start != -1 {
+		start += len(`"total_deleted_rows":`)
+		if end := strings.Index(digestJSON[start:], ","); end != -1 {
+			if val, err := strconv.Atoi(digestJSON[start : start+end]); err == nil {
+				result.TotalDeletedRows = val
+			}
+		} else if end := strings.Index(digestJSON[start:], "}"); end != -1 {
+			if val, err := strconv.Atoi(digestJSON[start : start+end]); err == nil {
+				result.TotalDeletedRows = val
+			}
+		}
+	}
+
+	// Extract has_more_to_delete
+	if start := strings.Index(digestJSON, `"has_more_to_delete":`); start != -1 {
+		start += len(`"has_more_to_delete":`)
+		if end := strings.Index(digestJSON[start:], ","); end != -1 {
+			result.HasMoreToDelete = digestJSON[start:start+end] == "true"
+		} else if end := strings.Index(digestJSON[start:], "}"); end != -1 {
+			result.HasMoreToDelete = digestJSON[start:start+end] == "true"
+		}
+	}
+
+	return result, nil
 }

--- a/extensions/tn_digest/internal/engine_ops_test.go
+++ b/extensions/tn_digest/internal/engine_ops_test.go
@@ -1,0 +1,45 @@
+package internal
+
+import "testing"
+
+func TestParseDigestResultFromTxLog_HasMoreTrue(t *testing.T) {
+	log := "INFO something\nNOTICE: auto_digest:{\"processed_days\":2,\"total_deleted_rows\":500,\"has_more_to_delete\":true}\nother"
+	res, err := parseDigestResultFromTxLog(log)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ProcessedDays != 2 {
+		t.Fatalf("processed_days: want 2, got %d", res.ProcessedDays)
+	}
+	if res.TotalDeletedRows != 500 {
+		t.Fatalf("total_deleted_rows: want 500, got %d", res.TotalDeletedRows)
+	}
+	if !res.HasMoreToDelete {
+		t.Fatalf("has_more_to_delete: want true, got false")
+	}
+}
+
+func TestParseDigestResultFromTxLog_HasMoreFalse(t *testing.T) {
+	log := "auto_digest:{\"processed_days\":1,\"total_deleted_rows\":1234,\"has_more_to_delete\":false}"
+	res, err := parseDigestResultFromTxLog(log)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ProcessedDays != 1 {
+		t.Fatalf("processed_days: want 1, got %d", res.ProcessedDays)
+	}
+	if res.TotalDeletedRows != 1234 {
+		t.Fatalf("total_deleted_rows: want 1234, got %d", res.TotalDeletedRows)
+	}
+	if res.HasMoreToDelete {
+		t.Fatalf("has_more_to_delete: want false, got true")
+	}
+}
+
+func TestParseDigestResultFromTxLog_NoEntry(t *testing.T) {
+	log := "INFO: nothing relevant here\nNOTICE: something else"
+	_, err := parseDigestResultFromTxLog(log)
+	if err == nil {
+		t.Fatalf("expected error for missing auto_digest entry, got nil")
+	}
+}

--- a/extensions/tn_digest/scheduler/constants.go
+++ b/extensions/tn_digest/scheduler/constants.go
@@ -1,0 +1,13 @@
+package scheduler
+
+import "time"
+
+const (
+	// Digest drain mode constants (scheduler-scoped to avoid import cycles)
+	DigestDeleteCap                = 100_000
+	DigestExpectedRecordsPerStream = 24
+	DigestPreservePastDays         = 2
+	DrainRunDelay                  = 60 * time.Second // 1 minute
+	DrainMaxRuns                   = 100
+	DrainMaxConsecutiveFailures    = 5
+)


### PR DESCRIPTION
…dling and logging

This commit introduces several key improvements to the `auto_digest` process, including:

- Enhanced transaction broadcasting with error handling for transaction results.
- Added structured logging for better monitoring of processed days and deleted rows.
- Introduced a new `DigestTxResult` type to encapsulate results from the auto_digest transactions.
- Implemented a new method for parsing digest results from transaction logs, improving clarity and reliability.

These changes aim to optimize the digest operation's performance and provide better insights into its execution outcomes.<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #1109 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
