### PR TITLE
chore(attestation): non fatal signature issue on initialization

### DIFF
--- a/extensions/tn_attestation/tn_attestation.go
+++ b/extensions/tn_attestation/tn_attestation.go
@@ -72,8 +72,11 @@ func engineReadyHook(ctx context.Context, app *common.App) error {
 
 	// Initialize the validator signer with the loaded private key
 	if err := InitializeValidatorSigner(privateKey); err != nil {
-		logger.Error("failed to initialize validator signer", "error", err)
-		return fmt.Errorf("failed to initialize validator signer: %w", err)
+		logger.Warn("tn_attestation extension ready without validator signer (unsupported node key)",
+			"error", err,
+			"queue_size", GetAttestationQueue().Len())
+		// Leave the extension running so the node can operate without signing support.
+		return nil
 	}
 
 	if ext.NodeSigner() == nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

- Changed error handling in the engineReadyHook to log a warning instead of an error when the validator signer fails to initialize, allowing the extension to continue running without signing support.
- Added queue size information to the log for better operational visibility.

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: https://github.com/trufnetwork/node/issues/1221

-->

- fix https://github.com/trufnetwork/node/issues/1221

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization resilience. The system now continues operating with diagnostic logging when validator signing support is unavailable, instead of failing to start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->