### PR TITLE
fix: unlock fee to treasury

### DIFF
--- a/internal/migrations/erc20-bridge/001-actions.sql
+++ b/internal/migrations/erc20-bridge/001-actions.sql
@@ -23,12 +23,15 @@ CREATE OR REPLACE ACTION sepolia_wallet_balance($wallet_address TEXT) PUBLIC VIE
 
 CREATE OR REPLACE ACTION sepolia_admin_bridge_tokens($amount TEXT) PUBLIC {
   -- Calculate 1% fee and lock it in our treasury
-  $numAmount := $amount::NUMERIC(78, 0);
-  $fee := $numAmount * 0.01;
+  $num_amount := $amount::NUMERIC(78, 0);
+  $fee := $num_amount * 0.01;
   sepolia_bridge.lock($fee);
 
+  $treasury_address := '0xDe5B2aBce299eBdC3567895B1B4b02Ca2c33C94A';
+  sepolia_bridge.unlock($treasury_address, $fee);
+
   -- Bridge the rest to users
-  sepolia_bridge.bridge($numAmount - $fee);
+  sepolia_bridge.bridge($num_amount - $fee);
 };
 
 -- MAINNET
@@ -42,6 +45,10 @@ CREATE OR REPLACE ACTION mainnet_admin_bridge_tokens($amount TEXT) PUBLIC {
   $numAmount := $amount::NUMERIC(78, 0);
   $fee := $numAmount * 0.01;
   mainnet_bridge.lock($fee);
+
+  -- TODO: update when we have treasury address on mainnet
+  -- $treasury_address := ''
+  -- sepolia_bridge.unlock($treasury_address, $fee);
 
   -- Bridge the rest to users
   mainnet_bridge.bridge($numAmount - $fee);


### PR DESCRIPTION
## Related Problem
related: https://github.com/trufnetwork/truf-network/issues/1173

## How Has This Been Tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sepolia: Bridge fee is now automatically routed to the treasury address during admin token transfers. User-received amounts remain unchanged.

- Chores
  - Mainnet: Added placeholders for future treasury fee routing (no functional impact yet).

- Documentation
  - Clarified internal notes around fee handling to prepare for consistent behavior across networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->