### PR TITLE
chore: auto-assign local streams to node operator

### DIFF
--- a/extensions/tn_local/create_stream_test.go
+++ b/extensions/tn_local/create_stream_test.go
@@ -22,6 +22,21 @@ func TestCreateStream_NilRequest(t *testing.T) {
 	require.Contains(t, rpcErr.Message, "missing request")
 }
 
+func TestCreateStream_DisabledWhenNoNodeAddress(t *testing.T) {
+	// An extension without a configured node address (e.g. node has no
+	// secp256k1 key) must reject every request with the disabled error.
+	ext := &Extension{db: &utils.MockDB{}}
+	// isEnabled is intentionally not set.
+
+	_, rpcErr := ext.CreateStream(context.Background(), &CreateStreamRequest{
+		StreamID:   "st00000000000000000000000000test",
+		StreamType: "primitive",
+	})
+	require.NotNil(t, rpcErr)
+	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)
+	require.Contains(t, rpcErr.Message, "tn_local is disabled")
+}
+
 func TestCreateStream_Success(t *testing.T) {
 	var capturedStmt string
 	var capturedArgs []any
@@ -36,17 +51,16 @@ func TestCreateStream_Success(t *testing.T) {
 	ext.height.Store(42)
 
 	resp, rpcErr := ext.CreateStream(context.Background(), &CreateStreamRequest{
-		DataProvider: "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832",
-		StreamID:     "st00000000000000000000000000test",
-		StreamType:   "primitive",
+		StreamID:   "st00000000000000000000000000test",
+		StreamType: "primitive",
 	})
 
 	require.Nil(t, rpcErr, "expected no error")
 	require.NotNil(t, resp)
 	require.Contains(t, capturedStmt, "INSERT INTO "+SchemaName+".streams")
 	require.Len(t, capturedArgs, 4, "INSERT should have 4 parameters")
-	// data_provider should be lowercased (matching consensus behavior)
-	require.Equal(t, "0xec36224a679218ae28fcece8d3c68595b87dd832", capturedArgs[0])
+	// data_provider must be the node's own address — server-derived, never client-supplied.
+	require.Equal(t, testNodeAddress, capturedArgs[0])
 	require.Equal(t, "st00000000000000000000000000test", capturedArgs[1])
 	require.Equal(t, "primitive", capturedArgs[2])
 	// created_at should propagate the block height set on the extension
@@ -64,9 +78,8 @@ func TestCreateStream_ComposedType(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.CreateStream(context.Background(), &CreateStreamRequest{
-		DataProvider: "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832",
-		StreamID:     "st00000000000000000000000000test",
-		StreamType:   "composed",
+		StreamID:   "st00000000000000000000000000test",
+		StreamType: "composed",
 	})
 
 	require.Nil(t, rpcErr)
@@ -89,9 +102,8 @@ func TestCreateStream_InvalidStreamID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, rpcErr := ext.CreateStream(context.Background(), &CreateStreamRequest{
-				DataProvider: "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832",
-				StreamID:     tt.streamID,
-				StreamType:   "primitive",
+				StreamID:   tt.streamID,
+				StreamType: "primitive",
 			})
 			require.NotNil(t, rpcErr)
 			require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -104,40 +116,12 @@ func TestCreateStream_InvalidStreamType(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.CreateStream(context.Background(), &CreateStreamRequest{
-		DataProvider: "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832",
-		StreamID:     "st00000000000000000000000000test",
-		StreamType:   "invalid",
+		StreamID:   "st00000000000000000000000000test",
+		StreamType: "invalid",
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
 	require.Contains(t, rpcErr.Message, "must be 'primitive' or 'composed'")
-}
-
-func TestCreateStream_InvalidDataProvider(t *testing.T) {
-	ext := newTestExtension(&utils.MockDB{})
-
-	tests := []struct {
-		name         string
-		dataProvider string
-	}{
-		{"no 0x prefix", "EC36224A679218Ae28FCeCe8d3c68595B87Dd832"},
-		{"too short", "0xEC36224A679218Ae28"},
-		{"too long", "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832FF"},
-		{"invalid chars", "0xGG36224A679218Ae28FCeCe8d3c68595B87Dd832"},
-		{"empty", ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, rpcErr := ext.CreateStream(context.Background(), &CreateStreamRequest{
-				DataProvider: tt.dataProvider,
-				StreamID:     "st00000000000000000000000000test",
-				StreamType:   "primitive",
-			})
-			require.NotNil(t, rpcErr)
-			require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
-			require.Contains(t, rpcErr.Message, "data_provider must be a valid Ethereum address")
-		})
-	}
 }
 
 func TestCreateStream_DuplicateStream(t *testing.T) {
@@ -149,9 +133,8 @@ func TestCreateStream_DuplicateStream(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.CreateStream(context.Background(), &CreateStreamRequest{
-		DataProvider: "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832",
-		StreamID:     "st00000000000000000000000000test",
-		StreamType:   "primitive",
+		StreamID:   "st00000000000000000000000000test",
+		StreamType: "primitive",
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -167,9 +150,8 @@ func TestCreateStream_DuplicateStream_PgError(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.CreateStream(context.Background(), &CreateStreamRequest{
-		DataProvider: "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832",
-		StreamID:     "st00000000000000000000000000test",
-		StreamType:   "primitive",
+		StreamID:   "st00000000000000000000000000test",
+		StreamType: "primitive",
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -185,9 +167,8 @@ func TestCreateStream_DBError(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.CreateStream(context.Background(), &CreateStreamRequest{
-		DataProvider: "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832",
-		StreamID:     "st00000000000000000000000000test",
-		StreamType:   "primitive",
+		StreamID:   "st00000000000000000000000000test",
+		StreamType: "primitive",
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)

--- a/extensions/tn_local/extension.go
+++ b/extensions/tn_local/extension.go
@@ -56,9 +56,10 @@ func (e *Extension) configure(logger log.Logger, db sql.DB, localDB *LocalDB, no
 	e.db = db
 	e.localDB = localDB
 	e.nodeAddress = nodeAddress
-	if nodeAddress != "" {
-		e.isEnabled.Store(true)
-	}
+	// Always set isEnabled deterministically based on nodeAddress so that
+	// re-configuring an extension (e.g. in tests or on node re-init) can't
+	// leave a stale-true flag when the new address is empty.
+	e.isEnabled.Store(nodeAddress != "")
 }
 
 // currentHeight returns the latest committed block height.

--- a/extensions/tn_local/extension.go
+++ b/extensions/tn_local/extension.go
@@ -14,6 +14,12 @@ type Extension struct {
 	db        sql.DB
 	localDB   *LocalDB
 	isEnabled atomic.Bool
+	// nodeAddress is the lowercase 0x-prefixed Ethereum address derived from the
+	// node's secp256k1 operator key. It is the implicit data_provider for every
+	// local stream operation — clients never supply a data_provider. Empty when
+	// the node has no secp256k1 key (read-only / ed25519 nodes); in that case
+	// isEnabled stays false and all handlers return a clear error.
+	nodeAddress string
 	// height tracks the latest committed block height, updated by EndBlockHook.
 	// Local streams use the same created_at = block height semantics as consensus.
 	height atomic.Int64
@@ -40,11 +46,19 @@ func GetExtension() *Extension {
 // This preserves the pointer identity so that the admin server's registered
 // Svc reference remains valid. Called during sequential startup before the
 // server accepts requests.
-func (e *Extension) configure(logger log.Logger, db sql.DB, localDB *LocalDB) {
+//
+// nodeAddress must be the lowercase 0x-prefixed Ethereum address derived from
+// the node's secp256k1 key. If empty (no secp256k1 key available), the
+// extension stays disabled and all handlers return an error — local streams
+// require a stable operator identity to claim ownership of.
+func (e *Extension) configure(logger log.Logger, db sql.DB, localDB *LocalDB, nodeAddress string) {
 	e.logger = logger
 	e.db = db
 	e.localDB = localDB
-	e.isEnabled.Store(true)
+	e.nodeAddress = nodeAddress
+	if nodeAddress != "" {
+		e.isEnabled.Store(true)
+	}
 }
 
 // currentHeight returns the latest committed block height.

--- a/extensions/tn_local/get_index_test.go
+++ b/extensions/tn_local/get_index_test.go
@@ -20,13 +20,20 @@ func TestGetIndex_NilRequest(t *testing.T) {
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
 }
 
+func TestGetIndex_DisabledWhenNoNodeAddress(t *testing.T) {
+	ext := &Extension{db: &utils.MockDB{}}
+	_, rpcErr := ext.GetIndex(context.Background(), &GetIndexRequest{StreamID: testSID})
+	require.NotNil(t, rpcErr)
+	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)
+	require.Contains(t, rpcErr.Message, "tn_local is disabled")
+}
+
 func TestGetIndex_StreamNotFound(t *testing.T) {
 	mockDB := mockDBForQuery(0, "", nil)
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.GetIndex(context.Background(), &GetIndexRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
+		StreamID: testSID,
 	})
 	require.Nil(t, resp)
 	require.NotNil(t, rpcErr)
@@ -85,10 +92,9 @@ func TestGetIndex_Primitive_DefaultBaseTime(t *testing.T) {
 	from := int64(1000)
 	to := int64(5000)
 	resp, rpcErr := ext.GetIndex(context.Background(), &GetIndexRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
 	})
 	require.Nil(t, rpcErr, "expected no error, got: %v", rpcErr)
 	require.NotNil(t, resp)
@@ -139,11 +145,10 @@ func TestGetIndex_ExplicitBaseTime(t *testing.T) {
 	to := int64(5000)
 	baseTime := int64(2000)
 	resp, rpcErr := ext.GetIndex(context.Background(), &GetIndexRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
-		BaseTime:     &baseTime,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
+		BaseTime: &baseTime,
 	})
 	require.Nil(t, rpcErr)
 	require.NotNil(t, resp)
@@ -182,10 +187,9 @@ func TestGetIndex_BaseValueZero(t *testing.T) {
 	from := int64(1000)
 	to := int64(5000)
 	_, rpcErr := ext.GetIndex(context.Background(), &GetIndexRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -208,8 +212,7 @@ func TestGetIndex_EmptyStream(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.GetIndex(context.Background(), &GetIndexRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
+		StreamID: testSID,
 	})
 	require.Nil(t, rpcErr)
 	require.NotNil(t, resp)

--- a/extensions/tn_local/get_record_test.go
+++ b/extensions/tn_local/get_record_test.go
@@ -21,36 +21,31 @@ func TestGetRecord_NilRequest(t *testing.T) {
 	require.Contains(t, rpcErr.Message, "missing request")
 }
 
+func TestGetRecord_DisabledWhenNoNodeAddress(t *testing.T) {
+	ext := &Extension{db: &utils.MockDB{}}
+	_, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{StreamID: testSID})
+	require.NotNil(t, rpcErr)
+	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)
+	require.Contains(t, rpcErr.Message, "tn_local is disabled")
+}
+
 func TestGetRecord_StreamNotFound(t *testing.T) {
 	mockDB := mockDBWithStream(0, "", nil)
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
+		StreamID: testSID,
 	})
 	require.Nil(t, resp)
 	require.NotNil(t, rpcErr)
 	require.Contains(t, rpcErr.Message, "stream not found")
 }
 
-func TestGetRecord_InvalidDataProvider(t *testing.T) {
-	ext := newTestExtension(&utils.MockDB{})
-
-	_, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{
-		DataProvider: "invalid",
-		StreamID:     testSID,
-	})
-	require.NotNil(t, rpcErr)
-	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
-}
-
 func TestGetRecord_InvalidStreamID(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     "short",
+		StreamID: "short",
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -63,10 +58,9 @@ func TestGetRecord_FromAfterTo(t *testing.T) {
 	from := int64(2)
 	to := int64(1)
 	resp, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
 	})
 	require.Nil(t, resp)
 	require.NotNil(t, rpcErr)
@@ -82,8 +76,7 @@ func TestGetRecord_Primitive_LatestRecord(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
+		StreamID: testSID,
 	})
 	require.Nil(t, rpcErr)
 	require.NotNil(t, resp)
@@ -103,10 +96,9 @@ func TestGetRecord_Primitive_TimeRange(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
 	})
 	require.Nil(t, rpcErr)
 	require.NotNil(t, resp)
@@ -123,15 +115,36 @@ func TestGetRecord_Primitive_EmptyResult(t *testing.T) {
 	from := int64(1000)
 	to := int64(5000)
 	resp, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
 	})
 	require.Nil(t, rpcErr)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Records, "Records should be non-nil empty slice, not nil")
 	require.Empty(t, resp.Records)
+}
+
+func TestGetRecord_LookupUsesNodeAddress(t *testing.T) {
+	// Verify the stream lookup uses the node's own address.
+	var lookupDP string
+	mockDB := &utils.MockDB{
+		ExecuteFn: func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
+			if strings.Contains(stmt, "SELECT id, stream_type") && len(args) >= 2 {
+				lookupDP = args[0].(string)
+				return &kwilsql.ResultSet{
+					Columns: []string{"id", "stream_type"},
+					Rows:    [][]any{{int64(1), "primitive"}},
+				}, nil
+			}
+			return &kwilsql.ResultSet{Rows: [][]any{}}, nil
+		},
+	}
+	ext := newTestExtension(mockDB)
+
+	_, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{StreamID: testSID})
+	require.Nil(t, rpcErr)
+	require.Equal(t, testNodeAddress, lookupDP, "GetRecord must look up streams under the node's own address")
 }
 
 func TestGetRecord_Composed_Dispatches(t *testing.T) {
@@ -166,8 +179,7 @@ func TestGetRecord_Composed_Dispatches(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.GetRecord(context.Background(), &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
+		StreamID: testSID,
 	})
 	require.Nil(t, rpcErr)
 	require.NotNil(t, resp)

--- a/extensions/tn_local/handlers.go
+++ b/extensions/tn_local/handlers.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -19,7 +18,14 @@ import (
 // pgUniqueViolation is the PostgreSQL error code for unique_violation.
 const pgUniqueViolation = "23505"
 
-var ethAddrRegex = regexp.MustCompile(`^0x[0-9a-fA-F]{40}$`)
+// disabledError is the error every handler returns when the extension is not
+// enabled (e.g. the node has no secp256k1 operator key). Local stream
+// operations require a stable operator identity to claim ownership of, so
+// they cannot run on read-only or ed25519-only nodes.
+func disabledError() *jsonrpc.Error {
+	return jsonrpc.NewError(jsonrpc.ErrorInternal,
+		"tn_local is disabled: this node has no secp256k1 operator key", nil)
+}
 
 // validateStreamID checks that stream_id is 32 chars and starts with "st".
 func validateStreamID(streamID string) error {
@@ -36,14 +42,6 @@ func validateStreamID(streamID string) error {
 func validateStreamType(streamType string) error {
 	if streamType != "primitive" && streamType != "composed" {
 		return fmt.Errorf("stream_type must be 'primitive' or 'composed', got %q", streamType)
-	}
-	return nil
-}
-
-// validateDataProvider checks that data_provider is a valid Ethereum address (0x + 40 hex).
-func validateDataProvider(dataProvider string) error {
-	if !ethAddrRegex.MatchString(dataProvider) {
-		return fmt.Errorf("data_provider must be a valid Ethereum address (0x + 40 hex chars)")
 	}
 	return nil
 }
@@ -78,8 +76,8 @@ func validateWeight(weight string) error {
 // Mirrors consensus: uuid_generate_kwil(@txid||$data_provider||...).
 // Since local operations have no @txid, we include UnixNano for per-call
 // uniqueness (analogous to how @txid differs per transaction in consensus).
-func generateTaxonomyID(dataProvider, streamID, childDP, childSID string, index int) string {
-	h := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s|%s|%d|%d", dataProvider, streamID, childDP, childSID, index, time.Now().UnixNano())))
+func generateTaxonomyID(dataProvider, streamID, childSID string, index int) string {
+	h := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s|%d|%d", dataProvider, streamID, childSID, index, time.Now().UnixNano())))
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
 		h[0:4], h[4:6], h[6:8], h[8:10], h[10:16])
 }
@@ -98,19 +96,15 @@ func isDuplicateKeyError(err error) bool {
 	return strings.Contains(msg, "duplicate key") || strings.Contains(msg, "unique constraint")
 }
 
-// CreateStream creates a local stream.
+// CreateStream creates a local stream owned by the node operator.
 func (ext *Extension) CreateStream(ctx context.Context, req *CreateStreamRequest) (*CreateStreamResponse, *jsonrpc.Error) {
 	if req == nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "missing request", nil)
 	}
-
-	// Normalize data_provider to lowercase to match consensus behavior
-	// (consensus uses LOWER() in 001-common-actions.sql before insertion).
-	dataProvider := strings.ToLower(req.DataProvider)
-
-	if err := validateDataProvider(dataProvider); err != nil {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, err.Error(), nil)
+	if !ext.isEnabled.Load() {
+		return nil, disabledError()
 	}
+
 	if err := validateStreamID(req.StreamID); err != nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, err.Error(), nil)
 	}
@@ -118,9 +112,9 @@ func (ext *Extension) CreateStream(ctx context.Context, req *CreateStreamRequest
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, err.Error(), nil)
 	}
 
-	if err := ext.dbCreateStream(ctx, dataProvider, req.StreamID, req.StreamType); err != nil {
+	if err := ext.dbCreateStream(ctx, ext.nodeAddress, req.StreamID, req.StreamType); err != nil {
 		if isDuplicateKeyError(err) {
-			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream already exists: %s/%s", dataProvider, req.StreamID), nil)
+			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream already exists: %s", req.StreamID), nil)
 		}
 		ext.logger.Error("failed to create local stream", "error", err)
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to create stream", nil)
@@ -129,35 +123,33 @@ func (ext *Extension) CreateStream(ctx context.Context, req *CreateStreamRequest
 	return &CreateStreamResponse{}, nil
 }
 
-// InsertRecords inserts records into local primitive streams.
+// InsertRecords inserts records into local primitive streams owned by the node.
 // Mirrors the consensus insert_records action (003-primitive-insertion.sql):
-//   - Parallel arrays: data_provider[], stream_id[], event_time[], value[]
+//   - Parallel arrays: stream_id[], event_time[], value[]
 //   - Zero values are silently filtered (WHERE value != 0)
 //   - Multiple rows per (stream_ref, event_time) allowed (created_at versioning)
 //   - Returns empty response (consensus returns nothing)
+//
+// All records implicitly target streams owned by this node — no data_provider
+// on the wire.
 func (ext *Extension) InsertRecords(ctx context.Context, req *InsertRecordsRequest) (*InsertRecordsResponse, *jsonrpc.Error) {
 	if req == nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "missing request", nil)
 	}
+	if !ext.isEnabled.Load() {
+		return nil, disabledError()
+	}
 
-	n := len(req.DataProvider)
+	n := len(req.StreamID)
 	if n == 0 {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "records must not be empty", nil)
 	}
-	if n != len(req.StreamID) || n != len(req.EventTime) || n != len(req.Value) {
+	if n != len(req.EventTime) || n != len(req.Value) {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "array lengths mismatch", nil)
-	}
-
-	// Normalize data_providers to lowercase (consensus uses LOWER() in 001-common-actions.sql).
-	for i := range req.DataProvider {
-		req.DataProvider[i] = strings.ToLower(req.DataProvider[i])
 	}
 
 	// Validate all inputs upfront.
 	for i := 0; i < n; i++ {
-		if err := validateDataProvider(req.DataProvider[i]); err != nil {
-			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("record %d: %v", i, err), nil)
-		}
 		if err := validateStreamID(req.StreamID[i]); err != nil {
 			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("record %d: %v", i, err), nil)
 		}
@@ -170,26 +162,25 @@ func (ext *Extension) InsertRecords(ctx context.Context, req *InsertRecordsReque
 		}
 	}
 
-	// Resolve stream refs for unique (data_provider, stream_id) pairs.
-	type streamKey struct{ dp, sid string }
-	streamRefMap := make(map[streamKey]int64)
+	// Resolve stream refs for unique stream_ids (all owned by ext.nodeAddress).
+	streamRefMap := make(map[string]int64)
 	for i := 0; i < n; i++ {
-		key := streamKey{req.DataProvider[i], req.StreamID[i]}
-		if _, ok := streamRefMap[key]; ok {
+		sid := req.StreamID[i]
+		if _, ok := streamRefMap[sid]; ok {
 			continue
 		}
-		ref, stype, err := ext.dbLookupStreamRef(ctx, key.dp, key.sid)
+		ref, stype, err := ext.dbLookupStreamRef(ctx, ext.nodeAddress, sid)
 		if err != nil {
 			ext.logger.Error("failed to look up stream", "error", err)
 			return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to look up stream", nil)
 		}
 		if ref == 0 {
-			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream not found: %s/%s", key.dp, key.sid), nil)
+			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream not found: %s", sid), nil)
 		}
 		if stype != "primitive" {
-			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream %s/%s is not a primitive stream", key.dp, key.sid), nil)
+			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream %s is not a primitive stream", sid), nil)
 		}
-		streamRefMap[key] = ref
+		streamRefMap[sid] = ref
 	}
 
 	// Build resolved records, filtering zero values (mirrors consensus WHERE value != 0).
@@ -201,8 +192,7 @@ func (ext *Extension) InsertRecords(ctx context.Context, req *InsertRecordsReque
 		if f == 0 {
 			continue
 		}
-		key := streamKey{req.DataProvider[i], req.StreamID[i]}
-		streamRefs = append(streamRefs, streamRefMap[key])
+		streamRefs = append(streamRefs, streamRefMap[req.StreamID[i]])
 		eventTimes = append(eventTimes, req.EventTime[i])
 		values = append(values, req.Value[i])
 	}
@@ -219,28 +209,26 @@ func (ext *Extension) InsertRecords(ctx context.Context, req *InsertRecordsReque
 
 // InsertTaxonomy adds a taxonomy group to a local composed stream.
 // Mirrors the consensus insert_taxonomy action (004-composed-taxonomy.sql):
-//   - Parallel arrays: child_data_providers[], child_stream_ids[], weights[]
-//   - All children must exist in local storage (no cross-storage references)
+//   - Parallel arrays: child_stream_ids[], weights[]
+//   - All children are local streams owned by this node (no cross-DP children)
 //   - Increments group_sequence (MAX+1)
 //   - Returns empty response (consensus returns nothing)
 func (ext *Extension) InsertTaxonomy(ctx context.Context, req *InsertTaxonomyRequest) (*InsertTaxonomyResponse, *jsonrpc.Error) {
 	if req == nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "missing request", nil)
 	}
+	if !ext.isEnabled.Load() {
+		return nil, disabledError()
+	}
 
 	n := len(req.ChildStreamIDs)
 	if n == 0 {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "there must be at least 1 child", nil)
 	}
-	if n != len(req.ChildDataProviders) || n != len(req.Weights) {
+	if n != len(req.Weights) {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "child array lengths mismatch", nil)
 	}
 
-	// Normalize parent data_provider to lowercase (consensus: LOWER()).
-	dataProvider := strings.ToLower(req.DataProvider)
-	if err := validateDataProvider(dataProvider); err != nil {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, err.Error(), nil)
-	}
 	if err := validateStreamID(req.StreamID); err != nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, err.Error(), nil)
 	}
@@ -248,54 +236,45 @@ func (ext *Extension) InsertTaxonomy(ctx context.Context, req *InsertTaxonomyReq
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "start_date must be >= 0", nil)
 	}
 
