### PR TITLE
chore: release ami build during version release

### DIFF
--- a/.github/workflows/ami-build.yml
+++ b/.github/workflows/ami-build.yml
@@ -84,6 +84,7 @@ jobs:
           echo "Deploying AMI pipeline infrastructure for stage: ${{ env.STAGE }}..."
           cdk bootstrap --require-approval never
           cdk deploy AMI-Pipeline-${{ env.STAGE }}-Stack \
+            --app "go run ami-cdk.go" \
             --context stage=${{ env.STAGE }} \
             --require-approval never
 


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/truf-network/issues/1249

The CI fails, let me try

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined AMI deployment step in the build pipeline to improve reliability and consistency.
  - Adjusted deployment invocation within CI without changing environments, conditions, or release timelines.
  - No user-facing changes; functionality and availability remain the same, with reduced risk of deployment errors and smoother future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->