### PR TITLE
feat: enable AWS Marketplace distribution support

### DIFF
--- a/.github/workflows/ami-build.yml
+++ b/.github/workflows/ami-build.yml
@@ -184,22 +184,22 @@ jobs:
               --output table
           fi
 
-      - name: Make AMI public (prod only)
+      - name: Tag AMI for Marketplace (prod only)
         if: env.AMI_ID && env.STAGE == 'prod'
         run: |
-          echo "🌍 Making AMI public for production release..."
-          aws ec2 modify-image-attribute \
-            --image-id "$AMI_ID" \
-            --launch-permission "Add=[{Group=all}]" \
+          echo "🏷️ Tagging AMI for AWS Marketplace distribution..."
+          aws ec2 create-tags \
+            --resources "$AMI_ID" \
+            --tags \
+              Key=marketplace,Value=ready \
+              Key=version,Value=${{ github.ref_name || 'latest' }} \
+              Key=stage,Value=${{ env.STAGE }} \
             --region "${{ env.AWS_REGION }}"
 
-          echo "✅ AMI is now publicly available in Community AMIs"
-
-          # Verify public status
-          aws ec2 describe-image-attribute \
-            --image-id "$AMI_ID" \
-            --attribute launchPermission \
-            --region "${{ env.AWS_REGION }}"
+          echo "✅ AMI is ready for Marketplace submission"
+          echo "📝 AMI is private and unencrypted (Marketplace requirement)"
+          echo "🔗 Next: Submit to AWS Marketplace Seller Console"
+          echo "    https://aws.amazon.com/marketplace/management/products"
 
       - name: Update GitHub release with AMI details
         if: github.event_name == 'release' && env.AMI_ID