-	// Normalize child data_providers to lowercase.
-	for i := range req.ChildDataProviders {
-		req.ChildDataProviders[i] = strings.ToLower(req.ChildDataProviders[i])
-	}
-
-	// Validate all children upfront.
-	type childKey struct{ dp, sid string }
-	seenChildren := make(map[childKey]struct{}, n)
+	// Validate all children upfront. Children share the node's data_provider,
+	// so dedup is purely by stream_id.
+	seenChildren := make(map[string]struct{}, n)
 	for i := 0; i < n; i++ {
-		if err := validateDataProvider(req.ChildDataProviders[i]); err != nil {
-			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("child %d: %v", i, err), nil)
-		}
 		if err := validateStreamID(req.ChildStreamIDs[i]); err != nil {
 			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("child %d: %v", i, err), nil)
 		}
 		if err := validateWeight(req.Weights[i]); err != nil {
 			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("child %d: %v", i, err), nil)
 		}
-		key := childKey{req.ChildDataProviders[i], req.ChildStreamIDs[i]}
-		if _, exists := seenChildren[key]; exists {
-			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("child %d: duplicate child_data_provider/child_stream_id tuple", i), nil)
+		if _, exists := seenChildren[req.ChildStreamIDs[i]]; exists {
+			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("child %d: duplicate child_stream_id", i), nil)
 		}
