### PR TITLE
chore: force deterministic args for attestation queries

### DIFF
--- a/internal/migrations/024-attestation-actions.sql
+++ b/internal/migrations/024-attestation-actions.sql
@@ -37,11 +37,15 @@ $max_fee INT8
     $caller_hex := LOWER(substring(@caller, 3, 40));
     $caller_bytes := decode($caller_hex, 'hex');
     
+    -- Force deterministic execution by overriding non-deterministic parameters.
+    -- Query actions (IDs 1-5) all have use_cache as their last parameter.
+    -- Force use_cache=false to ensure all validators compute identical results
+    -- regardless of cache state.
+    if $action_id >= 1 AND $action_id <= 5 {
+        $args_bytes := tn_utils.force_last_arg_false($args_bytes);
+    }
+
     -- Execute target query deterministically using tn_utils.call_dispatch precompile
-    -- TODO: some arguments are not deterministic, such as `use_cache`
-    -- we should aim at filtering these out before we release attestations.
-    -- One idea is to also store a force_args in the whitelisted actions. Then this should help us force 
-    -- some args per action
     $query_result := tn_utils.call_dispatch($action_name, $args_bytes);
     
     $version := 1;


### PR DESCRIPTION
Add tn_utils.force_last_arg_false precompile to override use_cache parameter in attestation requests, ensuring all validators compute identical results regardless of cache state.

Changes:
- Add force_last_arg_false() precompile to tn_utils
- Update request_attestation to force use_cache=false for query actions
- Add comprehensive tests covering edge cases

Fixes non-deterministic attestation results when users pass use_cache=true for composed stream queries. Query actions (IDs 1-5) now automatically override the last parameter to false before executing via call_dispatch.

resolves: https://github.com/trufnetwork/node/issues/1208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures deterministic execution for certain attestation actions by disabling caching during dispatch, improving reliability and consistency of results.
  * Preserves original behavior when no arguments are provided and handles malformed inputs more robustly.

* **Tests**
  * Added comprehensive tests validating that the last argument is correctly forced to false, including cases with empty inputs, single/multiple arguments, and invalid data, improving error-path coverage and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->