### PR TITLE
feat: create node with identity from provided key

### DIFF
--- a/deployments/infra/stacks/docker-compose.template.yml
+++ b/deployments/infra/stacks/docker-compose.template.yml
@@ -22,6 +22,8 @@ services:
     image: ghcr.io/trufnetwork/node:latest
     container_name: tn-node
     entrypoint: ""
+    env_file:
+      - .env
     volumes:
       - ./tn-data:/root/.kwild
       - /opt/tn/configs:/opt/tn/configs:ro
@@ -40,7 +42,7 @@ services:
       sh -c "
         # Only generate NEW config if persistent storage is empty
         if [ ! -f /root/.kwild/config.toml ]; then
-          echo 'No existing configuration found. Generating new node identity...'
+          echo 'No existing configuration found. Generating new node configuration...'
 
           # Resolve external address (prefer env override; fallback if tools exist)
           PUBLIC_IP=\"$${TN_EXTERNAL_ADDRESS:-}\"
@@ -54,26 +56,28 @@ services:
           [ -n \"$$PUBLIC_IP\" ] && EXTERNAL_FLAG=\"--p2p.external-address $$PUBLIC_IP:26656\" || EXTERNAL_FLAG=\"\"
           echo \"Detected public IP: $$PUBLIC_IP\"
 
+          # Generate full configuration with kwild setup init
           /app/kwild setup init --genesis /opt/tn/configs/network/v2/genesis.json --root /root/.kwild-new --p2p.bootnodes \"4e0b5c952be7f26698dc1898ff3696ac30e990f25891aeaf88b0285eab4663e1#ed25519@node-1.mainnet.truf.network:26656,0c830b69790eaa09315826403c2008edc65b5c7132be9d4b7b4da825c2a166ae#ed25519@node-2.mainnet.truf.network:26656\" --state-sync.enable --state-sync.trusted-providers \"4e0b5c952be7f26698dc1898ff3696ac30e990f25891aeaf88b0285eab4663e1#ed25519@node-1.mainnet.truf.network:26656\" --rpc.private --db.host tn-postgres $$EXTERNAL_FLAG
           mkdir -p /root/.kwild
           cp /root/.kwild-new/* /root/.kwild/
           rm -rf /root/.kwild-new
-          echo 'New node identity created and saved!'
-        else
-          echo 'Using existing node identity from persistent storage.'
-        fi
 
-        # Convert private key to nodekey.json if TN_PRIVATE_KEY is provided
-        if [ -n \"$${TN_PRIVATE_KEY:-}\" ]; then
-          echo 'Converting private key to nodekey.json format...'
-          CLEAN_KEY=\"$${TN_PRIVATE_KEY#0x}\"
-          if ! echo \"$$CLEAN_KEY\" | grep -qE '^[a-fA-F0-9]{64}$$'; then
-            echo 'Error: Private key must be 64 hex characters (32 bytes)'
-            exit 1
+          # Now override nodekey if TN_PRIVATE_KEY is provided
+          if [ -n \"$${TN_PRIVATE_KEY:-}\" ]; then
+            echo 'Overriding generated nodekey with provided private key...'
+            CLEAN_KEY=\"$${TN_PRIVATE_KEY#0x}\"
+            if ! echo \"$$CLEAN_KEY\" | grep -qE '^[a-fA-F0-9]{64}$$'; then
+              echo 'Error: Private key must be 64 hex characters (32 bytes)'
+              exit 1
+            fi
+            echo '{\"key\":\"'$$CLEAN_KEY'\",\"type\":\"secp256k1\"}' > /root/.kwild/nodekey.json
+            chmod 600 /root/.kwild/nodekey.json || true
+            echo 'Node identity set from provided private key'
+          else
+            echo 'Using generated node identity'
           fi
-          echo '{\"key\":\"'$$CLEAN_KEY'\",\"type\":\"secp256k1\"}' > /root/.kwild/nodekey.json
-          chmod 600 /root/.kwild/nodekey.json || true
-          echo 'Nodekey created successfully'
+        else
+          echo 'Using existing node configuration from persistent storage.'
         fi
 
         echo 'Starting TRUF.NETWORK node...'


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/truf-network/issues/1244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support supplying a private key via TN_PRIVATE_KEY to set node identity deterministically.
  * Added .env file support in Docker Compose for easier environment configuration.
  * Clearer startup logs indicating whether configuration is generated, provided, or loaded from persistent storage.

* **Chores**
  * Updated container startup flow to handle private key validation and secure storage.
  * Standardized messaging around configuration initialization and reuse during node startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->