-		seenChildren[key] = struct{}{}
+		seenChildren[req.ChildStreamIDs[i]] = struct{}{}
 	}
 
 	// Verify parent stream exists and is composed.
-	parentRef, parentType, err := ext.dbLookupStreamRef(ctx, dataProvider, req.StreamID)
+	parentRef, parentType, err := ext.dbLookupStreamRef(ctx, ext.nodeAddress, req.StreamID)
 	if err != nil {
 		ext.logger.Error("failed to look up parent stream", "error", err)
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to look up parent stream", nil)
 	}
 	if parentRef == 0 {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("parent stream not found: %s/%s", dataProvider, req.StreamID), nil)
+		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("parent stream not found: %s", req.StreamID), nil)
 	}
 	if parentType != "composed" {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream %s/%s is not a composed stream", dataProvider, req.StreamID), nil)
+		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream %s is not a composed stream", req.StreamID), nil)
 	}
 
 	// Resolve all child stream refs (must exist in local storage).
 	childRefs := make([]int64, n)
 	for i := 0; i < n; i++ {
-		ref, _, lookupErr := ext.dbLookupStreamRef(ctx, req.ChildDataProviders[i], req.ChildStreamIDs[i])
+		ref, _, lookupErr := ext.dbLookupStreamRef(ctx, ext.nodeAddress, req.ChildStreamIDs[i])
 		if lookupErr != nil {
 			ext.logger.Error("failed to look up child stream", "error", lookupErr)
 			return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to look up child stream", nil)
 		}
 		if ref == 0 {
-			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("child stream not found in local storage: %s/%s", req.ChildDataProviders[i], req.ChildStreamIDs[i]), nil)
+			return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("child stream not found in local storage: %s", req.ChildStreamIDs[i]), nil)
 		}
 		childRefs[i] = ref
 	}
@@ -319,7 +298,7 @@ func (ext *Extension) InsertTaxonomy(ctx context.Context, req *InsertTaxonomyReq
 
 	createdAt := ext.currentHeight()
 	for i := 0; i < n; i++ {
-		taxonomyID := generateTaxonomyID(dataProvider, req.StreamID, req.ChildDataProviders[i], req.ChildStreamIDs[i], i)
+		taxonomyID := generateTaxonomyID(ext.nodeAddress, req.StreamID, req.ChildStreamIDs[i], i)
 		if insertErr := ext.dbInsertTaxonomyRow(ctx, tx, taxonomyID, parentRef, childRefs[i], req.Weights[i], startDate, groupSeq, createdAt); insertErr != nil {
 			ext.logger.Error("failed to insert taxonomy row", "error", insertErr)
 			return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to insert taxonomy", nil)
@@ -344,11 +323,10 @@ func (ext *Extension) GetRecord(ctx context.Context, req *GetRecordRequest) (*Ge
 	if req == nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "missing request", nil)
 	}
-
-	dataProvider := strings.ToLower(req.DataProvider)
-	if err := validateDataProvider(dataProvider); err != nil {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, err.Error(), nil)
+	if !ext.isEnabled.Load() {
+		return nil, disabledError()
 	}
+
 	if err := validateStreamID(req.StreamID); err != nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, err.Error(), nil)
 	}
@@ -358,13 +336,13 @@ func (ext *Extension) GetRecord(ctx context.Context, req *GetRecordRequest) (*Ge
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "from_time must be <= to_time", nil)
 	}
 
-	ref, stype, err := ext.dbLookupStreamRef(ctx, dataProvider, req.StreamID)
+	ref, stype, err := ext.dbLookupStreamRef(ctx, ext.nodeAddress, req.StreamID)
 	if err != nil {
 		ext.logger.Error("failed to look up stream", "error", err)
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to look up stream", nil)
 	}
 	if ref == 0 {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream not found: %s/%s", dataProvider, req.StreamID), nil)
+		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream not found: %s", req.StreamID), nil)
 	}
 
 	var records []RecordOutput
@@ -395,11 +373,10 @@ func (ext *Extension) GetIndex(ctx context.Context, req *GetIndexRequest) (*GetI
 	if req == nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "missing request", nil)
 	}
-
-	dataProvider := strings.ToLower(req.DataProvider)
-	if err := validateDataProvider(dataProvider); err != nil {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, err.Error(), nil)
+	if !ext.isEnabled.Load() {
+		return nil, disabledError()
 	}
+
 	if err := validateStreamID(req.StreamID); err != nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, err.Error(), nil)
 	}
@@ -409,13 +386,13 @@ func (ext *Extension) GetIndex(ctx context.Context, req *GetIndexRequest) (*GetI
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "from_time must be <= to_time", nil)
 	}
 
-	ref, stype, err := ext.dbLookupStreamRef(ctx, dataProvider, req.StreamID)
+	ref, stype, err := ext.dbLookupStreamRef(ctx, ext.nodeAddress, req.StreamID)
 	if err != nil {
 		ext.logger.Error("failed to look up stream", "error", err)
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to look up stream", nil)
 	}
 	if ref == 0 {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream not found: %s/%s", dataProvider, req.StreamID), nil)
+		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, fmt.Sprintf("stream not found: %s", req.StreamID), nil)
 	}
 
 	// Resolve base_time: default to first event_time in the stream
@@ -500,8 +477,11 @@ func (ext *Extension) GetIndex(ctx context.Context, req *GetIndexRequest) (*GetI
 	return &GetIndexResponse{Records: indexRecords}, nil
 }
 
