### PR TITLE
chore: add GitHub Actions workflow for publishing Node image

### DIFF
--- a/.github/workflows/publish-node-image.yaml
+++ b/.github/workflows/publish-node-image.yaml
@@ -49,13 +49,13 @@ jobs:
             type=ref,event=tag
             type=semver,pattern={{version}}
 
-      - name: Build and push image
+      - name: Build and push image (multi-arch)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: deployments/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/publish-node-image.yaml
+++ b/.github/workflows/publish-node-image.yaml
@@ -1,0 +1,59 @@
+name: Publish Node Image
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/tn-db
+
+jobs:
+  build-and-push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deployments/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Summary
+        run: |
+          echo "Image pushed: ${{ env.IMAGE_NAME }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "Tags:\n${{ steps.meta.outputs.tags }}"

--- a/.github/workflows/publish-node-image.yaml
+++ b/.github/workflows/publish-node-image.yaml
@@ -2,6 +2,11 @@ name: Publish Node Image
 
 on:
   workflow_dispatch:
+    inputs:
+      tag_latest:
+        description: "Also tag this build as latest"
+        type: boolean
+        default: false
   release:
     types:
       - published
@@ -17,6 +22,8 @@ jobs:
   build-and-push:
     name: Build and Push
     runs-on: ubuntu-latest
+    env:
+      TAG_LATEST: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.tag_latest == 'true') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,7 +44,7 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ env.TAG_LATEST }}
             type=sha
             type=ref,event=tag
             type=semver,pattern={{version}}

--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -22,9 +22,10 @@ FROM busybox:1.35.0-uclibc as busybox
 
 FROM alpine:latest
 
-ARG CHAIN_ID=truflation-dev
-
+ENV SETUP_CHAIN_ID=truflation-dev
+ENV SETUP_DB_OWNER=
 # DB_OWNER will be provided as an environment variable at runtime
+ENV CONFIG_PATH=/root/.kwild
 
 WORKDIR /app
 
@@ -41,13 +42,13 @@ RUN chmod +x /app/entrypoint.sh
 
 # create the configuration script; note that we are NOT running it here
 RUN echo "#!/bin/sh" > /app/config.sh && \
-    echo "set -e" >> /app/config.sh && \
-    echo "if [ ! -f /root/.kwild/config.toml ]; then" >> /app/config.sh && \
+    echo "set -xe" >> /app/config.sh && \
+    echo "if [ ! -f $CONFIG_PATH/config.toml ]; then" >> /app/config.sh && \
     echo "    echo 'Configuration does not exist';" >> /app/config.sh && \
     echo "    echo 'Creating configuration';" >> /app/config.sh && \
-    echo "    ./kwild setup init --chain-id $CHAIN_ID --db-owner \$DB_OWNER -r /root/.kwil-new;" >> /app/config.sh && \
-    echo "    mkdir -p /root/.kwild;" >> /app/config.sh && \
-    echo "    cp /root/.kwil-new/* /root/.kwild;" >> /app/config.sh && \
+    echo "    ./kwild setup init --chain-id \"\$SETUP_CHAIN_ID\" --db-owner \"\$SETUP_DB_OWNER\" -r '/root/.kwil-new';" >> /app/config.sh && \
+    echo "    mkdir -p $CONFIG_PATH;" >> /app/config.sh && \
+    echo "    cp /root/.kwil-new/* $CONFIG_PATH;" >> /app/config.sh && \
     echo "    rm -rf /root/.kwil-new;" >> /app/config.sh && \
     echo "    echo 'Configuration created';" >> /app/config.sh && \
     echo "else" >> /app/config.sh && \

--- a/deployments/tn-entrypoint.sh
+++ b/deployments/tn-entrypoint.sh
@@ -14,6 +14,4 @@ else
     echo "Config path set to $CONFIG_PATH"
 fi
 
-exec /app/kwild start --root $CONFIG_PATH \
-       --db.read-timeout "60s"\
-       --snapshots.enable
+exec /app/kwild start --root $CONFIG_PATH


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

This commit introduces a new workflow in `.github/workflows/publish-node-image.yaml` to automate the building and pushing of a Docker image to the GitHub Container Registry upon release events. Additionally, it updates the `Dockerfile` to use environment variables for configuration and refines the entrypoint script to improve clarity and maintainability.



## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #1164 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Official container image published to GHCR with semver, ref, and digest tags; optional latest tag. Multi-arch builds for linux/amd64 and linux/arm64.

- Changes
  - Configuration keys updated (SETUP_CHAIN_ID, new SETUP_DB_OWNER) and CONFIG_PATH defaulted to /root/.kwild.
  - Startup now uses defaults for DB read timeout and snapshot settings (previous explicit flags removed).

- Chores
  - Automated workflow added to build and publish the container image with metadata-driven tagging and release-triggered builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->