### PR TITLE
docs: view Upgrading the PostgreSQL Image section guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -75,8 +75,12 @@ task single:start:admin
 
 It layers `compose.admin.yaml` on the default compose file: host port
 `8485` bound to `127.0.0.1` only, kwild started with `--admin.listen
-0.0.0.0:8485 --admin.notls`. Same trust model as the default unix socket
-— just over TCP. Stop with the regular `task single:stop`.
+0.0.0.0:8485 --admin.notls`. Convenient for on-host dev work, but **not
+equivalent to the default unix socket** — any process running as any
+user on the host can reach loopback TCP, while the unix socket gates
+access by filesystem permissions. For production on the same host,
+prefer the default unix socket; if you need the port open, pair it with
+`--admin.pass` or mTLS. Stop with the regular `task single:stop`.
 
 For **off-host access** (data provider's laptop, a different VM, a CI
 runner) set `TN_ADMIN_BIND=0.0.0.0` to expose the port and pick a real

--- a/docs/node-operator-guide.md
+++ b/docs/node-operator-guide.md
@@ -626,6 +626,58 @@ pg_dump --version
 
 **Security Warning**: It is recommended to not expose port 5432 publicly in production environments.
 
+### Upgrading the PostgreSQL Image
+
+Some `kwild` upgrades ship alongside a new `kwil-postgres` image. The `:latest` tag is **not** auto-pulled — Docker keeps using the image you originally pulled until you explicitly refresh it. If a node upgrade fails to start because of a Postgres version or setting mismatch, manually pull the latest image and recreate the container.
+
+#### For Linux
+
+```bash
+# Stop kwild first so it releases the database connection
+sudo systemctl stop kwild
+
+# Stop and remove the old container — KEEP the volume, your data lives there
+docker stop tn-postgres
+docker rm tn-postgres
+
+# Pull the latest image
+docker pull ghcr.io/trufnetwork/kwil-postgres:latest
+
+# Recreate the container with the SAME volume name (data is preserved)
+docker run -d -p 127.0.0.1:5432:5432 --name tn-postgres \
+    -e "POSTGRES_HOST_AUTH_METHOD=trust" \
+    -v tn-pgdata:/var/lib/postgresql/data \
+    --shm-size=1gb \
+    ghcr.io/trufnetwork/kwil-postgres:latest
+
+# Start kwild back up
+sudo systemctl start kwild
+```
+
+#### For macOS
+
+```bash
+# Stop kwild first so it releases the database connection
+launchctl stop com.trufnetwork.kwild
+
+# Stop and remove the old container — KEEP the volume, your data lives there
+docker stop tn-postgres
+docker rm tn-postgres
+
+# Pull the latest image
+docker pull ghcr.io/trufnetwork/kwil-postgres:latest
+
+# Recreate the container with the SAME volume name (data is preserved)
+docker run -d -p 127.0.0.1:5432:5432 --name tn-postgres \
+    -e "POSTGRES_HOST_AUTH_METHOD=trust" \
+    -v tn-pgdata:/var/lib/postgresql/data \
+    --shm-size=1gb \
+    ghcr.io/trufnetwork/kwil-postgres:latest
+
+# Start kwild back up
+launchctl start com.trufnetwork.kwild
+```
+
 ### Missing Logs on Linux (`journalctl` shows no entries)
 
 If you're running `kwild` as a `systemd` service but encounter the following when checking logs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced admin RPC security guidance in development documentation with clarified warnings about TCP vs. unix-socket trust models and production recommendations.
  * Added PostgreSQL Docker image upgrade instructions to the node operator guide, including step-by-step procedures for Linux and macOS environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->