-// ListStreams lists all local streams.
+// ListStreams lists all local streams owned by this node.
 func (ext *Extension) ListStreams(ctx context.Context, _ *ListStreamsRequest) (*ListStreamsResponse, *jsonrpc.Error) {
+	if !ext.isEnabled.Load() {
+		return nil, disabledError()
+	}
 	streams, err := ext.dbListStreams(ctx)
 	if err != nil {
 		ext.logger.Error("failed to list streams", "error", err)

--- a/extensions/tn_local/handlers.go
+++ b/extensions/tn_local/handlers.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/shopspring/decimal"
@@ -73,11 +72,14 @@ func validateWeight(weight string) error {
 }
 
 // generateTaxonomyID creates a unique UUID from taxonomy components.
-// Mirrors consensus: uuid_generate_kwil(@txid||$data_provider||...).
-// Since local operations have no @txid, we include UnixNano for per-call
-// uniqueness (analogous to how @txid differs per transaction in consensus).
-func generateTaxonomyID(dataProvider, streamID, childSID string, index int) string {
-	h := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s|%d|%d", dataProvider, streamID, childSID, index, time.Now().UnixNano())))
+// Mirrors consensus: uuid_generate_kwil(@txid||$data_provider||$stream_id||$child||$i).
+// Since local operations have no @txid, we use groupSeq — an int assigned by
+// dbGetNextGroupSequence under an advisory lock, guaranteed unique per
+// (parent stream, insertion call). Together with index (unique per child in
+// a single call), this makes IDs deterministic and collision-free without
+// depending on wall-clock time.
+func generateTaxonomyID(dataProvider, streamID, childSID string, groupSeq, index int) string {
+	h := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%s|%d|%d", dataProvider, streamID, childSID, groupSeq, index)))
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
 		h[0:4], h[4:6], h[6:8], h[8:10], h[10:16])
 }
@@ -298,7 +300,7 @@ func (ext *Extension) InsertTaxonomy(ctx context.Context, req *InsertTaxonomyReq
 
 	createdAt := ext.currentHeight()
 	for i := 0; i < n; i++ {
-		taxonomyID := generateTaxonomyID(ext.nodeAddress, req.StreamID, req.ChildStreamIDs[i], i)
+		taxonomyID := generateTaxonomyID(ext.nodeAddress, req.StreamID, req.ChildStreamIDs[i], groupSeq, i)
 		if insertErr := ext.dbInsertTaxonomyRow(ctx, tx, taxonomyID, parentRef, childRefs[i], req.Weights[i], startDate, groupSeq, createdAt); insertErr != nil {
 			ext.logger.Error("failed to insert taxonomy row", "error", insertErr)
 			return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to insert taxonomy", nil)

--- a/extensions/tn_local/insert_records_test.go
+++ b/extensions/tn_local/insert_records_test.go
@@ -44,7 +44,7 @@ func mockDBWithStream(streamRef int64, streamType string, executeFn func(ctx con
 	}
 }
 
-const testDP = "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832"
+// testSID is the canonical 32-char stream ID used by handler tests.
 const testSID = "st00000000000000000000000000test"
 
 func TestInsertRecords_NilRequest(t *testing.T) {
@@ -57,14 +57,25 @@ func TestInsertRecords_NilRequest(t *testing.T) {
 	require.Contains(t, rpcErr.Message, "missing request")
 }
 
+func TestInsertRecords_DisabledWhenNoNodeAddress(t *testing.T) {
+	ext := &Extension{db: &utils.MockDB{}}
+	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
+		StreamID:  []string{testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"1.0"},
+	})
+	require.NotNil(t, rpcErr)
+	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)
+	require.Contains(t, rpcErr.Message, "tn_local is disabled")
+}
+
 func TestInsertRecords_EmptyArrays(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{},
-		StreamID:     []string{},
-		EventTime:    []int64{},
-		Value:        []string{},
+		StreamID:  []string{},
+		EventTime: []int64{},
+		Value:     []string{},
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -75,10 +86,9 @@ func TestInsertRecords_ArrayLengthMismatch(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP, testDP},
-		StreamID:     []string{testSID},
-		EventTime:    []int64{1000},
-		Value:        []string{"1.0"},
+		StreamID:  []string{testSID, testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"1.0"},
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -96,10 +106,9 @@ func TestInsertRecords_Success(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP, testDP},
-		StreamID:     []string{testSID, testSID},
-		EventTime:    []int64{1000, 2000},
-		Value:        []string{"123.456", "789.012"},
+		StreamID:  []string{testSID, testSID},
+		EventTime: []int64{1000, 2000},
+		Value:     []string{"123.456", "789.012"},
 	})
 
 	require.Nil(t, rpcErr, "expected no error")
@@ -126,6 +135,40 @@ func TestInsertRecords_Success(t *testing.T) {
 	require.Equal(t, "789.012", capturedArgs[1][2])
 }
 
+func TestInsertRecords_LookupUsesNodeAddress(t *testing.T) {
+	// Verify that the stream lookup uses the node's own address, not anything
+	// caller-controlled. This is the core regression test for the auth fix.
+	var lookupDP string
+	mockDB := &utils.MockDB{
+		ExecuteFn: func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
+			if strings.Contains(stmt, "SELECT") && len(args) >= 2 {
+				lookupDP = args[0].(string)
+				return &kwilsql.ResultSet{
+					Columns: []string{"id", "stream_type"},
+					Rows:    [][]any{{int64(42), "primitive"}},
+				}, nil
+			}
+			return &kwilsql.ResultSet{}, nil
+		},
+		BeginTxFn: func(ctx context.Context) (kwilsql.Tx, error) {
+			return &utils.MockTx{
+				ExecuteFn: func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
+					return &kwilsql.ResultSet{}, nil
+				},
+			}, nil
+		},
+	}
+	ext := newTestExtension(mockDB)
+
+	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
+		StreamID:  []string{testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"1.0"},
+	})
+	require.Nil(t, rpcErr)
+	require.Equal(t, testNodeAddress, lookupDP, "stream lookup must use the node's own address")
+}
+
 func TestInsertRecords_ZeroValuesFiltered(t *testing.T) {
 	var capturedArgs [][]any
 	mockDB := mockDBWithStream(42, "primitive", func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
@@ -135,10 +178,9 @@ func TestInsertRecords_ZeroValuesFiltered(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP, testDP, testDP},
-		StreamID:     []string{testSID, testSID, testSID},
-		EventTime:    []int64{1000, 2000, 3000},
-		Value:        []string{"1.5", "0", "2.5"},
+		StreamID:  []string{testSID, testSID, testSID},
+		EventTime: []int64{1000, 2000, 3000},
+		Value:     []string{"1.5", "0", "2.5"},
 	})
 
 	require.Nil(t, rpcErr)
@@ -161,10 +203,9 @@ func TestInsertRecords_AllZerosNoInsert(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP},
-		StreamID:     []string{testSID},
-		EventTime:    []int64{1000},
-		Value:        []string{"0"},
+		StreamID:  []string{testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"0"},
 	})
 
 	require.Nil(t, rpcErr)
@@ -177,10 +218,9 @@ func TestInsertRecords_StreamNotFound(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP},
-		StreamID:     []string{testSID},
-		EventTime:    []int64{1000},
-		Value:        []string{"1.0"},
+		StreamID:  []string{testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"1.0"},
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -192,10 +232,9 @@ func TestInsertRecords_ComposedStreamRejected(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP},
-		StreamID:     []string{testSID},
-		EventTime:    []int64{1000},
-		Value:        []string{"1.0"},
+		StreamID:  []string{testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"1.0"},
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -209,38 +248,22 @@ func TestInsertRecords_DBError(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP},
-		StreamID:     []string{testSID},
-		EventTime:    []int64{1000},
-		Value:        []string{"1.0"},
+		StreamID:  []string{testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"1.0"},
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)
 	require.Contains(t, rpcErr.Message, "failed to insert records")
 }
 
-func TestInsertRecords_InvalidDataProvider(t *testing.T) {
-	ext := newTestExtension(&utils.MockDB{})
-
-	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{"invalid"},
-		StreamID:     []string{testSID},
-		EventTime:    []int64{1000},
-		Value:        []string{"1.0"},
-	})
-	require.NotNil(t, rpcErr)
-	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
-	require.Contains(t, rpcErr.Message, "data_provider must be a valid Ethereum address")
-}
-
 func TestInsertRecords_InvalidStreamID(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP},
-		StreamID:     []string{"bad"},
-		EventTime:    []int64{1000},
-		Value:        []string{"1.0"},
+		StreamID:  []string{"bad"},
+		EventTime: []int64{1000},
+		Value:     []string{"1.0"},
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -265,10 +288,9 @@ func TestInsertRecords_InvalidValue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-				DataProvider: []string{testDP},
-				StreamID:     []string{testSID},
-				EventTime:    []int64{1000},
-				Value:        []string{tt.value},
+				StreamID:  []string{testSID},
+				EventTime: []int64{1000},
+				Value:     []string{tt.value},
 			})
 			require.NotNil(t, rpcErr)
 			require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -282,10 +304,9 @@ func TestInsertRecords_InvalidValueAtIndex(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP, testDP},
-		StreamID:     []string{testSID, testSID},
-		EventTime:    []int64{1000, 2000},
-		Value:        []string{"1.0", "bad"},
+		StreamID:  []string{testSID, testSID},
+		EventTime: []int64{1000, 2000},
+		Value:     []string{"1.0", "bad"},
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -301,10 +322,9 @@ func TestInsertRecords_LookupDBError(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertRecords(context.Background(), &InsertRecordsRequest{
-		DataProvider: []string{testDP},
-		StreamID:     []string{testSID},
-		EventTime:    []int64{1000},
-		Value:        []string{"1.0"},
+		StreamID:  []string{testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"1.0"},
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)

--- a/extensions/tn_local/insert_taxonomy_test.go
+++ b/extensions/tn_local/insert_taxonomy_test.go
@@ -17,10 +17,11 @@ const testChildSID1 = "st000000000000000000000000child1"
 const testChildSID2 = "st000000000000000000000000child2"
 
 // mockDBForTaxonomy returns a MockDB that simulates stream lookups for taxonomy tests.
-// parentSID is the parent stream ID (used to distinguish parent from child lookups).
-// parentRef/parentType is returned for the parent stream lookup.
-// childRefs maps "dp/sid" -> ref for child lookups.
-// executeFn captures INSERT/SELECT statements in transactions.
+// All children/parents implicitly belong to the node operator (testNodeAddress).
+//
+//   - parentRef/parentType is returned for the parent stream lookup (matched by stream_id).
+//   - childRefs maps child stream_id -> ref for child lookups.
+//   - executeFn captures INSERT/SELECT statements in transactions.
 func mockDBForTaxonomy(
 	parentRef int64, parentType string,
 	childRefs map[string]int64,
@@ -28,12 +29,10 @@ func mockDBForTaxonomy(
 ) *utils.MockDB {
 	lookupFn := func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
 		if strings.Contains(stmt, "SELECT") && len(args) >= 2 {
-			dp, _ := args[0].(string)
 			sid, _ := args[1].(string)
-			key := dp + "/" + sid
 
-			// First check the childRefs map
-			if ref, ok := childRefs[key]; ok {
+			// First check the childRefs map (keyed by stream_id only).
+			if ref, ok := childRefs[sid]; ok {
 				return &kwilsql.ResultSet{
 					Columns: []string{"id", "stream_type"},
 					Rows:    [][]any{{ref, "primitive"}},
@@ -89,16 +88,26 @@ func TestInsertTaxonomy_NilRequest(t *testing.T) {
 	require.Contains(t, rpcErr.Message, "missing request")
 }
 
+func TestInsertTaxonomy_DisabledWhenNoNodeAddress(t *testing.T) {
+	ext := &Extension{db: &utils.MockDB{}}
+	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+	})
+	require.NotNil(t, rpcErr)
+	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)
+	require.Contains(t, rpcErr.Message, "tn_local is disabled")
+}
+
 func TestInsertTaxonomy_EmptyChildren(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{},
-		ChildStreamIDs:     []string{},
-		Weights:            []string{},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{},
+		Weights:        []string{},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -109,12 +118,10 @@ func TestInsertTaxonomy_ArrayLengthMismatch(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP, testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1, testChildSID2},
+		Weights:        []string{"1.0"},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -122,10 +129,9 @@ func TestInsertTaxonomy_ArrayLengthMismatch(t *testing.T) {
 }
 
 func TestInsertTaxonomy_Success(t *testing.T) {
-	lowDP := strings.ToLower(testDP)
 	childRefs := map[string]int64{
-		lowDP + "/" + testChildSID1: 10,
-		lowDP + "/" + testChildSID2: 11,
+		testChildSID1: 10,
+		testChildSID2: 11,
 	}
 
 	var capturedStmts []string
@@ -138,12 +144,10 @@ func TestInsertTaxonomy_Success(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP, testDP},
-		ChildStreamIDs:     []string{testChildSID1, testChildSID2},
-		Weights:            []string{"0.6", "0.4"},
-		StartDate:          1000,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1, testChildSID2},
+		Weights:        []string{"0.6", "0.4"},
+		StartDate:      1000,
 	})
 
 	require.Nil(t, rpcErr, "expected no error")
@@ -160,9 +164,8 @@ func TestInsertTaxonomy_Success(t *testing.T) {
 }
 
 func TestInsertTaxonomy_SingleChild(t *testing.T) {
-	lowDP := strings.ToLower(testDP)
 	childRefs := map[string]int64{
-		lowDP + "/" + testChildSID1: 10,
+		testChildSID1: 10,
 	}
 
 	var insertCalled bool
@@ -174,19 +177,17 @@ func TestInsertTaxonomy_SingleChild(t *testing.T) {
 			require.Equal(t, int64(100), args[1]) // parent_ref
 			require.Equal(t, int64(10), args[2])  // child_ref
 			require.Equal(t, "1.0", args[3])      // weight
-			require.Equal(t, int64(500), args[4])  // start_date
+			require.Equal(t, int64(500), args[4]) // start_date
 		}
 		return &kwilsql.ResultSet{}, nil
 	})
 	ext := newTestExtension(mockDB)
 
 	resp, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          500,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+		StartDate:      500,
 	})
 
 	require.Nil(t, rpcErr)
@@ -194,17 +195,66 @@ func TestInsertTaxonomy_SingleChild(t *testing.T) {
 	require.True(t, insertCalled, "INSERT should have been called")
 }
 
+func TestInsertTaxonomy_LookupUsesNodeAddress(t *testing.T) {
+	// Verify both parent and child lookups use the node's own address.
+	var parentDP, childDP string
+	lookupCalls := 0
+	mockDB := &utils.MockDB{
+		ExecuteFn: func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
+			if strings.Contains(stmt, "SELECT") && len(args) >= 2 {
+				lookupCalls++
+				dp := args[0].(string)
+				if lookupCalls == 1 {
+					parentDP = dp
+					return &kwilsql.ResultSet{
+						Columns: []string{"id", "stream_type"},
+						Rows:    [][]any{{int64(100), "composed"}},
+					}, nil
+				}
+				childDP = dp
+				return &kwilsql.ResultSet{
+					Columns: []string{"id", "stream_type"},
+					Rows:    [][]any{{int64(10), "primitive"}},
+				}, nil
+			}
+			return &kwilsql.ResultSet{}, nil
+		},
+		BeginTxFn: func(ctx context.Context) (kwilsql.Tx, error) {
+			return &utils.MockTx{
+				ExecuteFn: func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
+					if strings.Contains(stmt, "MAX(group_sequence)") {
+						return &kwilsql.ResultSet{
+							Columns: []string{"next_seq"},
+							Rows:    [][]any{{int64(1)}},
+						}, nil
+					}
+					return &kwilsql.ResultSet{}, nil
+				},
+			}, nil
+		},
+	}
+	ext := newTestExtension(mockDB)
+
+	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+	})
+
+	require.Nil(t, rpcErr)
+	require.Equal(t, testNodeAddress, parentDP, "parent lookup must use the node's own address")
+	require.Equal(t, testNodeAddress, childDP, "child lookup must use the node's own address")
+}
+
 func TestInsertTaxonomy_ParentNotFound(t *testing.T) {
 	mockDB := mockDBForTaxonomy(0, "", nil, nil)
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -216,12 +266,10 @@ func TestInsertTaxonomy_ParentNotComposed(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -234,76 +282,38 @@ func TestInsertTaxonomy_ChildNotFound(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
 	require.Contains(t, rpcErr.Message, "child stream not found in local storage")
 }
 
-func TestInsertTaxonomy_InvalidParentDataProvider(t *testing.T) {
-	ext := newTestExtension(&utils.MockDB{})
-
-	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       "invalid",
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
-	})
-	require.NotNil(t, rpcErr)
-	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
-	require.Contains(t, rpcErr.Message, "data_provider must be a valid Ethereum address")
-}
-
 func TestInsertTaxonomy_InvalidParentStreamID(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           "bad",
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
+		StreamID:       "bad",
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
 	require.Contains(t, rpcErr.Message, "stream_id must be exactly 32 characters")
 }
 