@@ -218,7 +218,7 @@ jobs:
             **Stage:** \`${stage}\`
             **AMI ID:** \`${amiId}\`
             **Region:** \`${region}\`
-            **Availability:** ${stage === 'prod' ? '🌍 Public (Community AMIs)' : '🔒 Private'}
+            **Availability:** ${stage === 'prod' ? '🏪 Ready for AWS Marketplace' : '🔒 Private (Dev)'}
             **Launch URL:** \\
             https://console.aws.amazon.com/ec2/home?region=${region}#LaunchInstances:ami=${amiId}
 

--- a/deployments/infra/stacks/docker-compose.template.yml
+++ b/deployments/infra/stacks/docker-compose.template.yml
@@ -56,8 +56,19 @@ services:
           [ -n \"$$PUBLIC_IP\" ] && EXTERNAL_FLAG=\"--p2p.external-address $$PUBLIC_IP:26656\" || EXTERNAL_FLAG=\"\"
           echo \"Detected public IP: $$PUBLIC_IP\"
 
-          # Generate full configuration with kwild setup init
-          /app/kwild setup init --genesis /opt/tn/configs/network/v2/genesis.json --root /root/.kwild-new --p2p.bootnodes \"4e0b5c952be7f26698dc1898ff3696ac30e990f25891aeaf88b0285eab4663e1#ed25519@node-1.mainnet.truf.network:26656,0c830b69790eaa09315826403c2008edc65b5c7132be9d4b7b4da825c2a166ae#ed25519@node-2.mainnet.truf.network:26656\" --state-sync.enable --state-sync.trusted-providers \"4e0b5c952be7f26698dc1898ff3696ac30e990f25891aeaf88b0285eab4663e1#ed25519@node-1.mainnet.truf.network:26656\" --rpc.private --db.host tn-postgres $$EXTERNAL_FLAG
+          # Determine network type and generate appropriate configuration
+          NETWORK_TYPE=\"$${NETWORK_TYPE:-mainnet}\"
+
+          if [ \"$$NETWORK_TYPE\" = \"custom\" ]; then
+            echo 'Creating new custom network with chain ID: '\"$$CHAIN_ID\"
+            # Create new network without genesis file
+            /app/kwild setup init --root /root/.kwild-new --chain-id \"$$CHAIN_ID\" --rpc.private --db.host tn-postgres $$EXTERNAL_FLAG
+          else
+            echo 'Joining existing mainnet (tn-v2.1)...'
+            # Join existing network using genesis file
+            /app/kwild setup init --genesis /opt/tn/configs/network/v2/genesis.json --root /root/.kwild-new --p2p.bootnodes \"4e0b5c952be7f26698dc1898ff3696ac30e990f25891aeaf88b0285eab4663e1#ed25519@node-1.mainnet.truf.network:26656,0c830b69790eaa09315826403c2008edc65b5c7132be9d4b7b4da825c2a166ae#ed25519@node-2.mainnet.truf.network:26656\" --state-sync.enable --state-sync.trusted-providers \"4e0b5c952be7f26698dc1898ff3696ac30e990f25891aeaf88b0285eab4663e1#ed25519@node-1.mainnet.truf.network:26656\" --rpc.private --db.host tn-postgres $$EXTERNAL_FLAG
+          fi
+
           mkdir -p /root/.kwild
           cp /root/.kwild-new/* /root/.kwild/
           rm -rf /root/.kwild-new

--- a/scripts/test-ami.sh
+++ b/scripts/test-ami.sh
@@ -107,6 +107,12 @@ echo "Using shared Docker Compose configuration..."
 # Use shared Docker Compose configuration (single source of truth)
 cp deployments/infra/stacks/docker-compose.template.yml /tmp/test-docker-compose.yml
 
+# Create dummy .env file for validation (docker-compose expects it)
+cat > /tmp/.env << 'EOF'
+CHAIN_ID=tn-v2.1
+NETWORK_TYPE=mainnet
+EOF
+
 if eval "$COMPOSE -f /tmp/test-docker-compose.yml config" > /dev/null 2>&1; then
     echo -e "${GREEN}✅ Docker Compose configuration valid${NC}"
     TESTS_PASSED=$((TESTS_PASSED + 1))
@@ -114,7 +120,7 @@ else
     echo -e "${RED}❌ Docker Compose configuration invalid${NC}"
     TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
-rm -f /tmp/test-docker-compose.yml
+rm -f /tmp/test-docker-compose.yml /tmp/.env
 
 # Test 4: Shell Script Syntax
 echo "4. Testing shell script syntax..."
@@ -396,6 +402,12 @@ echo "Starting PostgreSQL container to test database connectivity..."
 # Use shared Docker Compose configuration for PostgreSQL test
 cp deployments/infra/stacks/docker-compose.template.yml /tmp/tn-test-compose.yml
 
+# Create .env file in same directory (docker-compose expects .env relative to compose file)
+cat > /tmp/.env << 'EOF'
+CHAIN_ID=tn-v2.1
+NETWORK_TYPE=mainnet
+EOF
+
 echo "Starting PostgreSQL container..."
 if eval "$COMPOSE -f /tmp/tn-test-compose.yml up -d tn-postgres"; then
     echo "Waiting for PostgreSQL to be ready..."
@@ -428,8 +440,8 @@ else
 fi
 
 echo "Cleaning up test containers..."
-eval "$COMPOSE -f /tmp/tn-test-compose.yml down -v"
-rm -f /tmp/tn-test-compose.yml
+eval "$COMPOSE -f /tmp/tn-test-compose.yml down -v" 2>/dev/null || true
+rm -f /tmp/tn-test-compose.yml /tmp/.env
 
 # Test 10: Update Script Workflow
 echo "10. Testing update script workflow..."


### PR DESCRIPTION
Configure AMI build pipeline to comply with AWS Marketplace requirements, enabling commercial distribution through AWS Marketplace seller program.

Changes:
- Disable EBS encryption (AWS Marketplace prohibits encrypted AMIs)
- Replace public AMI sharing with Marketplace tagging workflow
- Update release notifications to indicate "Ready for AWS Marketplace"
- Split oversized TNConfigComponent to meet 16KB ImageBuilder limit
- Add --network flag for developer custom network initialization

resolves: https://github.com/trufnetwork/truf-network/issues/1249
resolves: https://github.com/trufnetwork/truf-network/issues/1247

The dev AMI is already available too