### PR TITLE
feat: apply fee when withdrawing TRUF tokens

### DIFF
--- a/internal/migrations/erc20-bridge/001-actions.sql
+++ b/internal/migrations/erc20-bridge/001-actions.sql
@@ -1,7 +1,24 @@
+CREATE OR REPLACE ACTION get_erc20_bridge_info() 
+PUBLIC VIEW RETURNS (
+  chain TEXT,
+  escrow TEXT,
+  epoch_period TEXT,
+  erc20 TEXT,
+  decimals INT,
+  balance NUMERIC(78, 0),
+  synced BOOLEAN,
+  synced_at INT8,
+  enabled BOOLEAN
+) {
+  FOR $row IN sepolia_bridge.info() {
+    RETURN $row.chain, $row.escrow, $row.epoch_period, $row.erc20, $row.decimals, $row.balance, $row.synced, $row.synced_at, $row.enabled;
+  }
+};
+
 -- TESTNET
 CREATE OR REPLACE ACTION sepolia_wallet_balance($wallet_address TEXT) PUBLIC VIEW RETURNS (balance NUMERIC(78, 0)) {
   $balance := sepolia_bridge.balance($wallet_address);
-  return $balance;
+  RETURN $balance;
 };
 
 CREATE OR REPLACE ACTION sepolia_admin_bridge_tokens($amount TEXT) PUBLIC {
@@ -17,7 +34,7 @@ CREATE OR REPLACE ACTION sepolia_admin_bridge_tokens($amount TEXT) PUBLIC {
 -- MAINNET
 CREATE OR REPLACE ACTION mainnet_wallet_balance($wallet_address TEXT) PUBLIC VIEW RETURNS (balance NUMERIC(78, 0)) {
   $balance := mainnet_bridge.balance($wallet_address);
-  return $balance;
+  RETURN $balance;
 };
 
 CREATE OR REPLACE ACTION mainnet_admin_bridge_tokens($amount TEXT) PUBLIC {


### PR DESCRIPTION
## Related Problem
resolves: https://github.com/trufnetwork/truf-network/issues/1173

- wallet balance can be checked by anyone
- bridge have 1% fee

## How Has This Been Tested?

---

### Initial Balance on Layer-1
<img width="387" height="568" alt="Screenshot 2025-09-15 at 11 07 56" src="https://github.com/user-attachments/assets/53edafa2-dfff-4718-ab04-258542c0378e" />

---

### Bridge 2 tokens, (fee 1%)
<img width="918" height="217" alt="Screenshot 2025-09-15 at 11 17 20" src="https://github.com/user-attachments/assets/4b05ba01-69e4-4cc8-a07f-a44d258b0e5b" />

---

### Claim tokens on Layer-1 (deducted by fee already)
<img width="1376" height="198" alt="Screenshot 2025-09-15 at 11 12 54" src="https://github.com/user-attachments/assets/4df54ad3-ce23-41c9-98b0-7f0a291bbccf" />
<img width="393" height="555" alt="Screenshot 2025-09-15 at 11 14 53" src="https://github.com/user-attachments/assets/84510940-1602-41f1-ac08-7580dd9013d6" />

---
### Fee is still in our treasury

<img width="1260" height="69" alt="Screenshot 2025-09-15 at 11 19 51" src="https://github.com/user-attachments/assets/4b4a3f92-851e-4a34-bd2f-5113c118022c" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a public bridge info endpoint showing network, escrow, epoch period, token details, balance, sync status, and enablement.
- Refactor
  - Simplified per-network admin bridging with an automatic 1% treasury fee; the remaining 99% is bridged to users.
  - Wallet balances are now readable without special roles.
  - Deprecated separate admin lock/unlock/issue token actions across networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->