### PR TITLE
fix: add missing primary key to primitive_events table

### DIFF
--- a/internal/migrations/023-primitive-events-primary-key.sql
+++ b/internal/migrations/023-primitive-events-primary-key.sql
@@ -1,0 +1,21 @@
+/*
+ * PRIMITIVE EVENTS PRIMARY KEY MIGRATION
+ *
+ * Establishes the primary key constraint for the primitive_events table
+ * following the schema normalization completed in migration 017.
+ *
+ * The primary key ensures data integrity and enables efficient operations
+ * on time-series event data by providing:
+ * - Unique row identification for logical replication
+ * - Optimal indexing for time-based queries
+ * - Proper constraint enforcement for data consistency
+ *
+ * This migration adds the composite primary key (stream_ref, event_time, created_at)
+ * which provides both uniqueness constraints and automatic indexing.
+ */
+
+-- Add composite primary key for normalized schema
+-- Ensures unique identification of time-series data points
+-- Primary key automatically creates a unique index for optimal performance
+ALTER TABLE primitive_events ADD CONSTRAINT primitive_events_pkey
+    PRIMARY KEY (stream_ref, event_time, created_at);


### PR DESCRIPTION
Migration 017 dropped the original primary key constraint but never added a replacement, leaving primitive_events table without proper constraints.

- Add composite primary key: (stream_ref, event_time, created_at)
- Single ALTER TABLE statement in new migration 023
- Fixes logical replication replica identity issues

- `internal/migrations/023-primitive-events-primary-key.sql` (new migration)

resolves: https://github.com/trufnetwork/truf-network/issues/1233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated database schema to enforce uniqueness of event records, reducing duplicate entries in timelines and ensuring consistent event history across views.
  - Improves responsiveness for pages and reports that display time-based event data.
  - Enhances reliability of event data across environments, minimizing inconsistencies users may encounter during data synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->