-func TestInsertTaxonomy_InvalidChildDataProvider(t *testing.T) {
-	ext := newTestExtension(&utils.MockDB{})
-
-	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{"bad_address"},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
-	})
-	require.NotNil(t, rpcErr)
-	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
-	require.Contains(t, rpcErr.Message, "child 0: data_provider must be a valid Ethereum address")
-}
-
 func TestInsertTaxonomy_InvalidChildStreamID(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{"short"},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{"short"},
+		Weights:        []string{"1.0"},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -327,12 +337,10 @@ func TestInsertTaxonomy_InvalidWeight(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ext := newTestExtension(&utils.MockDB{})
 			_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-				DataProvider:       testDP,
-				StreamID:           testComposedSID,
-				ChildDataProviders: []string{testDP},
-				ChildStreamIDs:     []string{testChildSID1},
-				Weights:            []string{tt.weight},
-				StartDate:          0,
+				StreamID:       testComposedSID,
+				ChildStreamIDs: []string{testChildSID1},
+				Weights:        []string{tt.weight},
+				StartDate:      0,
 			})
 			require.NotNil(t, rpcErr)
 			require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -345,39 +353,19 @@ func TestInsertTaxonomy_DuplicateChild(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP, testDP},
-		ChildStreamIDs:     []string{testChildSID1, testChildSID1},
-		Weights:            []string{"0.5", "0.5"},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1, testChildSID1},
+		Weights:        []string{"0.5", "0.5"},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
-	require.Contains(t, rpcErr.Message, "child 1: duplicate child_data_provider/child_stream_id tuple")
-}
-
-func TestInsertTaxonomy_DuplicateChildMixedCase(t *testing.T) {
-	ext := newTestExtension(&utils.MockDB{})
-
-	// Same address, different casing — should still detect as duplicate after normalization
-	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{"0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832", "0xec36224a679218ae28fcece8d3c68595b87dd832"},
-		ChildStreamIDs:     []string{testChildSID1, testChildSID1},
-		Weights:            []string{"0.5", "0.5"},
-		StartDate:          0,
-	})
-	require.NotNil(t, rpcErr)
-	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
-	require.Contains(t, rpcErr.Message, "child 1: duplicate child_data_provider/child_stream_id tuple")
+	require.Contains(t, rpcErr.Message, "child 1: duplicate child_stream_id")
 }
 
 func TestInsertTaxonomy_DBInsertError(t *testing.T) {
-	lowDP := strings.ToLower(testDP)
 	childRefs := map[string]int64{
-		lowDP + "/" + testChildSID1: 10,
+		testChildSID1: 10,
 	}
 
 	mockDB := mockDBForTaxonomy(100, "composed", childRefs, func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
@@ -389,84 +377,14 @@ func TestInsertTaxonomy_DBInsertError(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)
 	require.Contains(t, rpcErr.Message, "failed to insert taxonomy")
-}
-
-func TestInsertTaxonomy_LowercaseNormalization(t *testing.T) {
-	mixedCaseDP := "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832"
-	lowDP := strings.ToLower(mixedCaseDP)
-	childRefs := map[string]int64{
-		lowDP + "/" + testChildSID1: 10,
-	}
-
-	var capturedParentDP string
-	var capturedChildDP string
-
-	// Use a custom mock that captures the lowercased lookup args
-	lookupCalls := 0
-	mockDB := &utils.MockDB{
-		ExecuteFn: func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
-			if strings.Contains(stmt, "SELECT") && len(args) >= 2 {
-				lookupCalls++
-				dp := args[0].(string)
-				sid := args[1].(string)
-				if lookupCalls == 1 {
-					capturedParentDP = dp
-					return &kwilsql.ResultSet{
-						Columns: []string{"id", "stream_type"},
-						Rows:    [][]any{{int64(100), "composed"}},
-					}, nil
-				}
-				capturedChildDP = dp
-				key := dp + "/" + sid
-				if ref, ok := childRefs[key]; ok {
-					return &kwilsql.ResultSet{
-						Columns: []string{"id", "stream_type"},
-						Rows:    [][]any{{ref, "primitive"}},
-					}, nil
-				}
-				return &kwilsql.ResultSet{Rows: [][]any{}}, nil
-			}
-			return &kwilsql.ResultSet{}, nil
-		},
-		BeginTxFn: func(ctx context.Context) (kwilsql.Tx, error) {
-			return &utils.MockTx{
-				ExecuteFn: func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
-					if strings.Contains(stmt, "MAX(group_sequence)") {
-						return &kwilsql.ResultSet{
-							Columns: []string{"next_seq"},
-							Rows:    [][]any{{int64(1)}},
-						}, nil
-					}
-					return &kwilsql.ResultSet{}, nil
-				},
-			}, nil
-		},
-	}
-	ext := newTestExtension(mockDB)
-
-	resp, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       mixedCaseDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{mixedCaseDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
-	})
-
-	require.Nil(t, rpcErr)
-	require.NotNil(t, resp)
-	require.Equal(t, lowDP, capturedParentDP, "parent data_provider should be lowercased")
-	require.Equal(t, lowDP, capturedChildDP, "child data_provider should be lowercased")
 }
 
 func TestInsertTaxonomy_ParentLookupDBError(t *testing.T) {
@@ -478,12 +396,10 @@ func TestInsertTaxonomy_ParentLookupDBError(t *testing.T) {
 	ext := newTestExtension(mockDB)
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+		StartDate:      0,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInternal), rpcErr.Code)
@@ -494,12 +410,10 @@ func TestInsertTaxonomy_NegativeStartDate(t *testing.T) {
 	ext := newTestExtension(&utils.MockDB{})
 
 	_, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"1.0"},
-		StartDate:          -1,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"1.0"},
+		StartDate:      -1,
 	})
 	require.NotNil(t, rpcErr)
 	require.Equal(t, jsonrpc.ErrorCode(jsonrpc.ErrorInvalidParams), rpcErr.Code)
@@ -507,9 +421,8 @@ func TestInsertTaxonomy_NegativeStartDate(t *testing.T) {
 }
 
 func TestInsertTaxonomy_ZeroWeight(t *testing.T) {
-	lowDP := strings.ToLower(testDP)
 	childRefs := map[string]int64{
-		lowDP + "/" + testChildSID1: 10,
+		testChildSID1: 10,
 	}
 
 	mockDB := mockDBForTaxonomy(100, "composed", childRefs, func(ctx context.Context, stmt string, args ...any) (*kwilsql.ResultSet, error) {
@@ -519,12 +432,10 @@ func TestInsertTaxonomy_ZeroWeight(t *testing.T) {
 
 	// Zero weight should be allowed (non-negative)
 	resp, rpcErr := ext.InsertTaxonomy(context.Background(), &InsertTaxonomyRequest{
-		DataProvider:       testDP,
-		StreamID:           testComposedSID,
-		ChildDataProviders: []string{testDP},
-		ChildStreamIDs:     []string{testChildSID1},
-		Weights:            []string{"0"},
-		StartDate:          0,
+		StreamID:       testComposedSID,
+		ChildStreamIDs: []string{testChildSID1},
+		Weights:        []string{"0"},
+		StartDate:      0,
 	})
 	require.Nil(t, rpcErr)
 	require.NotNil(t, resp)

--- a/extensions/tn_local/query_integration_test.go
+++ b/extensions/tn_local/query_integration_test.go
@@ -74,8 +74,9 @@ func setupIntegrationDB(t *testing.T) *Extension {
 	}
 
 	ext := &Extension{
-		logger: logger,
-		db:     wrapper,
+		logger:      logger,
+		db:          wrapper,
+		nodeAddress: testNodeAddress,
 	}
 	ext.isEnabled.Store(true)
 
@@ -93,25 +94,22 @@ func TestIntegration_PrimitiveGetRecord(t *testing.T) {
 
 	// Create a primitive stream
 	_, rpcErr := ext.CreateStream(ctx, &CreateStreamRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		StreamType:   "primitive",
+		StreamID:   testSID,
+		StreamType: "primitive",
 	})
 	require.Nil(t, rpcErr, "create stream failed: %v", rpcErr)
 
 	// Insert records
 	_, rpcErr = ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{testDP, testDP, testDP, testDP, testDP},
-		StreamID:     []string{testSID, testSID, testSID, testSID, testSID},
-		EventTime:    []int64{1000, 2000, 3000, 4000, 5000},
-		Value:        []string{"10.5", "20.0", "30.75", "40.0", "50.25"},
+		StreamID:  []string{testSID, testSID, testSID, testSID, testSID},
+		EventTime: []int64{1000, 2000, 3000, 4000, 5000},
+		Value:     []string{"10.5", "20.0", "30.75", "40.0", "50.25"},
 	})
 	require.Nil(t, rpcErr, "insert records failed: %v", rpcErr)
 
 	// Test 1: Latest record (both nil)
 	resp, rpcErr := ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
+		StreamID: testSID,
 	})
 	require.Nil(t, rpcErr)
 	require.Len(t, resp.Records, 1, "latest record should return 1 row")
