### PR TITLE
chore: add COOKIE_SAME_SITE configuration to gateway

### DIFF
--- a/deployments/dev-gateway/dev-gateway-compose.yaml
+++ b/deployments/dev-gateway/dev-gateway-compose.yaml
@@ -27,6 +27,7 @@ services:
       BACKENDS: ${BACKENDS:-tn-db:8484}
       CHAIN_ID: ${CHAIN_ID:-trufnetwork-dev}
       CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS}
+      COOKIE_SAME_SITE: ${COOKIE_SAME_SITE:-None}
       EXPORT_RPC_META_LOG: "true"
       META_LOG_FORMAT: "otel_nested"
       META_LOG_OTEL_PROCESSOR: "batch"

--- a/deployments/gateway/gateway-compose.yaml
+++ b/deployments/gateway/gateway-compose.yaml
@@ -17,6 +17,7 @@ services:
       DOMAIN: https://${DOMAIN:?}
       CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS}
       XFF_TRUST_PROXY_COUNT: ${XFF_TRUST_PROXY_COUNT:-}
+      COOKIE_SAME_SITE: ${COOKIE_SAME_SITE:-None}
       ALLOW_ADHOC_QUERY: ${ALLOW_ADHOC_QUERY:-true}
       EXTRA_ARGS: "--allow-chain-rpcs"
     volumes:

--- a/deployments/gateway/kgw-config.pkl
+++ b/deployments/gateway/kgw-config.pkl
@@ -40,6 +40,9 @@ xff_trust_proxy_count = xff_trust_proxy_count_raw?.toIntOrNull()
 allow_deploy_db = read?("env:ALLOW_DEPLOY_DB") == "true"
 allow_adhoc_query = read?("env:ALLOW_ADHOC_QUERY") == "true"
 
+// cookie same site configuration
+cookie_same_site = read?("env:COOKIE_SAME_SITE")
+
 // SPECIAL CASE: BACKENDS
 // we just need to split the string by comma
 hidden backends_str = read("env:BACKENDS")

--- a/deployments/infra/lib/constructs/kwil_cluster/kwil_cluster.go
+++ b/deployments/infra/lib/constructs/kwil_cluster/kwil_cluster.go
@@ -64,6 +64,7 @@ func NewKwilCluster(scope constructs.Construct, id string, props *KwilClusterPro
 			Nodes:            props.Validators,
 			// default to 1, because it is behind a TLS termination point
 			XffTrustProxyCount: jsii.String("1"),
+			CookieSameSite:     jsii.String("None"),
 		},
 		InitElements: props.InitElements,
 	})

--- a/deployments/infra/lib/kwil-gateway/kgw_instance.go
+++ b/deployments/infra/lib/kwil-gateway/kgw_instance.go
@@ -22,6 +22,7 @@ type KGWConfig struct {
 	ChainId            *string
 	Nodes              []tn.TNInstance
 	XffTrustProxyCount *string
+	CookieSameSite     *string
 }
 
 type NewKGWInstanceInput struct {

--- a/deployments/infra/lib/kwil-gateway/kgw_startup_scripts.go
+++ b/deployments/infra/lib/kwil-gateway/kgw_startup_scripts.go
@@ -32,6 +32,7 @@ func AddKwilGatewayStartupScriptsToInstance(options AddKwilGatewayStartupScripts
 		ChainId:            config.ChainId,
 		Domain:             jsii.String("gateway." + *config.Domain),
 		XffTrustProxyCount: config.XffTrustProxyCount,
+		CookieSameSite:     config.CookieSameSite,
 	}
 
 	script := "#!/bin/bash\nset -e\nset -x\n\n"
@@ -74,6 +75,7 @@ type KGWEnvConfig struct {
 	XffTrustProxyCount *string `env:"XFF_TRUST_PROXY_COUNT"`
 	Backends           *string `env:"BACKENDS"`
 	ChainId            *string `env:"CHAIN_ID"`
+	CookieSameSite     *string `env:"COOKIE_SAME_SITE"`
 }
 
 // GetDict returns a map of the environment variables and their values


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Introduced COOKIE_SAME_SITE environment variable in both dev-gateway and gateway compose files, defaulting to 'None'.
- Updated kgw-config.pkl to read COOKIE_SAME_SITE from environment variables.
- Modified KGWConfig and related startup scripts to include CookieSameSite property for better cookie management.

This enhancement improves the handling of cookie policies across services.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

- fix #1201 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Already redeployed to test the stack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway cookies now support a configurable SameSite attribute via the COOKIE_SAME_SITE environment variable (default: None), improving cross-origin authentication and embedded client compatibility.

* **Chores**
  * Updated deployment configurations to include and propagate the COOKIE_SAME_SITE setting across environments.
  * Infrastructure configuration extended to pass the SameSite option through startup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->