### PR TITLE
chore: reduce nonce noise caused by attestation

### DIFF
--- a/extensions/tn_attestation/extension.go
+++ b/extensions/tn_attestation/extension.go
@@ -3,11 +3,13 @@ package tn_attestation
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/trufnetwork/kwil-db/common"
 	"github.com/trufnetwork/kwil-db/core/crypto/auth"
 	"github.com/trufnetwork/kwil-db/core/log"
+	ktypes "github.com/trufnetwork/kwil-db/core/types"
 	sql "github.com/trufnetwork/kwil-db/node/types/sql"
 )
 
@@ -35,6 +37,13 @@ type signerExtension struct {
 	statusQueue chan txStatusWork
 
 	processOverride func(context.Context, []string)
+
+	// pendingNonce tracks the next nonce to use for attestation transactions.
+	// Initialized from the ledger on first use, then incremented after each
+	// successful broadcast. This prevents "invalid nonce" errors when
+	// submitting multiple attestations in a single EndBlock.
+	pendingNonce      uint64
+	nonceInitialized  bool
 
 	mu sync.RWMutex
 }
@@ -277,6 +286,60 @@ func parsePositiveInt64(raw string) (int64, error) {
 		return 0, fmt.Errorf("value must be positive, got %d", v)
 	}
 	return v, nil
+}
+
+// resetNonce clears the cached nonce so the next submission re-fetches from the ledger.
+func (e *signerExtension) resetNonce() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.nonceInitialized = false
+	e.pendingNonce = 0
+}
+
+// nextNonce returns the next nonce to use and increments the internal counter.
+// On first call (or after reset), it initializes from the ledger.
+func (e *signerExtension) nextNonce(ctx context.Context) (uint64, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.nonceInitialized {
+		nonce := e.pendingNonce
+		e.pendingNonce++
+		return nonce, nil
+	}
+
+	// Initialize from ledger
+	accounts := e.accounts
+	db := e.db
+	if accounts == nil || db == nil {
+		return 0, fmt.Errorf("accounts or db unavailable for nonce lookup")
+	}
+
+	signer := e.nodeSigner
+	if signer == nil {
+		return 0, fmt.Errorf("node signer unavailable for nonce lookup")
+	}
+
+	accountID, err := ktypes.GetSignerAccount(signer)
+	if err != nil {
+		return 0, fmt.Errorf("derive account id: %w", err)
+	}
+
+	account, err := accounts.GetAccount(ctx, db, accountID)
+	var nonce uint64 = 1
+	if err != nil {
+		msg := strings.ToLower(err.Error())
+		if !strings.Contains(msg, "not found") && !strings.Contains(msg, "no rows") {
+			return 0, fmt.Errorf("get account: %w", err)
+		}
+		// Account not found — first ever transaction
+	} else {
+		nonce = uint64(account.Nonce + 1)
+	}
+
+	e.pendingNonce = nonce + 1
+	e.nonceInitialized = true
+	return nonce, nil
 }
 
 // getTxQueryClient retrieves the query client for transaction status polling.

--- a/extensions/tn_attestation/extension.go
+++ b/extensions/tn_attestation/extension.go
@@ -3,7 +3,6 @@ package tn_attestation
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/trufnetwork/kwil-db/common"
@@ -326,16 +325,12 @@ func (e *signerExtension) nextNonce(ctx context.Context) (uint64, error) {
 	}
 
 	account, err := accounts.GetAccount(ctx, db, accountID)
-	var nonce uint64 = 1
 	if err != nil {
-		msg := strings.ToLower(err.Error())
-		if !strings.Contains(msg, "not found") && !strings.Contains(msg, "no rows") {
-			return 0, fmt.Errorf("get account: %w", err)
-		}
-		// Account not found — first ever transaction
-	} else {
-		nonce = uint64(account.Nonce + 1)
+		return 0, fmt.Errorf("get account: %w", err)
 	}
+	// GetAccount returns a zero-value account (nonce=0) when not found,
+	// so nonce+1 = 1 for the first ever transaction.
+	nonce := uint64(account.Nonce + 1)
 
 	e.pendingNonce = nonce + 1
 	e.nonceInitialized = true

--- a/extensions/tn_attestation/integration_test.go
+++ b/extensions/tn_attestation/integration_test.go
@@ -269,8 +269,13 @@ func (signerAccountsStub) Transfer(context.Context, sql.TxMaker, *ktypes.Account
 	return nil
 }
 