@@ -123,10 +121,9 @@ func TestIntegration_PrimitiveGetRecord(t *testing.T) {
 	from := int64(1500)
 	to := int64(4000)
 	resp, rpcErr = ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
 	})
 	require.Nil(t, rpcErr)
 	require.Len(t, resp.Records, 4, "should have anchor + 3 interval records")
@@ -139,10 +136,9 @@ func TestIntegration_PrimitiveGetRecord(t *testing.T) {
 	from = int64(9000)
 	to = int64(9999)
 	resp, rpcErr = ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
 	})
 	require.Nil(t, rpcErr)
 	require.Len(t, resp.Records, 1, "should have exactly 1 anchor record")
@@ -154,17 +150,15 @@ func TestIntegration_PrimitiveGetIndex(t *testing.T) {
 	ctx := context.Background()
 
 	_, rpcErr := ext.CreateStream(ctx, &CreateStreamRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		StreamType:   "primitive",
+		StreamID:   testSID,
+		StreamType: "primitive",
 	})
 	require.Nil(t, rpcErr)
 
 	_, rpcErr = ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{testDP, testDP, testDP},
-		StreamID:     []string{testSID, testSID, testSID},
-		EventTime:    []int64{1000, 2000, 3000},
-		Value:        []string{"10.0", "20.0", "30.0"},
+		StreamID:  []string{testSID, testSID, testSID},
+		EventTime: []int64{1000, 2000, 3000},
+		Value:     []string{"10.0", "20.0", "30.0"},
 	})
 	require.Nil(t, rpcErr)
 
@@ -173,10 +167,9 @@ func TestIntegration_PrimitiveGetIndex(t *testing.T) {
 	from := int64(500)
 	to := int64(5000)
 	resp, rpcErr := ext.GetIndex(ctx, &GetIndexRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
 	})
 	require.Nil(t, rpcErr, "get_index failed: %v", rpcErr)
 	require.Len(t, resp.Records, 3)
@@ -191,11 +184,10 @@ func TestIntegration_PrimitiveGetIndex(t *testing.T) {
 	// Index = (value / 20) * 100 → 50, 100, 150
 	baseTime := int64(2000)
 	resp, rpcErr = ext.GetIndex(ctx, &GetIndexRequest{
-		DataProvider: testDP,
-		StreamID:     testSID,
-		FromTime:     &from,
-		ToTime:       &to,
-		BaseTime:     &baseTime,
+		StreamID: testSID,
+		FromTime: &from,
+		ToTime:   &to,
+		BaseTime: &baseTime,
 	})
 	require.Nil(t, rpcErr, "get_index with base_time failed: %v", rpcErr)
 	require.Len(t, resp.Records, 3)
@@ -218,15 +210,15 @@ func TestIntegration_ListStreams(t *testing.T) {
 
 	// Create some streams
 	streams := []struct {
-		dp, sid, stype string
+		sid, stype string
 	}{
-		{testDP, "st00000000000000000000000000aaaa", "primitive"},
-		{testDP, "st00000000000000000000000000bbbb", "composed"},
-		{testDP, "st00000000000000000000000000cccc", "primitive"},
+		{"st00000000000000000000000000aaaa", "primitive"},
+		{"st00000000000000000000000000bbbb", "composed"},
+		{"st00000000000000000000000000cccc", "primitive"},
 	}
 	for _, s := range streams {
 		_, rpcErr := ext.CreateStream(ctx, &CreateStreamRequest{
-			DataProvider: s.dp, StreamID: s.sid, StreamType: s.stype,
+			StreamID: s.sid, StreamType: s.stype,
 		})
 		require.Nil(t, rpcErr, "create stream %s failed", s.sid)
 	}
@@ -239,6 +231,9 @@ func TestIntegration_ListStreams(t *testing.T) {
 	types := make(map[string]int)
 	for _, s := range resp.Streams {
 		types[s.StreamType]++
+		// list_streams response mirrors consensus shape — DataProvider is always
+		// the node's own address (redundant but kept for parity).
+		require.Equal(t, testNodeAddress, s.DataProvider)
 	}
 	require.Equal(t, 2, types["primitive"])
 	require.Equal(t, 1, types["composed"])
@@ -249,16 +244,15 @@ func TestIntegration_GapFilling(t *testing.T) {
 	ctx := context.Background()
 
 	_, rpcErr := ext.CreateStream(ctx, &CreateStreamRequest{
-		DataProvider: testDP, StreamID: testSID, StreamType: "primitive",
+		StreamID: testSID, StreamType: "primitive",
 	})
 	require.Nil(t, rpcErr)
 
 	// Insert sparse data: values at 1000, 3000, 5000
 	_, rpcErr = ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{testDP, testDP, testDP},
-		StreamID:     []string{testSID, testSID, testSID},
-		EventTime:    []int64{1000, 3000, 5000},
-		Value:        []string{"10.0", "30.0", "50.0"},
+		StreamID:  []string{testSID, testSID, testSID},
+		EventTime: []int64{1000, 3000, 5000},
+		Value:     []string{"10.0", "30.0", "50.0"},
 	})
 	require.Nil(t, rpcErr)
 
@@ -267,7 +261,7 @@ func TestIntegration_GapFilling(t *testing.T) {
 	from := int64(2000)
 	to := int64(4000)
 	resp, rpcErr := ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: testDP, StreamID: testSID,
+		StreamID: testSID,
 		FromTime: &from, ToTime: &to,
 	})
 	require.Nil(t, rpcErr)
@@ -292,32 +286,30 @@ func TestIntegration_HeightAsCreatedAt(t *testing.T) {
 	ext.height.Store(100)
 
 	_, rpcErr := ext.CreateStream(ctx, &CreateStreamRequest{
-		DataProvider: testDP, StreamID: testSID, StreamType: "primitive",
+		StreamID: testSID, StreamType: "primitive",
 	})
 	require.Nil(t, rpcErr)
 
 	// Insert at height 100
 	_, rpcErr = ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{testDP},
-		StreamID:     []string{testSID},
-		EventTime:    []int64{1000},
-		Value:        []string{"10.0"},
+		StreamID:  []string{testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"10.0"},
 	})
 	require.Nil(t, rpcErr)
 
 	// Advance height and insert updated value for same event_time
 	ext.height.Store(200)
 	_, rpcErr = ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{testDP},
-		StreamID:     []string{testSID},
-		EventTime:    []int64{1000},
-		Value:        []string{"99.0"},
+		StreamID:  []string{testSID},
+		EventTime: []int64{1000},
+		Value:     []string{"99.0"},
 	})
 	require.Nil(t, rpcErr)
 
 	// Query: should get latest value (created_at=200 wins over 100)
 	resp, rpcErr := ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: testDP, StreamID: testSID,
+		StreamID: testSID,
 	})
 	require.Nil(t, rpcErr)
 	require.Len(t, resp.Records, 1)
@@ -335,7 +327,6 @@ func TestIntegration_HeightAsCreatedAt(t *testing.T) {
 func TestIntegration_ComposedGetRecord(t *testing.T) {
 	ext := setupIntegrationDB(t)
 	ctx := context.Background()
-	dp := testDP
 
 	// Create two primitive child streams and one composed parent (exactly 32 chars each)
 	childSID1 := "st000000000000000000000000child1"
@@ -348,37 +339,33 @@ func TestIntegration_ComposedGetRecord(t *testing.T) {
 			stype = "composed"
 		}
 		_, rpcErr := ext.CreateStream(ctx, &CreateStreamRequest{
-			DataProvider: dp, StreamID: sid, StreamType: stype,
+			StreamID: sid, StreamType: stype,
 		})
 		require.Nil(t, rpcErr, "create stream %s failed: %v", sid, rpcErr)
 	}
 
 	// child1: 10, 20, 30 at times 1000, 2000, 3000
 	_, rpcErr := ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{dp, dp, dp},
-		StreamID:     []string{childSID1, childSID1, childSID1},
-		EventTime:    []int64{1000, 2000, 3000},
-		Value:        []string{"10.0", "20.0", "30.0"},
+		StreamID:  []string{childSID1, childSID1, childSID1},
+		EventTime: []int64{1000, 2000, 3000},
+		Value:     []string{"10.0", "20.0", "30.0"},
 	})
 	require.Nil(t, rpcErr)
 
 	// child2: 100, 200, 300 at times 1000, 2000, 3000
 	_, rpcErr = ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{dp, dp, dp},
-		StreamID:     []string{childSID2, childSID2, childSID2},
-		EventTime:    []int64{1000, 2000, 3000},
-		Value:        []string{"100.0", "200.0", "300.0"},
+		StreamID:  []string{childSID2, childSID2, childSID2},
+		EventTime: []int64{1000, 2000, 3000},
+		Value:     []string{"100.0", "200.0", "300.0"},
 	})
 	require.Nil(t, rpcErr)
 
 	// Taxonomy: composed = 0.5 * child1 + 0.5 * child2
 	_, rpcErr = ext.InsertTaxonomy(ctx, &InsertTaxonomyRequest{
-		DataProvider:       dp,
-		StreamID:           composedSID,
-		ChildDataProviders: []string{dp, dp},
-		ChildStreamIDs:     []string{childSID1, childSID2},
-		Weights:            []string{"0.5", "0.5"},
-		StartDate:          0,
+		StreamID:       composedSID,
+		ChildStreamIDs: []string{childSID1, childSID2},
+		Weights:        []string{"0.5", "0.5"},
+		StartDate:      0,
 	})
 	require.Nil(t, rpcErr, "insert taxonomy failed: %v", rpcErr)
 
@@ -386,7 +373,7 @@ func TestIntegration_ComposedGetRecord(t *testing.T) {
 	from := int64(500)
 	to := int64(5000)
 	resp, rpcErr := ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: dp, StreamID: composedSID,
+		StreamID: composedSID,
 		FromTime: &from, ToTime: &to,
 	})
 	require.Nil(t, rpcErr, "get_record composed failed: %v", rpcErr)
@@ -397,7 +384,7 @@ func TestIntegration_ComposedGetRecord(t *testing.T) {
 
 	// Latest record
 	resp, rpcErr = ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: dp, StreamID: composedSID,
+		StreamID: composedSID,
 	})
 	require.Nil(t, rpcErr)
 	require.Len(t, resp.Records, 1)
