### PR TITLE
chore: rename erc20 action names

### DIFF
--- a/internal/migrations/erc20-bridge/001-actions.sql
+++ b/internal/migrations/erc20-bridge/001-actions.sql
@@ -21,35 +21,16 @@ CREATE OR REPLACE ACTION sepolia_wallet_balance($wallet_address TEXT) PUBLIC VIE
   RETURN $balance;
 };
 
-CREATE OR REPLACE ACTION sepolia_admin_bridge_tokens($amount TEXT) PUBLIC {
-  -- Calculate 1% fee and lock it in our treasury
-  $num_amount := $amount::NUMERIC(78, 0);
-  $fee := $num_amount * 0.01;
-  sepolia_bridge.lock($fee);
-
-  $treasury_address := '0xDe5B2aBce299eBdC3567895B1B4b02Ca2c33C94A';
-  sepolia_bridge.unlock($treasury_address, $fee);
-
-  -- Bridge the rest to users
-  sepolia_bridge.bridge($num_amount - $fee);
+CREATE OR REPLACE ACTION sepolia_bridge_tokens($amount TEXT) PUBLIC {
+  sepolia_bridge.bridge($amount::NUMERIC(78, 0));
 };
 
 -- MAINNET
-CREATE OR REPLACE ACTION mainnet_wallet_balance($wallet_address TEXT) PUBLIC VIEW RETURNS (balance NUMERIC(78, 0)) {
+CREATE OR REPLACE ACTION ethereum_wallet_balance($wallet_address TEXT) PUBLIC VIEW RETURNS (balance NUMERIC(78, 0)) {
   $balance := mainnet_bridge.balance($wallet_address);
   RETURN $balance;
 };
 
-CREATE OR REPLACE ACTION mainnet_admin_bridge_tokens($amount TEXT) PUBLIC {
-  -- Calculate 1% fee and lock it in our treasury
-  $numAmount := $amount::NUMERIC(78, 0);
-  $fee := $numAmount * 0.01;
-  mainnet_bridge.lock($fee);
-
-  -- TODO: update when we have treasury address on mainnet
-  -- $treasury_address := ''
-  -- sepolia_bridge.unlock($treasury_address, $fee);
-
-  -- Bridge the rest to users
-  mainnet_bridge.bridge($numAmount - $fee);
+CREATE OR REPLACE ACTION ethereum_bridge_tokens($amount TEXT) PUBLIC {
+  mainnet_bridge.bridge($amount::NUMERIC(78, 0));
 };


### PR DESCRIPTION
## Related Problem
resolves: https://github.com/trufnetwork/truf-network/issues/1203

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced simplified token bridging on Ethereum and Sepolia that transfers the full specified amount without fees.

* **Refactor**
  * Renamed “Mainnet” terminology to “Ethereum” across wallet balance and bridging actions for clarity and consistency.
  * Consolidated/updated bridging entry points to use consistent Ethereum/Sepolia naming.

* **Chores**
  * Streamlined bridge logic by removing fee/treasury handling to reduce friction and improve predictability for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->