### PR TITLE
chore: limit single transaction to 10 rows

### DIFF
--- a/internal/migrations/003-primitive-insertion.sql
+++ b/internal/migrations/003-primitive-insertion.sql
@@ -37,6 +37,12 @@ CREATE OR REPLACE ACTION insert_records(
     -- Get record count (used for both fee calculation and validation)
     $num_records INT := array_length($data_provider);
 
+    -- Cap batch size to prevent superlinear block execution time.
+    -- With per-tx PG isolation, blocks handle thousands of small txns efficiently.
+    if $num_records > 10 {
+        ERROR('insert_records: batch size exceeds maximum of 10 records');
+    }
+
     -- ===== FEE COLLECTION WITH ROLE EXEMPTION =====
     -- Check if caller is exempt (has system:network_writer role)
     $is_exempt BOOL := FALSE;


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Added a 10-record limit to batch insertion operations. Requests attempting to insert more than 10 records in a single batch will be rejected with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->