### PR TITLE
chore: make get last transaction backward compatible

### DIFF
--- a/internal/migrations/010-get-latest-write-activity.sql
+++ b/internal/migrations/010-get-latest-write-activity.sql
@@ -189,15 +189,15 @@ CREATE OR REPLACE ACTION get_last_transactions(
         ERROR('Limit size cannot exceed 100');
     }
 
-    RETURN
-    SELECT
-        NULL::TEXT AS tx_id,
-        lt.created_at,
-        lt.method,
-        NULL::TEXT AS caller,
-        NULL::NUMERIC(78, 0) AS fee_amount,
-        NULL::TEXT AS fee_recipient,
-        NULL::TEXT AS metadata,
-        ''::TEXT AS fee_distributions
-    FROM get_last_transactions_v1($normalized_provider, $limit_val) lt;
+    FOR $row IN get_last_transactions_v1($normalized_provider, $limit_val) {
+        $fee_distributions TEXT := '';
+        RETURN NEXT NULL::TEXT,
+            $row.created_at,
+            $row.method,
+            NULL::TEXT,
+            NULL::NUMERIC(78, 0),
+            NULL::TEXT,
+            NULL::TEXT,
+            $fee_distributions;
+    }
 };


### PR DESCRIPTION
using return select statement directly will cause error
```
❌ Error: JSON RPC call error: code: -300, message: query planner error: error in UNKNOWN section of sql statement: function does not exist: "get_last_transactions_v1"
```

This change the format into return next, so it works.

already migrated and currently working

resolves: https://github.com/trufnetwork/truf-network/issues/1338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal database migration for transaction activity retrieval to improve data handling efficiency. No user-facing changes to functionality or features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->