### PR TITLE
fix: digest and prune stops permanently on database timeouts

### DIFF
--- a/extensions/tn_digest/README.md
+++ b/extensions/tn_digest/README.md
@@ -41,13 +41,17 @@ UPDATE main.digest_config SET enabled = true, digest_schedule = '*/10 * * * *' W
 - The extension checks the config again every N blocks (default 1000, configurable below).
 
 ### Configuration (TOML)
-- Reload interval (best effort parse of integer blocks):
+- Reload interval and retry settings:
 ```toml
 [extensions.tn_digest]
-reload_interval_blocks = "1000"   # default 1000; set to small values for faster reconciling
+reload_interval_blocks = "1000"          # default 1000; how often to check digest_config for changes
+reload_retry_backoff_seconds = "60"     # default 60; wait time between config reload retries
+reload_max_retries = "15"               # default 15; max attempts to reload config before giving up
 # optional explicit RPC URL (overrides [rpc].listen normalization)
 # rpc_url = "https://127.0.0.1:8484"
 ```
+
+**Config reload resilience**: If reading `digest_config` fails (e.g., database timeout), the extension retries up to `reload_max_retries` times with `reload_retry_backoff_seconds` between attempts. If all retries fail, the current config is preserved and the scheduler continues running (won't stop due to transient failures).
 - RPC listen (must be enabled if `rpc_url` not set):
 ```toml
 [rpc]

--- a/extensions/tn_digest/extension.go
+++ b/extensions/tn_digest/extension.go
@@ -41,6 +41,12 @@ type Extension struct {
 	reloadRetryBackoff   time.Duration // backoff between config reload retries (default 1 minute)
 	reloadMaxRetries     int           // max retries for config reload (default 15)
 
+	// background retry worker
+	retryWorkerCtx    context.Context
+	retryWorkerCancel context.CancelFunc
+	retrySignal       chan struct{} // signal to trigger retry worker
+	retryMu           sync.Mutex    // protects retry state
+
 	// tx submission wiring
 	broadcaster TxBroadcaster
 	nodeSigner  auth.Signer
@@ -98,10 +104,10 @@ func (e *Extension) SetScheduler(s *scheduler.DigestScheduler) {
 	e.scheduler = s
 }
 
-func (e *Extension) SetReloadIntervalBlocks(v int64) { e.reloadIntervalBlocks = v }
-func (e *Extension) ReloadIntervalBlocks() int64     { return e.reloadIntervalBlocks }
-func (e *Extension) SetLastCheckedHeight(h int64)    { e.lastCheckedHeight = h }
-func (e *Extension) LastCheckedHeight() int64        { return e.lastCheckedHeight }
+func (e *Extension) SetReloadIntervalBlocks(v int64)       { e.reloadIntervalBlocks = v }
+func (e *Extension) ReloadIntervalBlocks() int64           { return e.reloadIntervalBlocks }
+func (e *Extension) SetLastCheckedHeight(h int64)          { e.lastCheckedHeight = h }
+func (e *Extension) LastCheckedHeight() int64              { return e.lastCheckedHeight }
 func (e *Extension) SetReloadRetryBackoff(d time.Duration) { e.reloadRetryBackoff = d }
 func (e *Extension) ReloadRetryBackoff() time.Duration {
 	if e.reloadRetryBackoff == 0 {
@@ -122,8 +128,128 @@ func (e *Extension) Broadcaster() TxBroadcaster     { return e.broadcaster }
 func (e *Extension) SetNodeSigner(s auth.Signer)    { e.nodeSigner = s }
 func (e *Extension) NodeSigner() auth.Signer        { return e.nodeSigner }
 
+// startRetryWorker starts the background config reload retry worker
+func (e *Extension) startRetryWorker() {
+	if e.retryWorkerCancel != nil {
+		return // already started
+	}
+	e.retryWorkerCtx, e.retryWorkerCancel = context.WithCancel(context.Background())
+	e.retrySignal = make(chan struct{}, 1) // buffered to avoid blocking
+	go e.retryWorkerLoop()
+}
+
+// stopRetryWorker stops the background retry worker
+func (e *Extension) stopRetryWorker() {
+	if e.retryWorkerCancel != nil {
+		e.retryWorkerCancel()
+		e.retryWorkerCancel = nil
+	}
+}
+
+// signalRetryNeeded signals the background worker that a retry is needed
+func (e *Extension) signalRetryNeeded() {
+	select {
+	case e.retrySignal <- struct{}{}:
+	default: // already signaled
+	}
+}
+
+// retryWorkerLoop is the background goroutine that retries config reloads
+func (e *Extension) retryWorkerLoop() {
+	for {
+		select {
+		case <-e.retryWorkerCtx.Done():
+			return
+		case <-e.retrySignal:
+			e.retryConfigReload()
+		}
+	}
+}
+
+// retryConfigReload performs multiple retry attempts with backoff
+func (e *Extension) retryConfigReload() {
+	backoff := e.ReloadRetryBackoff()
+	maxRetries := e.ReloadMaxRetries()
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			e.Logger().Warn("retrying config reload in background", "attempt", attempt, "backoff", backoff)
+			select {
+			case <-e.retryWorkerCtx.Done():
+				e.Logger().Info("retry worker cancelled")
+				return
+			case <-time.After(backoff):
+			}
+		}
+
+		enabled, schedule, err := e.EngineOps().LoadDigestConfig(e.retryWorkerCtx)
+		if err == nil {
+			// Success! Update config (app=nil since we're in background, service already cached)
+			e.Logger().Info("config reload succeeded in background", "attempt", attempt, "enabled", enabled, "schedule", schedule)
+			e.applyConfigChangeWithLock(e.retryWorkerCtx, enabled, schedule, nil)
+			return
+		}
+
+		// Check if context was cancelled during LoadDigestConfig
+		if e.retryWorkerCtx.Err() != nil {
+			e.Logger().Info("retry worker cancelled during config reload")
+			return
+		}
+
+		e.Logger().Warn("config reload attempt failed", "attempt", attempt, "error", err)
+	}
+
+	e.Logger().Error("all config reload retries failed in background, keeping current config", "attempts", maxRetries)
+}
+
+// applyConfigChangeWithLock applies config changes with proper synchronization
+// This method is called from both digestLeaderEndBlock and the background retry worker
+func (e *Extension) applyConfigChangeWithLock(ctx context.Context, enabled bool, schedule string, app *common.App) {
+	e.retryMu.Lock()
+	defer e.retryMu.Unlock()
+
+	if schedule == "" {
+		schedule = DefaultDigestSchedule
+	}
+
+	if enabled != e.ConfigEnabled() || schedule != e.Schedule() {
+		e.Logger().Info("digest config changed, updating scheduler",
+			"old_enabled", e.ConfigEnabled(),
+			"new_enabled", enabled,
+			"old_schedule", e.Schedule(),
+			"new_schedule", schedule,
+			"is_leader", e.IsLeader())
+		e.SetConfig(enabled, schedule)
+		if !enabled {
+			e.stopSchedulerIfRunning()
+			e.Logger().Info("tn_digest stopped due to config disabled")
+		} else if e.IsLeader() {
+			service := e.Service()
+			if app != nil && app.Service != nil {
+				service = app.Service
+				if e.Service() == nil {
+					e.SetService(service)
+				}
+			}
+			if e.Scheduler() == nil && !e.ensureSchedulerWithService(service) {
+				e.Logger().Debug("tn_digest: prerequisites missing; deferring (re)start after config update")
+			} else if e.Scheduler() != nil {
+				e.stopSchedulerIfRunning()
+				if err := e.startScheduler(ctx); err != nil {
+					e.Logger().Warn("failed to (re)start tn_digest scheduler after config update", "error", err)
+				} else {
+					e.Logger().Info("tn_digest (re)started with new schedule", "schedule", e.Schedule())
+				}
+			}
+		} else {
+			e.Logger().Info("tn_digest config enabled but not leader, will start when leadership acquired")
+		}
+	}
+}
+
 // Close stops background jobs.
 func (e *Extension) Close() {
+	e.stopRetryWorker()
 	if e.scheduler != nil {
 		_ = e.scheduler.Stop()
 	}

--- a/extensions/tn_digest/extension.go
+++ b/extensions/tn_digest/extension.go
@@ -8,6 +8,7 @@ package tn_digest
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/trufnetwork/kwil-db/common"
 	"github.com/trufnetwork/kwil-db/core/crypto/auth"
@@ -37,6 +38,8 @@ type Extension struct {
 	// reload policy
 	reloadIntervalBlocks int64
 	lastCheckedHeight    int64
+	reloadRetryBackoff   time.Duration // backoff between config reload retries (default 1 minute)
+	reloadMaxRetries     int           // max retries for config reload (default 15)
 
 	// tx submission wiring
 	broadcaster TxBroadcaster
@@ -99,6 +102,20 @@ func (e *Extension) SetReloadIntervalBlocks(v int64) { e.reloadIntervalBlocks = 
 func (e *Extension) ReloadIntervalBlocks() int64     { return e.reloadIntervalBlocks }
 func (e *Extension) SetLastCheckedHeight(h int64)    { e.lastCheckedHeight = h }
 func (e *Extension) LastCheckedHeight() int64        { return e.lastCheckedHeight }
+func (e *Extension) SetReloadRetryBackoff(d time.Duration) { e.reloadRetryBackoff = d }
+func (e *Extension) ReloadRetryBackoff() time.Duration {
+	if e.reloadRetryBackoff == 0 {
+		return 1 * time.Minute // default
+	}
+	return e.reloadRetryBackoff
+}
+func (e *Extension) SetReloadMaxRetries(n int) { e.reloadMaxRetries = n }
+func (e *Extension) ReloadMaxRetries() int {
+	if e.reloadMaxRetries == 0 {
+		return 15 // default
+	}
+	return e.reloadMaxRetries
+}
 
 func (e *Extension) SetBroadcaster(b TxBroadcaster) { e.broadcaster = b }
 func (e *Extension) Broadcaster() TxBroadcaster     { return e.broadcaster }

--- a/extensions/tn_digest/tn_digest.go
+++ b/extensions/tn_digest/tn_digest.go
@@ -3,6 +3,7 @@ package tn_digest
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/trufnetwork/kwil-db/common"
 	"github.com/trufnetwork/kwil-db/core/crypto/auth"
@@ -74,21 +75,40 @@ func engineReadyHook(ctx context.Context, app *common.App) error {
 	ext.SetService(app.Service)
 	ext.SetEngineOps(engOps)
 	ext.SetConfig(enabled, schedule)
-	// default reload interval: 1000 blocks; allow override via node config TOML
-	var reload int64 = 1000
+
+	// Load config from node TOML [extensions.tn_digest]
 	if ext.Service() != nil && ext.Service().LocalConfig != nil {
 		if m, ok := ext.Service().LocalConfig.Extensions[ExtensionName]; ok {
+			// reload_interval_blocks (default: 1000)
 			if v, ok2 := m["reload_interval_blocks"]; ok2 && v != "" {
-				// best-effort parse
 				var parsed int64
 				_, _ = fmt.Sscan(v, &parsed)
 				if parsed > 0 {
-					reload = parsed
+					ext.SetReloadIntervalBlocks(parsed)
+				}
+			}
+			// reload_retry_backoff_seconds (default: 60)
+			if v, ok2 := m["reload_retry_backoff_seconds"]; ok2 && v != "" {
+				var seconds int64
+				_, _ = fmt.Sscan(v, &seconds)
+				if seconds > 0 {
+					ext.SetReloadRetryBackoff(time.Duration(seconds) * time.Second)
+				}
+			}
+			// reload_max_retries (default: 15)
+			if v, ok2 := m["reload_max_retries"]; ok2 && v != "" {
+				var retries int
+				_, _ = fmt.Sscan(v, &retries)
+				if retries > 0 {
+					ext.SetReloadMaxRetries(retries)
 				}
 			}
 		}
 	}
-	ext.SetReloadIntervalBlocks(reload)
+	// Set defaults if not configured
+	if ext.ReloadIntervalBlocks() == 0 {
+		ext.SetReloadIntervalBlocks(1000)
+	}
 
 	// Fill in signer and broadcaster once engine is ready
 	wireSignerAndBroadcaster(app, ext)
@@ -169,12 +189,46 @@ func digestLeaderEndBlock(ctx context.Context, app *common.App, block *common.Bl
 		return
 	}
 
-	enabled, schedule, _ := ext.EngineOps().LoadDigestConfig(ctx)
+	// Retry config reload with configurable backoff and max retries
+	var (
+		enabled  bool
+		schedule string
+		loadErr  error
+	)
+	backoff := ext.ReloadRetryBackoff()
+	maxRetries := ext.ReloadMaxRetries()
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			ext.Logger().Warn("retrying config reload", "attempt", attempt, "last_error", loadErr, "backoff", backoff)
+			select {
+			case <-ctx.Done():
+				ext.Logger().Warn("context cancelled during config reload retry")
+				ext.SetLastCheckedHeight(block.Height)
+				return
+			case <-time.After(backoff):
+			}
+		}
+		enabled, schedule, loadErr = ext.EngineOps().LoadDigestConfig(ctx)
+		if loadErr == nil {
+			break
+		}
+	}
+	if loadErr != nil {
+		ext.Logger().Error("failed to reload digest config after retries, keeping current config (scheduler will not stop/start)", "error", loadErr, "attempts", maxRetries)
+		ext.SetLastCheckedHeight(block.Height)
+		return
+	}
 	if schedule == "" {
 		schedule = DefaultDigestSchedule
 	}
 
 	if enabled != ext.ConfigEnabled() || schedule != ext.Schedule() {
+		ext.Logger().Info("digest config changed, updating scheduler",
+			"old_enabled", ext.ConfigEnabled(),
+			"new_enabled", enabled,
+			"old_schedule", ext.Schedule(),
+			"new_schedule", schedule,
+			"is_leader", ext.IsLeader())
 		ext.SetConfig(enabled, schedule)
 		if !enabled {
 			ext.stopSchedulerIfRunning()
@@ -197,6 +251,8 @@ func digestLeaderEndBlock(ctx context.Context, app *common.App, block *common.Bl
 					ext.Logger().Info("tn_digest (re)started with new schedule", "schedule", ext.Schedule())
 				}
 			}
+		} else {
+			ext.Logger().Info("tn_digest config enabled but not leader, will start when leadership acquired")
 		}
 	}
 


### PR DESCRIPTION
Root Cause:
- Every 1000 blocks, digest reloads config from database table digest_config
- If database query fails (timeout, network issue), error was ignored
- Ignored error returns enabled=false by default
- Scheduler detects config change (true→false) and stops permanently
- Next reload also fails, but no change detected (false==false)
- Scheduler never restarts until node restart

Production Impact:
- Oct 4-5: Digest stopped with "tn_digest stopped due to config disabled"
- Database shows enabled=true but scheduler actually stopped
- No digest runs until manual node restart

Solution:
1. Retry logic: 15 attempts with 1 minute backoff (configurable)
2. Fail-safe: On all retries failed, keep current config (don't stop scheduler)
3. Context-aware: Respects context cancellation during retries
4. Better logging: Shows config changes, retry attempts, and errors

resolves: https://github.com/trufnetwork/truf-network/issues/1256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added resilient config reload with automatic retries and backoff.
  - New settings: reload_retry_backoff_seconds and reload_max_retries; existing reload interval retained.
  - Defaults applied when not configured; on persistent failures, the last valid config is preserved and scheduling continues.

- Documentation
  - Updated README with “Config reload resilience” explaining retry behavior and new settings.

- Tests
  - Added tests covering transient failures, max-retry exhaustion (preserve current config), and graceful shutdown on cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->