### PR TITLE
chore(erc20-bridge): protect admin actions

### DIFF
--- a/internal/migrations/erc20-bridge/001-actions.sql
+++ b/internal/migrations/erc20-bridge/001-actions.sql
@@ -5,11 +5,57 @@ CREATE OR REPLACE ACTION sepolia_wallet_balance($wallet_address TEXT) PUBLIC VIE
 };
 
 CREATE OR REPLACE ACTION sepolia_admin_lock_tokens($wallet_address TEXT, $amount TEXT) PUBLIC {
+  $lower_caller TEXT := LOWER(@caller);
+
+  -- Permission Check: Ensure caller has the 'system:erc20_bridge_writer' role.
+  $has_permission BOOL := false;
+  for $row in are_members_of('system', 'erc20_bridge_writer', ARRAY[$lower_caller]) {
+      if $row.wallet = $lower_caller AND $row.is_member {
+          $has_permission := true;
+          break;
+      }
+  }
+  if NOT $has_permission {
+      ERROR('Caller does not have the required system:erc20_bridge_writer role to lock tokens.');
+  }
+
   sepolia_bridge.lock_admin($wallet_address, $amount::NUMERIC(78, 0));
 };
 
 CREATE OR REPLACE ACTION sepolia_admin_unlock_tokens($to_address TEXT, $amount TEXT) PUBLIC {
+  $lower_caller TEXT := LOWER(@caller);
+
+  -- Permission Check: Ensure caller has the 'system:erc20_bridge_writer' role.
+  $has_permission BOOL := false;
+  for $row in are_members_of('system', 'erc20_bridge_writer', ARRAY[$lower_caller]) {
+      if $row.wallet = $lower_caller AND $row.is_member {
+          $has_permission := true;
+          break;
+      }
+  }
+  if NOT $has_permission {
+      ERROR('Caller does not have the required system:erc20_bridge_writer role to unlock tokens.');
+  }
+
   sepolia_bridge.unlock($to_address, $amount::NUMERIC(78, 0));
+};
+
+CREATE OR REPLACE ACTION sepolia_admin_issue_tokens($to_address TEXT, $amount TEXT) PUBLIC {
+  $lower_caller TEXT := LOWER(@caller);
+
+  -- Permission Check: Ensure caller has the 'system:erc20_bridge_writer' role.
+  $has_permission BOOL := false;
+  for $row in are_members_of('system', 'erc20_bridge_writer', ARRAY[$lower_caller]) {
+      if $row.wallet = $lower_caller AND $row.is_member {
+          $has_permission := true;
+          break;
+      }
+  }
+  if NOT $has_permission {
+      ERROR('Caller does not have the required system:erc20_bridge_writer role to issue tokens.');
+  }
+
+  sepolia_bridge.issue($to_address, $amount::NUMERIC(78, 0));
 };
 
 -- MAINNET
@@ -19,9 +65,55 @@ CREATE OR REPLACE ACTION mainnet_wallet_balance($wallet_address TEXT) PUBLIC VIE
 };
 
 CREATE OR REPLACE ACTION mainnet_admin_lock_tokens($wallet_address TEXT, $amount TEXT) PUBLIC {
+  $lower_caller TEXT := LOWER(@caller);
+
+  -- Permission Check: Ensure caller has the 'system:erc20_bridge_writer' role.
+  $has_permission BOOL := false;
+  for $row in are_members_of('system', 'erc20_bridge_writer', ARRAY[$lower_caller]) {
+      if $row.wallet = $lower_caller AND $row.is_member {
+          $has_permission := true;
+          break;
+      }
+  }
+  if NOT $has_permission {
+      ERROR('Caller does not have the required system:erc20_bridge_writer role to lock tokens.');
+  }
+
   mainnet_bridge.lock_admin($wallet_address, $amount::NUMERIC(78, 0));
 };
 
 CREATE OR REPLACE ACTION mainnet_admin_unlock_tokens($to_address TEXT, $amount TEXT) PUBLIC {
+  $lower_caller TEXT := LOWER(@caller);
+
+  -- Permission Check: Ensure caller has the 'system:erc20_bridge_writer' role.
+  $has_permission BOOL := false;
+  for $row in are_members_of('system', 'erc20_bridge_writer', ARRAY[$lower_caller]) {
+      if $row.wallet = $lower_caller AND $row.is_member {
+          $has_permission := true;
+          break;
+      }
+  }
+  if NOT $has_permission {
+      ERROR('Caller does not have the required system:erc20_bridge_writer role to unlock tokens.');
+  }
+
   mainnet_bridge.unlock($to_address, $amount::NUMERIC(78, 0));
+};
+
+CREATE OR REPLACE ACTION mainnet_admin_issue_tokens($to_address TEXT, $amount TEXT) PUBLIC {
+  $lower_caller TEXT := LOWER(@caller);
+
+  -- Permission Check: Ensure caller has the 'system:erc20_bridge_writer' role.
+  $has_permission BOOL := false;
+  for $row in are_members_of('system', 'erc20_bridge_writer', ARRAY[$lower_caller]) {
+      if $row.wallet = $lower_caller AND $row.is_member {
+          $has_permission := true;
+          break;
+      }
+  }
+  if NOT $has_permission {
+      ERROR('Caller does not have the required system:erc20_bridge_writer role to issue tokens.');
+  }
+
+  mainnet_bridge.issue($to_address, $amount::NUMERIC(78, 0));
 };


### PR DESCRIPTION
## Related Problem
resolves: https://github.com/trufnetwork/truf-network/issues/1186

## How Has This Been Tested?

### without the role
<img width="1080" height="114" alt="Screenshot 2025-09-11 at 01 28 50" src="https://github.com/user-attachments/assets/af810144-38ab-4f66-b79a-83dad332e6f4" />

### Using `erc20_bridge_writer` role wallet
<img width="1083" height="119" alt="Screenshot 2025-09-11 at 01 29 07" src="https://github.com/user-attachments/assets/392b8b2d-cd38-4445-8200-6e81834dfe78" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced role-based access control for admin token operations (lock, unlock, issue) on both mainnet and testnet. Only users with the designated writer role can execute these actions; others receive a clear permission error.
  * Read-only wallet balance lookups remain unchanged, ensuring no impact to users checking balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->