-func (signerAccountsStub) GetAccount(context.Context, sql.Executor, *ktypes.AccountID) (*ktypes.Account, error) {
-	return nil, fmt.Errorf("not found")
+func (signerAccountsStub) GetAccount(_ context.Context, _ sql.Executor, account *ktypes.AccountID) (*ktypes.Account, error) {
+	// Match real Accounts.GetAccount behavior: return zero-value account when not found.
+	return &ktypes.Account{
+		ID:      account,
+		Balance: big.NewInt(0),
+		Nonce:   0,
+	}, nil
 }
 
 func (signerAccountsStub) ApplySpend(context.Context, sql.Executor, *ktypes.AccountID, *big.Int, int64) error {

--- a/extensions/tn_attestation/processor_test.go
+++ b/extensions/tn_attestation/processor_test.go
@@ -474,10 +474,131 @@ func (s *stubAccounts) ApplySpend(ctx context.Context, tx nodesql.Executor, acco
 type recordingBroadcaster struct {
 	calls  int
 	lastTx *ktypes.Transaction
+	nonces []uint64 // records nonce of each broadcast call
+
+	// failOnCall, if > 0, causes the Nth call to return an error.
+	failOnCall int
 }
 
 func (b *recordingBroadcaster) BroadcastTx(ctx context.Context, tx *ktypes.Transaction, sync uint8) (ktypes.Hash, *ktypes.TxResult, error) {
 	b.calls++
 	b.lastTx = tx
+	b.nonces = append(b.nonces, tx.Body.Nonce)
+	if b.failOnCall > 0 && b.calls == b.failOnCall {
+		return ktypes.Hash{}, nil, fmt.Errorf("broadcast tx: invalid nonce")
+	}
 	return ktypes.Hash{}, &ktypes.TxResult{Code: uint32(ktypes.CodeOk)}, nil
+}
+
+// setupNonceTestExtension creates a signerExtension wired with stubs for nonce testing.
+// Returns the extension, broadcaster, and a slice of PreparedSignature items ready to submit.
+func setupNonceTestExtension(t *testing.T, ledgerNonce int64, numItems int) (*signerExtension, *recordingBroadcaster, []*PreparedSignature) {
+	t.Helper()
+	t.Cleanup(ResetValidatorSignerForTesting)
+
+	privateKey, _, err := kwilcrypto.GenerateSecp256k1Key(nil)
+	require.NoError(t, err)
+	require.NoError(t, InitializeValidatorSigner(privateKey))
+
+	broadcaster := &recordingBroadcaster{}
+	ext := &signerExtension{
+		logger:             log.DiscardLogger,
+		scanIntervalBlocks: 100,
+	}
+
+	service := &common.Service{
+		Logger:        log.DiscardLogger,
+		GenesisConfig: &config.GenesisConfig{ChainID: "test-chain"},
+		LocalConfig:   &config.Config{},
+	}
+	ext.setService(service)
+	ext.setApp(&common.App{
+		Engine:   &stubEngine{},
+		DB:       stubDB{},
+		Accounts: &stubAccounts{acct: &ktypes.Account{Nonce: ledgerNonce}},
+		Service:  service,
+	})
+	ext.setNodeSigner(auth.GetNodeSigner(privateKey))
+	ext.setBroadcaster(broadcaster)
+
+	// Build N prepared signatures with distinct hashes.
+	signer := GetValidatorSigner()
+	items := make([]*PreparedSignature, numItems)
+	for i := range items {
+		canonical := BuildCanonicalPayload(1, 0, uint64(100+i),
+			bytes.Repeat([]byte{0x55}, 20),
+			bytes.Repeat([]byte{byte(i + 1)}, 32),
+			5, []byte{0x01}, []byte{0xAA})
+		payload, err := ParseCanonicalPayload(canonical)
+		require.NoError(t, err)
+		hash := computeAttestationHash(payload)
+		sig, err := signer.SignDigest(hash[:])
+		require.NoError(t, err)
+		items[i] = &PreparedSignature{
+			RequestTxID:   fmt.Sprintf("0xreq%d", i),
+			HashHex:       hex.EncodeToString(hash[:]),
+			Hash:          hash[:],
+			Requester:     []byte("requester"),
+			Signature:     sig,
+			Payload:       payload,
+			CreatedHeight: int64(100 + i),
+		}
+	}
+
+	return ext, broadcaster, items
+}
+
+func TestNonceTracking(t *testing.T) {
+	t.Run("BatchSubmissionsUseIncrementingNonces", func(t *testing.T) {
+		ext, broadcaster, items := setupNonceTestExtension(t, 7, 3)
+
+		// Submit 3 attestations — they should get nonces 8, 9, 10.
+		for _, item := range items {
+			err := ext.submitSignature(context.Background(), item)
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, 3, broadcaster.calls)
+		assert.Equal(t, []uint64{8, 9, 10}, broadcaster.nonces,
+			"batch submissions should use incrementing nonces")
+	})
+
+	t.Run("BroadcastFailureResetsNonce", func(t *testing.T) {
+		ext, broadcaster, items := setupNonceTestExtension(t, 7, 3)
+		broadcaster.failOnCall = 2 // second broadcast fails
+
+		// First submission succeeds (nonce 8).
+		err := ext.submitSignature(context.Background(), items[0])
+		require.NoError(t, err)
+
+		// Second submission fails — nonce should reset.
+		err = ext.submitSignature(context.Background(), items[1])
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid nonce")
+
+		// Third submission should re-fetch from ledger (nonce 7+1=8 again).
+		err = ext.submitSignature(context.Background(), items[2])
+		require.NoError(t, err)
+
+		require.Equal(t, 3, broadcaster.calls)
+		assert.Equal(t, uint64(8), broadcaster.nonces[0], "first call nonce")
+		assert.Equal(t, uint64(9), broadcaster.nonces[1], "failed call nonce")
+		assert.Equal(t, uint64(8), broadcaster.nonces[2], "re-fetched nonce after reset")
+	})
+
+	t.Run("ResetNonceForcesLedgerRefetch", func(t *testing.T) {
+		ext, broadcaster, items := setupNonceTestExtension(t, 10, 2)
+
+		err := ext.submitSignature(context.Background(), items[0])
+		require.NoError(t, err)
+		assert.Equal(t, uint64(11), broadcaster.nonces[0])
+
+		// Manually reset (simulates leader transition).
+		ext.resetNonce()
+
+		err = ext.submitSignature(context.Background(), items[1])
+		require.NoError(t, err)
+		assert.Equal(t, uint64(11), broadcaster.nonces[1],
+			"after reset, nonce should be re-fetched from ledger (10+1=11)")
+	})
 }

--- a/extensions/tn_attestation/processor_test.go
+++ b/extensions/tn_attestation/processor_test.go
@@ -577,6 +577,9 @@ func TestNonceTracking(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid nonce")
 
 		// Third submission should re-fetch from ledger (nonce 7+1=8 again).
+		// Note: stubAccounts returns a fixed nonce (doesn't advance on broadcast),
+		// so re-fetch returns the same value. In production, the ledger nonce
+		// advances after tx inclusion, yielding a higher value here.
 		err = ext.submitSignature(context.Background(), items[2])
 		require.NoError(t, err)
 

--- a/extensions/tn_attestation/tn_attestation.go
+++ b/extensions/tn_attestation/tn_attestation.go
@@ -109,6 +109,7 @@ func onLeaderAcquire(ctx context.Context, app *common.App, block *common.BlockCo
 	if block != nil {
 		ext.setLeader(true, block.Height)
 	}
+	ext.resetNonce() // re-fetch nonce from ledger on new leadership term
 
 	logger := ext.Logger()
 	logger.Info("tn_attestation: acquired leadership")

--- a/extensions/tn_attestation/worker.go
+++ b/extensions/tn_attestation/worker.go
@@ -8,7 +8,6 @@ package tn_attestation
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	ktypes "github.com/trufnetwork/kwil-db/core/types"
@@ -94,33 +93,12 @@ func (e *signerExtension) submitSignature(ctx context.Context, item *PreparedSig
 		return fmt.Errorf("node signer not initialised")
 	}
 
-	accountID, err := ktypes.GetSignerAccount(signer)
+	// Use internal nonce tracking to avoid "invalid nonce" when submitting
+	// multiple attestations in a single EndBlock. The nonce is initialized
+	// from the ledger on first use and incremented after each broadcast.
+	nonce, err := e.nextNonce(ctx)
 	if err != nil {
-		return fmt.Errorf("derive account id: %w", err)
-	}
-
-	accounts := e.Accounts()
-	if accounts == nil {
-		return fmt.Errorf("accounts subsystem unavailable")
-	}
-
-	db := e.DB()
-	if db == nil {
-		return fmt.Errorf("database handle unavailable")
-	}
-
-	// Nonce handling: First signature ever gets nonce=1 (account doesn't exist yet).
-	// Subsequent signatures increment from last recorded nonce. We tolerate "not found"
-	// because leader's first-ever signature creates the account on-chain.
-	account, err := accounts.GetAccount(ctx, db, accountID)
-	var nonce uint64 = 1
-	if err != nil {
-		msg := strings.ToLower(err.Error())
-		if !strings.Contains(msg, "not found") && !strings.Contains(msg, "no rows") {
-			return fmt.Errorf("get account: %w", err)
-		}
-	} else {
-		nonce = uint64(account.Nonce + 1)
+		return fmt.Errorf("get nonce: %w", err)
 	}
 
 	requestTxIDArg, err := ktypes.EncodeValue(item.RequestTxID)
@@ -150,6 +128,9 @@ func (e *signerExtension) submitSignature(ctx context.Context, item *PreparedSig
 
 	txHash, _, err := broadcaster.BroadcastTx(ctx, tx, 0) // Use BroadcastWaitAccept to avoid blocking consensus
 	if err != nil {
+		// Reset nonce on broadcast failure so next attempt re-fetches from
+		// the ledger instead of continuing with a potentially stale counter.
+		e.resetNonce()
 		return fmt.Errorf("broadcast tx: %w", err)
 	}
 


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nonce tracking for attestation transaction submissions to ensure proper sequential numbering across submissions
  * Nonce state now automatically resets on broadcast failures, allowing graceful recovery on retry attempts
  * Nonce management is refreshed when leadership transitions occur to prevent stale counter usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->