### PR TITLE
docs: view port requirements and configuration

### DIFF
--- a/deployments/infra/stacks/ami_pipeline_stack.go
+++ b/deployments/infra/stacks/ami_pipeline_stack.go
@@ -369,12 +369,14 @@ phases:
               📦 To update to the latest software:
               sudo tn-node-update
 
-              🤖 MCP (AI Integration) Setup:
-              1. Configure node with --enable-mcp flag
-              2. Open port 8000 in your AWS Security Group:
-                 EC2 Console → Instance → Security → Edit inbound rules
-                 Add: Custom TCP, Port 8000, Source 0.0.0.0/0
-              3. Access via: http://YOUR-PUBLIC-IP:8000/sse
+              🔒 Security Group Ports:
+              - Port 6600 (P2P): Recommended for two-way peer connections
+              - Port 8484 (RPC): Needed for public node access
+
+              🤖 MCP (AI Integration) - Optional:
+              1. Configure: sudo tn-node-configure --enable-mcp
+              2. Open port 8000 in Security Group
+              3. Access: http://YOUR-PUBLIC-IP:8000/sse
               EOF
 
             - |
@@ -408,12 +410,14 @@ phases:
                 echo "📦 To update to the latest software:"
                 echo "sudo tn-node-update"
                 echo ""
-                echo "🤖 MCP (AI Integration) Setup:"
-                echo "1. Configure node with --enable-mcp flag"
-                echo "2. Open port 8000 in your AWS Security Group:"
-                echo "   EC2 Console → Instance → Security → Edit inbound rules"
-                echo "   Add: Custom TCP, Port 8000, Source 0.0.0.0/0"
-                echo "3. Access via: http://YOUR-PUBLIC-IP:8000/sse"
+                echo "🔒 Security Group Ports:"
+                echo "- Port 6600 (P2P): Recommended for two-way peer connections"
+                echo "- Port 8484 (RPC): Needed for public node access"
+                echo ""
+                echo "🤖 MCP (AI Integration) - Optional:"
+                echo "1. Configure: sudo tn-node-configure --enable-mcp"
+                echo "2. Open port 8000 in Security Group"
+                echo "3. Access: http://YOUR-PUBLIC-IP:8000/sse"
               fi
               EOF
             - sudo chmod +x /etc/profile.d/tn-welcome.sh

--- a/docs/ami-deployment-guide.md
+++ b/docs/ami-deployment-guide.md
@@ -30,13 +30,26 @@ In the AWS EC2 Console:
 - **VPC/Subnet**: Use default or your preferred network setup
 
 #### Security Groups
-If you plan to use MCP for AI integration (like Claude Code), add this inbound rule:
+
+**Required Inbound Rules** for your node to participate in the network:
+
+| Type | Protocol | Port Range | Source | Description                               |
+|------|----------|------------|--------|-------------------------------------------|
+| SSH | TCP | 22 | Your IP | Remote access                             |
+| Custom TCP | TCP | 6600 | 0.0.0.0/0 | P2P node communication (recommended) |
+| Custom TCP | TCP | 8484 | 0.0.0.0/0 | RPC service (if running public node)      |
+
+**Optional Inbound Rules:**
 
 | Type | Protocol | Port Range | Source | Description |
 |------|----------|------------|--------|-------------|
-| Custom TCP | TCP | 8000 | Your IP | MCP Server for Claude Code |
+| Custom TCP | TCP | 8000 | Your IP or 0.0.0.0/0 | MCP Server for AI integration |
 
-> **Note**: This is only needed if you want external AI tools like Claude Code to connect to your node's MCP server.
+> **Important**:
+> - **Port 6600**: Enables two-way P2P communication. Your node can sync without this (via outbound connections), but opening it helps network health by accepting incoming peer connections
+> - **Port 8484**: Needed if you want users/applications to query data from your node
+> - **Port 8000**: Only needed for MCP/AI integration (like Claude Code)
+> - **Port 22** (SSH): Should be restricted to your IP for security
 
 #### Storage
 - **Root volume**: 30 GB minimum (50+ GB recommended)

--- a/docs/node-operator-guide.md
+++ b/docs/node-operator-guide.md
@@ -395,10 +395,16 @@ EOF
 
 ### 5. Run TN Node
 
-Before you proceed, ensure your firewall allows incoming connections on:
+Before you proceed, ensure your firewall/security group allows incoming connections on:
 
-- JSON-RPC port (default: 8484)
-- P2P port (default: 6600)
+**Required Ports:**
+- **P2P port: 6600** (required for two-way node communication)
+- **RPC port: 8484** (needed if running a public node for user queries)
+
+**Optional Ports:**
+- **MCP port: 8000** (only if using AI integration)
+
+> **Important**: Port 6600 enables two-way P2P communication. Without it open, your node can still sync (by connecting outbound to other nodes), but other nodes cannot connect to you. Opening this port helps network health by allowing your node to accept incoming peer connections.
 
 #### For Linux
 


### PR DESCRIPTION
compliment for: https://github.com/trufnetwork/truf-network/issues/1124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explicit Security Group/Firewall guidance with Required (SSH 22, P2P 6600, RPC 8484) and Optional (MCP 8000) ports.
  * Clarified port purposes and when each is needed, noting MCP as optional and P2P’s role in network health.
  * Updated AMI deployment and node operator guides with clearer, categorized port instructions.

* **Style**
  * Revised AMI runtime and console welcome messages to reflect the new port sections and optional MCP guidance, improving clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->