### PR TITLE
chore: remove automated AMI builds from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,6 @@ permissions:
   packages: read
   # This is required for creating and modifying releases
   id-token: write
-  # Required for workflow dispatch
-  actions: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -75,31 +73,3 @@ jobs:
             ./.build/tn_${{ env.VERSION }}_linux_amd64.tar.gz
             ./.build/tn_${{ env.VERSION }}_linux_arm64.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
-
-  trigger-builds:
-    name: Trigger AMI and Docker builds
-    runs-on: ubuntu-latest
-    needs: build-release
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - name: Trigger AMI build
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'ami-build.yml',
-              ref: context.ref
-            });
-
-      - name: Trigger Docker build
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'publish-node-image.yaml',
-              ref: context.ref
-            });


### PR DESCRIPTION
The release workflow supposed to be only on release. 
The AMI build should be triggered manually as the image is handled via `latest` tag

<img width="1604" height="1363" alt="image" src="https://github.com/user-attachments/assets/f30ab332-9cd5-4470-920c-f9629eaaa8b7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced permissions in the release workflow by removing write access.
  * Removed the job that triggered downstream builds on tag releases, simplifying the pipeline.
  * Release process now runs only core steps; downstream AMI/Docker builds no longer auto-trigger automatically.
  * No impact to application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->