### PR TITLE
feat: lock and unlock TRUF tokens

### DIFF
--- a/internal/migrations/erc20-bridge/000-extension.sql
+++ b/internal/migrations/erc20-bridge/000-extension.sql
@@ -1,5 +1,5 @@
 -- Only necessary to run on leader and validator nodes.
-USE erc20_bridge {
+USE erc20 {
     chain: 'sepolia',
-    escrow: '0x1c6D0d1666E3Ea3896c0A94018B03Ca117C15762',
+    escrow: '0x1B0A6795D45Bb5137DaFEeAb49e2c4e005d788D7'
 } AS sepolia_bridge;

--- a/internal/migrations/erc20-bridge/000-extension.sql
+++ b/internal/migrations/erc20-bridge/000-extension.sql
@@ -1,5 +1,6 @@
 -- Only necessary to run on leader and validator nodes.
+
 USE erc20 {
     chain: 'sepolia',
-    escrow: '0x1B0A6795D45Bb5137DaFEeAb49e2c4e005d788D7'
+    escrow: '0x2D4f435867066737bA1617ef024E073413909Ad2'
 } AS sepolia_bridge;

--- a/internal/migrations/erc20-bridge/001-actions.sql
+++ b/internal/migrations/erc20-bridge/001-actions.sql
@@ -4,8 +4,24 @@ CREATE OR REPLACE ACTION sepolia_wallet_balance($wallet_address TEXT) PUBLIC VIE
   return $balance;
 };
 
+CREATE OR REPLACE ACTION sepolia_admin_lock_tokens($wallet_address TEXT, $amount NUMERIC(78, 0)) PUBLIC {
+  sepolia_bridge.lock_admin($wallet_address, $amount)
+}
+
+CREATE OR REPLACE ACTION sepolia_admin_unlock_tokens($to_address TEXT, $amount NUMERIC(78, 0)) PUBLIC {
+  sepolia_bridge.unlock($to_address, $amount)
+}
+
 -- MAINNET
 CREATE OR REPLACE ACTION mainnet_wallet_balance($wallet_address TEXT) PUBLIC VIEW RETURNS (balance NUMERIC(78, 0)) {
   $balance := mainnet_bridge.balance($wallet_address);
   return $balance;
 };
+
+CREATE OR REPLACE ACTION mainnet_admin_lock_tokens($wallet_address TEXT, $amount NUMERIC(78, 0)) PUBLIC {
+  mainnet_bridge.lock_admin($wallet_address, $amount)
+}
+
+CREATE OR REPLACE ACTION mainnet_admin_unlock_tokens($to_address TEXT, $amount NUMERIC(78, 0)) PUBLIC {
+  mainnet_bridge.unlock($to_address, $amount)
+}

--- a/internal/migrations/erc20-bridge/001-actions.sql
+++ b/internal/migrations/erc20-bridge/001-actions.sql
@@ -4,13 +4,13 @@ CREATE OR REPLACE ACTION sepolia_wallet_balance($wallet_address TEXT) PUBLIC VIE
   return $balance;
 };
 
-CREATE OR REPLACE ACTION sepolia_admin_lock_tokens($wallet_address TEXT, $amount NUMERIC(78, 0)) PUBLIC {
-  sepolia_bridge.lock_admin($wallet_address, $amount)
-}
+CREATE OR REPLACE ACTION sepolia_admin_lock_tokens($wallet_address TEXT, $amount TEXT) PUBLIC {
+  sepolia_bridge.lock_admin($wallet_address, $amount::NUMERIC(78, 0));
+};
 
-CREATE OR REPLACE ACTION sepolia_admin_unlock_tokens($to_address TEXT, $amount NUMERIC(78, 0)) PUBLIC {
-  sepolia_bridge.unlock($to_address, $amount)
-}
+CREATE OR REPLACE ACTION sepolia_admin_unlock_tokens($to_address TEXT, $amount TEXT) PUBLIC {
+  sepolia_bridge.unlock($to_address, $amount::NUMERIC(78, 0));
+};
 
 -- MAINNET
 CREATE OR REPLACE ACTION mainnet_wallet_balance($wallet_address TEXT) PUBLIC VIEW RETURNS (balance NUMERIC(78, 0)) {
@@ -18,10 +18,10 @@ CREATE OR REPLACE ACTION mainnet_wallet_balance($wallet_address TEXT) PUBLIC VIE
   return $balance;
 };
 
-CREATE OR REPLACE ACTION mainnet_admin_lock_tokens($wallet_address TEXT, $amount NUMERIC(78, 0)) PUBLIC {
-  mainnet_bridge.lock_admin($wallet_address, $amount)
-}
+CREATE OR REPLACE ACTION mainnet_admin_lock_tokens($wallet_address TEXT, $amount TEXT) PUBLIC {
+  mainnet_bridge.lock_admin($wallet_address, $amount::NUMERIC(78, 0));
+};
 
-CREATE OR REPLACE ACTION mainnet_admin_unlock_tokens($to_address TEXT, $amount NUMERIC(78, 0)) PUBLIC {
-  mainnet_bridge.unlock($to_address, $amount)
-}
+CREATE OR REPLACE ACTION mainnet_admin_unlock_tokens($to_address TEXT, $amount TEXT) PUBLIC {
+  mainnet_bridge.unlock($to_address, $amount::NUMERIC(78, 0));
+};


### PR DESCRIPTION
note: I will do the custom test on separate PR after transfer action is available.

## Related Problem
resolves: https://github.com/trufnetwork/truf-network/issues/1153
resolves: https://github.com/trufnetwork/truf-network/issues/1156

## How Has This Been Tested?

#### Initial Balance (in 18 decimals format)
<img width="891" height="67" alt="Screenshot 2025-09-09 at 10 48 24" src="https://github.com/user-attachments/assets/dcd879b4-41dc-46b7-be68-6ca60348b1ba" />

#### Lock Tokens
<img width="1090" height="154" alt="Screenshot 2025-09-09 at 10 57 24" src="https://github.com/user-attachments/assets/dbc888d9-8d9d-4a8e-bed4-7aa297a901f3" />

#### Treasury Balance after lock
<img width="1276" height="69" alt="Screenshot 2025-09-09 at 10 58 02" src="https://github.com/user-attachments/assets/ba9a765d-c82f-4929-9734-c791a81fca8a" />

#### Unlock Tokens
<img width="1099" height="149" alt="Screenshot 2025-09-09 at 10 59 35" src="https://github.com/user-attachments/assets/f1845acc-a6a8-4a25-a3dc-09caba46c9f5" />

#### Treasury Balance after unlock
<img width="1188" height="72" alt="Screenshot 2025-09-09 at 11 00 02" src="https://github.com/user-attachments/assets/f664efb9-3f5d-491c-8a36-735089c9567d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added admin actions to lock and unlock tokens on Sepolia and Mainnet, enabling controlled token movements by admins.
- Bug Fixes
  - Fixed a syntax issue in a wallet balance action to ensure proper execution.
- Chores
  - Updated Sepolia bridge configuration, including module reference and escrow address, to align with current network settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->