@@ -408,31 +395,27 @@ func TestIntegration_ComposedGetRecord(t *testing.T) {
 func TestIntegration_ComposedGetIndex(t *testing.T) {
 	ext := setupIntegrationDB(t)
 	ctx := context.Background()
-	dp := testDP
 
 	childSID := "st0000000000000000000000000chld1"
 	composedSID := "st0000000000000000000000000cmpsd"
 
-	_, rpcErr := ext.CreateStream(ctx, &CreateStreamRequest{DataProvider: dp, StreamID: childSID, StreamType: "primitive"})
+	_, rpcErr := ext.CreateStream(ctx, &CreateStreamRequest{StreamID: childSID, StreamType: "primitive"})
 	require.Nil(t, rpcErr)
-	_, rpcErr = ext.CreateStream(ctx, &CreateStreamRequest{DataProvider: dp, StreamID: composedSID, StreamType: "composed"})
+	_, rpcErr = ext.CreateStream(ctx, &CreateStreamRequest{StreamID: composedSID, StreamType: "composed"})
 	require.Nil(t, rpcErr)
 
 	_, rpcErr = ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{dp, dp, dp},
-		StreamID:     []string{childSID, childSID, childSID},
-		EventTime:    []int64{1000, 2000, 3000},
-		Value:        []string{"50.0", "75.0", "100.0"},
+		StreamID:  []string{childSID, childSID, childSID},
+		EventTime: []int64{1000, 2000, 3000},
+		Value:     []string{"50.0", "75.0", "100.0"},
 	})
 	require.Nil(t, rpcErr)
 
 	_, rpcErr = ext.InsertTaxonomy(ctx, &InsertTaxonomyRequest{
-		DataProvider:       dp,
-		StreamID:           composedSID,
-		ChildDataProviders: []string{dp},
-		ChildStreamIDs:     []string{childSID},
-		Weights:            []string{"1.0"},
-		StartDate:          0,
+		StreamID:       composedSID,
+		ChildStreamIDs: []string{childSID},
+		Weights:        []string{"1.0"},
+		StartDate:      0,
 	})
 	require.Nil(t, rpcErr)
 
@@ -440,7 +423,7 @@ func TestIntegration_ComposedGetIndex(t *testing.T) {
 	from := int64(500)
 	to := int64(5000)
 	resp, rpcErr := ext.GetIndex(ctx, &GetIndexRequest{
-		DataProvider: dp, StreamID: composedSID,
+		StreamID: composedSID,
 		FromTime: &from, ToTime: &to,
 	})
 	require.Nil(t, rpcErr, "get_index composed failed: %v", rpcErr)
@@ -453,40 +436,38 @@ func TestIntegration_ComposedGetIndex(t *testing.T) {
 func TestIntegration_NestedComposed(t *testing.T) {
 	ext := setupIntegrationDB(t)
 	ctx := context.Background()
-	dp := testDP
 
 	// Hierarchy: root (composed) → mid (composed) → leaf (primitive)
 	leafSID := "st000000000000000000000000leaf01"
 	midSID := "st000000000000000000000000midi01"
 	rootSID := "st000000000000000000000000root01"
 
-	_, err := ext.CreateStream(ctx, &CreateStreamRequest{DataProvider: dp, StreamID: leafSID, StreamType: "primitive"})
+	_, err := ext.CreateStream(ctx, &CreateStreamRequest{StreamID: leafSID, StreamType: "primitive"})
 	require.Nil(t, err)
-	_, err = ext.CreateStream(ctx, &CreateStreamRequest{DataProvider: dp, StreamID: midSID, StreamType: "composed"})
+	_, err = ext.CreateStream(ctx, &CreateStreamRequest{StreamID: midSID, StreamType: "composed"})
 	require.Nil(t, err)
-	_, err = ext.CreateStream(ctx, &CreateStreamRequest{DataProvider: dp, StreamID: rootSID, StreamType: "composed"})
+	_, err = ext.CreateStream(ctx, &CreateStreamRequest{StreamID: rootSID, StreamType: "composed"})
 	require.Nil(t, err)
 
 	_, err = ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{dp, dp, dp},
-		StreamID:     []string{leafSID, leafSID, leafSID},
-		EventTime:    []int64{1000, 2000, 3000},
-		Value:        []string{"100.0", "200.0", "300.0"},
+		StreamID:  []string{leafSID, leafSID, leafSID},
+		EventTime: []int64{1000, 2000, 3000},
+		Value:     []string{"100.0", "200.0", "300.0"},
 	})
 	require.Nil(t, err)
 
 	// mid = 1.0 * leaf
 	_, err = ext.InsertTaxonomy(ctx, &InsertTaxonomyRequest{
-		DataProvider: dp, StreamID: midSID,
-		ChildDataProviders: []string{dp}, ChildStreamIDs: []string{leafSID},
+		StreamID: midSID,
+		ChildStreamIDs: []string{leafSID},
 		Weights: []string{"1.0"}, StartDate: 0,
 	})
 	require.Nil(t, err)
 
 	// root = 0.5 * mid
 	_, err = ext.InsertTaxonomy(ctx, &InsertTaxonomyRequest{
-		DataProvider: dp, StreamID: rootSID,
-		ChildDataProviders: []string{dp}, ChildStreamIDs: []string{midSID},
+		StreamID: rootSID,
+		ChildStreamIDs: []string{midSID},
 		Weights: []string{"0.5"}, StartDate: 0,
 	})
 	require.Nil(t, err)
@@ -495,7 +476,7 @@ func TestIntegration_NestedComposed(t *testing.T) {
 	from := int64(500)
 	to := int64(5000)
 	resp, rpcErr := ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: dp, StreamID: rootSID,
+		StreamID: rootSID,
 		FromTime: &from, ToTime: &to,
 	})
 	require.Nil(t, rpcErr, "nested composed query failed: %v", rpcErr)
