### PR TITLE
fix: auto-update P2P address on AWS instance restart

### DIFF
--- a/deployments/infra/stacks/ami_pipeline_stack.go
+++ b/deployments/infra/stacks/ami_pipeline_stack.go
@@ -372,6 +372,23 @@ phases:
               sudo systemctl enable tn-node
               sudo systemctl start tn-node
 
+              # Wait for containers to actually start
+              echo "Waiting for containers to start..."
+              MAX_WAIT=60
+              ELAPSED=0
+              while [ $ELAPSED -lt $MAX_WAIT ]; do
+                if sudo -u tn docker compose ps --status running 2>/dev/null | grep -q tn-node; then
+                  echo "Containers started successfully!"
+                  break
+                fi
+                sleep 2
+                ELAPSED=$((ELAPSED + 2))
+              done
+
+              if [ $ELAPSED -ge $MAX_WAIT ]; then
+                echo "Warning: Containers did not start within ${MAX_WAIT}s. Check logs with: sudo -u tn docker compose logs"
+              fi
+
               if [ "$RECONFIGURE" = true ]; then
                 echo "TRUF.NETWORK node reconfiguration complete!"
               else

--- a/deployments/infra/stacks/docker-compose.template.yml
+++ b/deployments/infra/stacks/docker-compose.template.yml
@@ -40,21 +40,41 @@ services:
     restart: unless-stopped
     command: |
       sh -c "
+        # Detect current public IP for P2P external address
+        PUBLIC_IP=\"$${TN_EXTERNAL_ADDRESS:-}\"
+        if [ -z \"$$PUBLIC_IP\" ]; then
+          if command -v wget >/dev/null 2>&1; then
+            PUBLIC_IP=$$(wget -T 2 -qO- https://checkip.amazonaws.com/ 2>/dev/null || true)
+          elif command -v curl >/dev/null 2>&1; then
+            PUBLIC_IP=$$(curl -m 2 -s https://checkip.amazonaws.com/ 2>/dev/null || true)
+          fi
+        fi
+        echo \"Current public IP: $$PUBLIC_IP\"
+
+        # Update external address in existing config if IP has changed
+        if [ -f /root/.kwild/config.toml ] && [ -n \"$$PUBLIC_IP\" ]; then
+          # Extract the P2P listen port from config (look in [p2p] section)
+          P2P_PORT=$$(awk '/^\\[p2p\\]/,/^\\[/ {if (/^listen/) {print}}' /root/.kwild/config.toml | awk -F\":\" '{print \$NF}' | tr -d \"' \\\"\" | head -1)
+          # Default to 6600 if extraction failed
+          P2P_PORT=\"\$${P2P_PORT:-6600}\"
+          CURRENT_EXTERNAL=$$(grep \"external_address\" /root/.kwild/config.toml | sed 's/.*= *[\"'\\'']*\\([^\"'\\'']*\\)[\"'\\'']*$/\\1/')
+          NEW_EXTERNAL=\"$$PUBLIC_IP:$$P2P_PORT\"
+          echo \"Config has: '$$CURRENT_EXTERNAL', Detected: '$$NEW_EXTERNAL' (P2P port: $$P2P_PORT)\"
+          if [ \"$$CURRENT_EXTERNAL\" != \"$$NEW_EXTERNAL\" ]; then
+            echo \"Updating external address from '$$CURRENT_EXTERNAL' to '$$NEW_EXTERNAL'\"
+            sed -i \"s|^external_address = .*\$|external_address = '$$NEW_EXTERNAL'|\" /root/.kwild/config.toml
+            echo \"Update complete\"
+          else
+            echo \"External address unchanged\"
+          fi
+        fi
+
         # Only generate NEW config if persistent storage is empty
         if [ ! -f /root/.kwild/config.toml ]; then
           echo 'No existing configuration found. Generating new node configuration...'
 
-          # Resolve external address (prefer env override; fallback if tools exist)
-          PUBLIC_IP=\"$${TN_EXTERNAL_ADDRESS:-}\"
-          if [ -z \"$$PUBLIC_IP\" ]; then
-            if command -v wget >/dev/null 2>&1; then
-              PUBLIC_IP=$$(wget -T 2 -qO- https://checkip.amazonaws.com/ 2>/dev/null || true)
-            elif command -v curl >/dev/null 2>&1; then
-              PUBLIC_IP=$$(curl -m 2 -s https://checkip.amazonaws.com/ 2>/dev/null || true)
-            fi
-          fi
-          [ -n \"$$PUBLIC_IP\" ] && EXTERNAL_FLAG=\"--p2p.external-address $$PUBLIC_IP:26656\" || EXTERNAL_FLAG=\"\"
-          echo \"Detected public IP: $$PUBLIC_IP\"
+          # Set external address flag (use default Kwil P2P port 6600)
+          [ -n \"$$PUBLIC_IP\" ] && EXTERNAL_FLAG=\"--p2p.external-address $$PUBLIC_IP:6600\" || EXTERNAL_FLAG=\"\"
 
           # Determine network type and generate appropriate configuration
           NETWORK_TYPE=\"$${NETWORK_TYPE:-mainnet}\"


### PR DESCRIPTION
EC2 nodes lose P2P connectivity after stop/start when AWS assigns a new public IP address. The external_address config retained the old IP, preventing peer connections.

- Auto-detect public IP on every container start
- Update external_address if IP changed
- Extract P2P port from existing config to support custom ports
- Respect TN_EXTERNAL_ADDRESS env var for Elastic IP users
- Add container wait logic in tn-node-configure script

- Added IP detection before config check
- Extract P2P listen port from [p2p] section
- Compare current vs new external address
- Update config.toml if IP changed
- Log all IP changes for visibility

- Added 60s container startup wait in tn-node-configure
- Prevents race condition on first configuration
- Ensures containers are running before reporting success

resolves: https://github.com/trufnetwork/truf-network/issues/1262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects the public IP and updates the node’s external address during startup.
  * Simplifies initial configuration by setting the external address when storage is empty, reducing manual setup.

* **Bug Fixes**
  * Improves service reliability by waiting for containers to become healthy before proceeding, with a clear timeout and guidance if startup takes too long.

* **Chores**
  * Streamlines startup flow to consistently use the detected external address across network types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->