### PR TITLE
chore: bump kwil-db version for mainnet node upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.37.0
-	github.com/trufnetwork/kwil-db v0.10.3-0.20260414105203-b684b866ef30
-	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414105203-b684b866ef30
+	github.com/trufnetwork/kwil-db v0.10.3-0.20260414113323-696cc38f53b8
+	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8
 	github.com/trufnetwork/sdk-go v0.6.4-0.20260224122406-a741343e2f37
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa

--- a/go.sum
+++ b/go.sum
@@ -1256,6 +1256,8 @@ github.com/trufnetwork/kwil-db v0.10.3-0.20260414100322-facad37b3eb2 h1:mC687oWO
 github.com/trufnetwork/kwil-db v0.10.3-0.20260414100322-facad37b3eb2/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db v0.10.3-0.20260414105203-b684b866ef30 h1:L2E1whVeekeZw92CBKlKOeqKZASUWg79XtrVtjQ/BYk=
 github.com/trufnetwork/kwil-db v0.10.3-0.20260414105203-b684b866ef30/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
+github.com/trufnetwork/kwil-db v0.10.3-0.20260414113323-696cc38f53b8 h1:HuR9awZ/6r8YepSb8C5XRoSa7T++c5nr2jb9irxMTGU=
+github.com/trufnetwork/kwil-db v0.10.3-0.20260414113323-696cc38f53b8/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260406143732-e25a390e62bb h1:tghQHOXYDHwjBmhEVAQESPTvf3O9Oq/1qzow5aKE81c=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260406143732-e25a390e62bb/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260413125950-e0bc3b09a211 h1:h5HpwEqbPDEo4uGYz7ZUTfQ9tJBKyHaCmtwk2boB7Xs=
@@ -1270,6 +1272,8 @@ github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414100322-facad37b3eb2 h1:ADKw
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414100322-facad37b3eb2/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414105203-b684b866ef30 h1:9vaEXG8LRi0WVij3WvULGEsKquPZnV+XKOH3ASnjFnA=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414105203-b684b866ef30/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8 h1:fzkcURTH5LlSQpKbm5CezXNmJg8SMltcfYhblHY+HZA=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2 h1:DCq8MzbWH0wZmICNmMVsSzUHUPl+2vqRhluEABjxl88=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2/go.mod h1:Y0MJpPp9QXU5vC6Gpoilql2NkgmGNcbHm9HYC2v2N8s=
 github.com/trufnetwork/sdk-go v0.6.4-0.20260224122406-a741343e2f37 h1:VD/GWxLTshaXpLukEc1SXbG7QA9HrFzF8JvxJAJ/x7Q=

--- a/internal/migrations/erc20-bridge/006-disable-sepolia.prod.sql
+++ b/internal/migrations/erc20-bridge/006-disable-sepolia.prod.sql
@@ -1,0 +1,22 @@
+-- Disable and remove the deprecated sepolia_bridge from mainnet.
+--
+-- The sepolia_bridge was a holdover from the early-2025 testnet setup that
+-- pointed at the Sepolia testnet escrow. With the prediction-market upgrade,
+-- mainnet collateral flows through ethereum_bridge (USDC) and the planned
+-- TRUF mainnet bridge — sepolia_bridge is no longer referenced by any
+-- mainnet action.
+--
+-- Side effect: stops the kwild ERC20 listener for sepolia, which on the new
+-- binary scans Ethereum from block 0 → ~10.7M and emits "exceed maximum
+-- block range: 50000" recovery warnings on every cycle. After UNUSE, those
+-- warnings cease.
+--
+-- UNUSE properly cleans up the extension namespace even if the instance is
+-- already disabled. The kwil_erc20_meta tables for this instance remain in
+-- the database for forensics; drop them separately if you want a full purge.
+--
+-- DO NOT apply on testnet — testnet still uses sepolia_bridge.
+-- This is a .prod.sql file: excluded from the embedded seed loader, applied
+-- manually via `kwil-cli exec-sql --file ... --sync` against the live node.
+
+UNUSE sepolia_bridge;

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -17,6 +17,33 @@ check_env_var "PROVIDER"
 # Set SYNC to true by default if not set
 SYNC="${SYNC:-true}"
 
+# Retry knobs — every kwil-cli call goes through run_with_retry so a
+# transient blip (DNS hiccup, dial timeout, leader rotation) doesn't abort
+# a multi-file migration midway. Override via env for flaky networks.
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
+RETRY_INITIAL_SECONDS="${RETRY_INITIAL_SECONDS:-2}"
+
+# run_with_retry runs "$@" until it succeeds or MAX_ATTEMPTS is reached.
+# Any non-zero exit triggers a retry; broken SQL still aborts once the
+# attempts are exhausted (default budget ~30s of backoff).
+run_with_retry() {
+    local attempt=1
+    local delay=$RETRY_INITIAL_SECONDS
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+            echo "  failed after $attempt attempt(s); aborting" >&2
+            return 1
+        fi
+        echo "  attempt $attempt/$MAX_ATTEMPTS failed; retrying in ${delay}s..." >&2
+        sleep "$delay"
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+    done
+}
+
 # Get all .sql files in ./internal/migrations folder
 files=(./internal/migrations/*.sql)
 num_files=${#files[@]}
@@ -25,15 +52,17 @@ num_files=${#files[@]}
 for i in "${!files[@]}"; do
     file="${files[$i]}"
     echo "Running $file"
-        
-    cmd="kwil-cli exec-sql --file $file --private-key \"$PRIVATE_KEY\" --provider \"$PROVIDER\""
+
+    cmd=(kwil-cli exec-sql --file "$file" --private-key "$PRIVATE_KEY" --provider "$PROVIDER")
 
     # Add --sync only for the last file if SYNC is true
     if [ "$SYNC" = "true" ] && [ $((i + 1)) -eq "$num_files" ]; then
-        cmd="$cmd --sync"
+        cmd+=(--sync)
     fi
-    
-    eval $cmd
+
+    if ! run_with_retry "${cmd[@]}"; then
+        exit 1
+    fi
 done
 
 # After all migrations are run, grant the network_writers_manager role to the ADMIN_WALLET if provided.
@@ -43,9 +72,11 @@ if [ -n "$ADMIN_WALLET" ]; then
     local_admin_wallet=$(echo "$ADMIN_WALLET" | tr '[:upper:]' '[:lower:]')
 
     echo "Granting network_writers_manager role to $local_admin_wallet"
-    kwil-cli exec-sql \
+    if ! run_with_retry kwil-cli exec-sql \
         "INSERT INTO role_members (owner, role_name, wallet, granted_at, granted_by) VALUES ('system', 'network_writers_manager', \$wallet, 0, 'system') ON CONFLICT (owner, role_name, wallet) DO NOTHING;" \
         --param wallet:text="$local_admin_wallet" \
         --private-key "$PRIVATE_KEY" \
-        --provider "$PROVIDER" --sync
+        --provider "$PROVIDER" --sync; then
+        exit 1
+    fi
 fi


### PR DESCRIPTION
ref: https://github.com/truflation/website/issues/3391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal library dependencies to newer versions.
  * Added a production migration to disable the deprecated sepolia bridge on mainnet.
* **Bug Fixes**
  * Improved migration tooling: safer command execution and configurable retry/backoff to avoid partial failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->