@@ -517,7 +498,6 @@ func TestIntegration_NestedComposed(t *testing.T) {
 func TestIntegration_TaxonomyReplacementGroup(t *testing.T) {
 	ext := setupIntegrationDB(t)
 	ctx := context.Background()
-	dp := testDP
 
 	// Three primitive children + one composed parent (32-char SIDs).
 	childA := "st0000000000000000000000000reptA"
@@ -531,7 +511,7 @@ func TestIntegration_TaxonomyReplacementGroup(t *testing.T) {
 			stype = "composed"
 		}
 		_, rpcErr := ext.CreateStream(ctx, &CreateStreamRequest{
-			DataProvider: dp, StreamID: sid, StreamType: stype,
+			StreamID: sid, StreamType: stype,
 		})
 		require.Nil(t, rpcErr, "create stream %s failed: %v", sid, rpcErr)
 	}
@@ -540,32 +520,27 @@ func TestIntegration_TaxonomyReplacementGroup(t *testing.T) {
 	// Each leaf has a constant value to make weighted-avg arithmetic obvious.
 	// A: value 10, B: value 100, C: value 1000.
 	_, rpcErr := ext.InsertRecords(ctx, &InsertRecordsRequest{
-		DataProvider: []string{dp, dp, dp, dp, dp, dp},
-		StreamID:     []string{childA, childA, childB, childB, childC, childC},
-		EventTime:    []int64{100, 300, 100, 300, 100, 300},
-		Value:        []string{"10.0", "10.0", "100.0", "100.0", "1000.0", "1000.0"},
+		StreamID:  []string{childA, childA, childB, childB, childC, childC},
+		EventTime: []int64{100, 300, 100, 300, 100, 300},
+		Value:     []string{"10.0", "10.0", "100.0", "100.0", "1000.0", "1000.0"},
 	})
 	require.Nil(t, rpcErr)
 
 	// Group 1 @ start_time=0: { A: 0.5, B: 0.5 }
 	_, rpcErr = ext.InsertTaxonomy(ctx, &InsertTaxonomyRequest{
-		DataProvider:       dp,
-		StreamID:           composedSID,
-		ChildDataProviders: []string{dp, dp},
-		ChildStreamIDs:     []string{childA, childB},
-		Weights:            []string{"0.5", "0.5"},
-		StartDate:          0,
+		StreamID:       composedSID,
+		ChildStreamIDs: []string{childA, childB},
+		Weights:        []string{"0.5", "0.5"},
+		StartDate:      0,
 	})
 	require.Nil(t, rpcErr, "insert taxonomy group 1 failed: %v", rpcErr)
 
 	// Group 2 @ start_time=200: { A: 0.7, C: 0.3 } — B is REMOVED.
 	_, rpcErr = ext.InsertTaxonomy(ctx, &InsertTaxonomyRequest{
-		DataProvider:       dp,
-		StreamID:           composedSID,
-		ChildDataProviders: []string{dp, dp},
-		ChildStreamIDs:     []string{childA, childC},
-		Weights:            []string{"0.7", "0.3"},
-		StartDate:          200,
+		StreamID:       composedSID,
+		ChildStreamIDs: []string{childA, childC},
+		Weights:        []string{"0.7", "0.3"},
+		StartDate:      200,
 	})
 	require.Nil(t, rpcErr, "insert taxonomy group 2 failed: %v", rpcErr)
 
@@ -573,7 +548,7 @@ func TestIntegration_TaxonomyReplacementGroup(t *testing.T) {
 	from := int64(50)
 	to := int64(400)
 	resp, rpcErr := ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: dp, StreamID: composedSID,
+		StreamID: composedSID,
 		FromTime: &from, ToTime: &to,
 	})
 	require.Nil(t, rpcErr, "get_record across replacement boundary failed: %v", rpcErr)
@@ -610,7 +585,7 @@ func TestIntegration_TaxonomyReplacementGroup(t *testing.T) {
 
 	// "Latest" lookup should also use the new weights, not the stale ones.
 	latestResp, rpcErr := ext.GetRecord(ctx, &GetRecordRequest{
-		DataProvider: dp, StreamID: composedSID,
+		StreamID: composedSID,
 	})
 	require.Nil(t, rpcErr)
 	require.Len(t, latestResp.Records, 1)
@@ -621,7 +596,7 @@ func TestIntegration_TaxonomyReplacementGroup(t *testing.T) {
 	// GetIndex with explicit base_time before the boundary should also work.
 	baseTime := int64(100)
 	indexResp, rpcErr := ext.GetIndex(ctx, &GetIndexRequest{
-		DataProvider: dp, StreamID: composedSID,
+		StreamID: composedSID,
 		FromTime: &from, ToTime: &to, BaseTime: &baseTime,
 	})
 	require.Nil(t, rpcErr, "get_index across replacement boundary failed: %v", rpcErr)

--- a/extensions/tn_local/test_init.go
+++ b/extensions/tn_local/test_init.go
@@ -6,7 +6,8 @@ import (
 
 // testOverrides holds test-injected state.
 var testOverrides struct {
-	sqlDB sql.DB
+	sqlDB       sql.DB
+	nodeAddress string
 }
 
 // SetTestDB allows tests to inject a database connection.
@@ -16,4 +17,14 @@ func SetTestDB(db sql.DB) {
 
 func getTestDB() sql.DB {
 	return testOverrides.sqlDB
+}
+
+// SetTestNodeAddress allows tests to inject a node operator address without
+// setting up a real ValidatorSigner. Pass "" to clear.
+func SetTestNodeAddress(addr string) {
+	testOverrides.nodeAddress = addr
+}
+
+func getTestNodeAddress() string {
+	return testOverrides.nodeAddress
 }

--- a/extensions/tn_local/tn_local.go
+++ b/extensions/tn_local/tn_local.go
@@ -2,6 +2,7 @@ package tn_local
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -53,6 +54,18 @@ func adminServerHook(server *rpcserver.Server) error {
 func engineReadyHook(ctx context.Context, app *common.App) error {
 	logger := app.Service.Logger.New("tn_local")
 
+	// Derive the node operator's Ethereum address from its secp256k1 key.
+	// This is the implicit data_provider for every local stream operation.
+	// If the node has no secp256k1 signer (read-only / ed25519), nodeAddress
+	// stays empty and the extension stays disabled — handlers will refuse all
+	// requests with a clear error.
+	nodeAddress := deriveNodeAddress(app, logger)
+
+	// Allow tests to inject an address without setting up a real ValidatorSigner.
+	if testAddr := getTestNodeAddress(); testAddr != "" {
+		nodeAddress = testAddr
+	}
+
 	var localDB *LocalDB
 	if testDB := getTestDB(); testDB != nil {
 		localDB = NewLocalDB(testDB, logger)
@@ -83,10 +96,30 @@ func engineReadyHook(ctx context.Context, app *common.App) error {
 	// Update existing singleton in-place to preserve the pointer registered
 	// with the admin server's RegisterSvc.
 	ext := GetExtension()
-	ext.configure(logger, localDB.db, localDB)
+	ext.configure(logger, localDB.db, localDB, nodeAddress)
 
-	logger.Info("tn_local extension initialized")
+	if nodeAddress == "" {
+		logger.Warn("tn_local disabled: node has no secp256k1 operator key — local stream operations will be rejected")
+	} else {
+		logger.Info("tn_local extension initialized", "node_address", nodeAddress)
+	}
 	return nil
+}
+
+// deriveNodeAddress returns the lowercase 0x-prefixed Ethereum address derived
+// from the node's secp256k1 operator key, or "" if no secp256k1 key is available.
+// Local streams use this as the implicit data_provider — there is no other way
+// to claim ownership of a local stream.
+func deriveNodeAddress(app *common.App, logger log.Logger) string {
+	if app == nil || app.Service == nil || app.Service.ValidatorSigner == nil {
+		return ""
+	}
+	addrBytes, err := app.Service.ValidatorSigner.EthereumAddress()
+	if err != nil {
+		logger.Warn("tn_local: failed to derive Ethereum address from node key", "error", err)
+		return ""
+	}
+	return "0x" + hex.EncodeToString(addrBytes)
 }
 
 // createIndependentConnectionPool creates a dedicated connection pool for local storage.

--- a/extensions/tn_local/tn_local_test.go
+++ b/extensions/tn_local/tn_local_test.go
@@ -109,10 +109,33 @@ func TestExtensionSingleton(t *testing.T) {
 	require.Same(t, ext1, ext2, "GetExtension should return same instance")
 	require.False(t, ext1.isEnabled.Load(), "default extension should be disabled")
 
-	// configure updates the existing instance in-place (preserves pointer identity)
-	ext1.configure(ext1.logger, nil, nil)
+	// configure updates the existing instance in-place (preserves pointer identity).
+	// Passing a non-empty node address transitions the extension to enabled.
+	ext1.configure(ext1.logger, nil, nil, testNodeAddress)
 	require.True(t, ext1.isEnabled.Load())
+	require.Equal(t, testNodeAddress, ext1.nodeAddress)
 	require.Same(t, ext1, GetExtension(), "still same pointer after configure")
+}
+
+func TestExtensionConfigureEmptyAddressStaysDisabled(t *testing.T) {
+	// configure() with an empty node address must NOT enable the extension —
+	// this is the read-only / ed25519 fallback path. Handlers will refuse
+	// requests with the disabled error.
+	prev := extensionInstance
+	extensionInstance = nil
+	once = sync.Once{}
+	t.Cleanup(func() {
+		extensionInstance = prev
+		once = sync.Once{}
+		if prev != nil {
+			once.Do(func() {})
+		}
+	})
+
+	ext := GetExtension()
+	ext.configure(ext.logger, nil, nil, "")
+	require.False(t, ext.isEnabled.Load(), "empty node address must keep extension disabled")
+	require.Empty(t, ext.nodeAddress)
 }
 
 func TestServiceInterface(t *testing.T) {
@@ -134,11 +157,20 @@ func TestServiceInterface(t *testing.T) {
 	require.NotNil(t, health)
 }
 
-// newTestExtension creates an Extension with a mock DB for handler tests.
+// testNodeAddress is the lowercase Ethereum address used as the implicit
+// data_provider for handler tests. It is the lowercase form of testDP, so
+// any test that previously asserted captured args matched a lowercased
+// testDP keeps working without value changes.
+const testNodeAddress = "0xec36224a679218ae28fcece8d3c68595b87dd832"
+
+// newTestExtension creates an Extension with a mock DB and a stub node address
+// for handler tests. The node address mirrors what the production engineReadyHook
+// would derive from the secp256k1 ValidatorSigner.
 func newTestExtension(db kwilsql.DB) *Extension {
 	ext := &Extension{
-		logger: log.New(log.WithWriter(io.Discard)),
-		db:     db,
+		logger:      log.New(log.WithWriter(io.Discard)),
+		db:          db,
+		nodeAddress: testNodeAddress,
 	}
 	ext.isEnabled.Store(true)
 	return ext

--- a/extensions/tn_local/types.go
+++ b/extensions/tn_local/types.go
@@ -1,23 +1,33 @@
 package tn_local
 
+// Request types intentionally do NOT carry a data_provider field. The server
+// derives the data_provider from the node operator's secp256k1 key (see
+// Extension.nodeAddress) — local streams are always owned by the node they
+// live on. Including data_provider on the wire would invite impersonation
+// since the admin RPC server has no per-request identity.
+//
+// Response types DO keep data_provider fields when the corresponding consensus
+// action returns one (e.g. list_streams), so callers can swap local/on-chain
+// without reshaping records. The value is always equal to the node's own
+// address — redundant but mirrored for compatibility.
+
 // CreateStreamRequest is the JSON-RPC request for local.create_stream.
 type CreateStreamRequest struct {
-	DataProvider string `json:"data_provider"`
-	StreamID     string `json:"stream_id"`
-	StreamType   string `json:"stream_type"` // "primitive" or "composed"
+	StreamID   string `json:"stream_id"`
+	StreamType string `json:"stream_type"` // "primitive" or "composed"
 }
 
 // CreateStreamResponse is the JSON-RPC response for local.create_stream.
 type CreateStreamResponse struct{}
 
 // InsertRecordsRequest is the JSON-RPC request for local.insert_records.
-// Mirrors the consensus insert_records($data_provider TEXT[], $stream_id TEXT[],
-// $event_time INT8[], $value NUMERIC(36,18)[]) signature — parallel arrays.
+// Mirrors the consensus insert_records signature minus data_provider —
+// parallel arrays for stream_id, event_time, and value. Each record may
+// target a different stream, but all streams are owned by the node.
 type InsertRecordsRequest struct {
-	DataProvider []string `json:"data_provider"`
-	StreamID     []string `json:"stream_id"`
-	EventTime    []int64  `json:"event_time"`
-	Value        []string `json:"value"`
+	StreamID  []string `json:"stream_id"`
+	EventTime []int64  `json:"event_time"`
+	Value     []string `json:"value"`
 }
 
 // InsertRecordsResponse is the JSON-RPC response for local.insert_records.
@@ -25,16 +35,13 @@ type InsertRecordsRequest struct {
 type InsertRecordsResponse struct{}
 
 // InsertTaxonomyRequest is the JSON-RPC request for local.insert_taxonomy.
-// Mirrors the consensus insert_taxonomy($data_provider, $stream_id,
-// $child_data_providers TEXT[], $child_stream_ids TEXT[], $weights NUMERIC(36,18)[],
-// $start_date INT) signature — parallel arrays for children.
+// Mirrors the consensus insert_taxonomy signature minus data_provider /
+// child_data_providers — children are always local to the same node.
 type InsertTaxonomyRequest struct {
-	DataProvider       string   `json:"data_provider"`
-	StreamID           string   `json:"stream_id"`
-	ChildDataProviders []string `json:"child_data_providers"`
-	ChildStreamIDs     []string `json:"child_stream_ids"`
-	Weights            []string `json:"weights"`
-	StartDate          int64    `json:"start_date"`
+	StreamID       string   `json:"stream_id"`
+	ChildStreamIDs []string `json:"child_stream_ids"`
+	Weights        []string `json:"weights"`
+	StartDate      int64    `json:"start_date"`
 }
 
 // InsertTaxonomyResponse is the JSON-RPC response for local.insert_taxonomy.
@@ -42,10 +49,9 @@ type InsertTaxonomyResponse struct{}
 
 // GetRecordRequest is the JSON-RPC request for local.get_record.
 type GetRecordRequest struct {
-	DataProvider string `json:"data_provider"`
-	StreamID     string `json:"stream_id"`
-	FromTime     *int64 `json:"from_time,omitempty"`
-	ToTime       *int64 `json:"to_time,omitempty"`
+	StreamID string `json:"stream_id"`
+	FromTime *int64 `json:"from_time,omitempty"`
+	ToTime   *int64 `json:"to_time,omitempty"`
 }
 
 // GetRecordResponse is the JSON-RPC response for local.get_record.
@@ -62,11 +68,10 @@ type RecordOutput struct {
 
 // GetIndexRequest is the JSON-RPC request for local.get_index.
 type GetIndexRequest struct {
-	DataProvider string `json:"data_provider"`
-	StreamID     string `json:"stream_id"`
-	FromTime     *int64 `json:"from_time,omitempty"`
-	ToTime       *int64 `json:"to_time,omitempty"`
-	BaseTime     *int64 `json:"base_time,omitempty"`
+	StreamID string `json:"stream_id"`
+	FromTime *int64 `json:"from_time,omitempty"`
+	ToTime   *int64 `json:"to_time,omitempty"`
+	BaseTime *int64 `json:"base_time,omitempty"`
 }
 
 // GetIndexResponse is the JSON-RPC response for local.get_index.
@@ -88,7 +93,9 @@ type ListStreamsResponse struct {
 	Streams []StreamInfo `json:"streams"`
 }
 
-// StreamInfo describes a local stream.
+// StreamInfo describes a local stream. DataProvider is always equal to the
+// node's own address — kept for parity with the consensus list_streams action
+// so that on-chain and local clients can use the same response shape.
 type StreamInfo struct {
 	DataProvider string `json:"data_provider"`
 	StreamID     string `json:"stream_id"`


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server now derives the local stream owner from the node operator address and surfaces that as the data provider.

* **Refactor**
  * Request payloads no longer accept data_provider; ownership is determined server-side.
  * List responses report the node address as the stream data provider.

* **Bug Fixes**
  * Operations return a clear "tn_local is disabled" error when no node address is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->