### PR TITLE
chore(erc20-bridge): protect wallet balance read

### DIFF
--- a/internal/migrations/erc20-bridge/001-actions.sql
+++ b/internal/migrations/erc20-bridge/001-actions.sql
@@ -9,6 +9,20 @@
 
 -- TESTNET
 CREATE OR REPLACE ACTION sepolia_wallet_balance($wallet_address TEXT) PUBLIC VIEW RETURNS (balance NUMERIC(78, 0)) {
+  $lower_caller TEXT := LOWER(@caller);
+
+  -- Permission Check: Ensure caller has the 'system:erc20_bridge_writer' role.
+  $has_permission BOOL := false;
+  for $row in are_members_of('system', 'erc20_bridge_writer', ARRAY[$lower_caller]) {
+      if $row.wallet = $lower_caller AND $row.is_member {
+          $has_permission := true;
+          break;
+      }
+  }
+  if NOT $has_permission {
+      ERROR('Caller does not have the required system:erc20_bridge_writer role to read balance.');
+  }
+  
   $balance := sepolia_bridge.balance($wallet_address);
   return $balance;
 };
@@ -69,6 +83,20 @@ CREATE OR REPLACE ACTION sepolia_admin_issue_tokens($to_address TEXT, $amount TE
 
 -- MAINNET
 CREATE OR REPLACE ACTION mainnet_wallet_balance($wallet_address TEXT) PUBLIC VIEW RETURNS (balance NUMERIC(78, 0)) {
+  $lower_caller TEXT := LOWER(@caller);
+
+  -- Permission Check: Ensure caller has the 'system:erc20_bridge_writer' role.
+  $has_permission BOOL := false;
+  for $row in are_members_of('system', 'erc20_bridge_writer', ARRAY[$lower_caller]) {
+      if $row.wallet = $lower_caller AND $row.is_member {
+          $has_permission := true;
+          break;
+      }
+  }
+  if NOT $has_permission {
+      ERROR('Caller does not have the required system:erc20_bridge_writer role to read balance.');
+  }
+
   $balance := mainnet_bridge.balance($wallet_address);
   return $balance;
 };


### PR DESCRIPTION
## Related Problem
resolves: https://github.com/trufnetwork/truf-network/issues/1186

## How Has This Been Tested?

<img width="894" height="201" alt="Screenshot 2025-09-11 at 16 25 05" src="https://github.com/user-attachments/assets/90b1665d-eb68-4502-a873-0408419e3d61" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime permission checks for ERC20 bridge actions across supported networks.
  * Wallet balance reads and admin token operations now require appropriate access; unauthorized requests are blocked.
  * Improved, user-friendly error messages when permissions are insufficient.
  * No behavioral changes for authorized users; existing functionality continues as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->