### PR TITLE
feat: allow zeros per-stream to persist value=0

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -67,3 +67,20 @@ Flexible key-value storage for additional stream properties.
 | `value_ref` | | Reference value |
 | `created_at` | | Record creation timestamp |
 | `disabled_at` | | Soft deletion timestamp |
+
+#### Reserved metadata keys
+
+The `metadata_key` column is open for stream-owner use, but a fixed set
+of reserved keys drive built-in actions:
+
+| Key | Value column | Set by | Read by |
+|-----|--------------|--------|---------|
+| `stream_owner` | `value_ref` | `create_stream`, `transfer_stream_ownership` | `is_stream_owner` |
+| `read_visibility` | `value_i` | `create_stream`, `set_read_visibility` | `is_allowed_to_read_*` |
+| `compose_visibility` | `value_i` | `set_compose_visibility` | composed-query gates |
+| `allow_read_wallet` | `value_ref` | `allow_read_wallet` | `is_allowed_to_read_*` |
+| `allow_compose_stream` | `value_ref` | `allow_compose_stream` | composed-query gates |
+| `readonly_key` | `value_s` | `create_stream` | `insert_metadata`, `disable_metadata` |
+| `type` | `value_s` | `create_stream` | informational |
+| `default_base_time` | `value_i` | SDK `set_default_base_time` | index-base lookup |
+| `allow_zeros` | `value_b` | `create_stream($allow_zeros=TRUE)`, `set_allow_zeros(true)` | `insert_records`, `helper_enqueue_prune_days` (default FALSE: zeros dropped on insert) |

--- a/internal/migrations/001-common-actions.prod.sql
+++ b/internal/migrations/001-common-actions.prod.sql
@@ -16,7 +16,8 @@
 
 CREATE OR REPLACE ACTION create_streams(
     $stream_ids TEXT[],
-    $stream_types TEXT[]
+    $stream_types TEXT[],
+    $allow_zeros BOOL[] DEFAULT NULL
 ) PUBLIC {
     -- ===== FEE COLLECTION WITH ROLE EXEMPTION =====
     $lower_caller TEXT := LOWER(@caller);
@@ -71,6 +72,12 @@ CREATE OR REPLACE ACTION create_streams(
     -- Check if stream_ids and stream_types arrays have the same length
     if array_length($stream_ids) != array_length($stream_types) {
         ERROR('Stream IDs and stream types arrays must have the same length');
+    }
+
+    -- If allow_zeros array was provided, it must have the same length as stream_ids.
+    -- A NULL array means "use default (FALSE) for every stream" — no row written.
+    if $allow_zeros IS NOT NULL AND array_length($allow_zeros) != array_length($stream_ids) {
+        ERROR('allow_zeros array length must match stream_ids');
     }
 
     -- Validate stream IDs
@@ -268,6 +275,41 @@ CREATE OR REPLACE ACTION create_streams(
     FROM UNNEST($stream_ids, $stream_types) AS t(stream_id, stream_type)
     JOIN data_providers dp ON dp.address = $data_provider
     JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id;
+
+    -- Insert allow_zeros metadata only when explicitly set to TRUE.
+    -- FALSE / NULL leaves the row absent so the implicit default of FALSE
+    -- (today's behavior — zeros dropped on insert) is preserved.
+    if $allow_zeros IS NOT NULL {
+        INSERT INTO metadata (
+            row_id,
+            metadata_key,
+            value_i,
+            value_f,
+            value_b,
+            value_s,
+            value_ref,
+            created_at,
+            disabled_at,
+            stream_ref,
+            tx_id
+        )
+        SELECT
+            uuid_generate_v5($base_uuid, 'metadata' || $data_provider || t.stream_id || 'allow_zeros' || '6')::UUID,
+            'allow_zeros'::TEXT,
+            NULL::INT,
+            NULL::NUMERIC(36,18),
+            TRUE,
+            NULL::TEXT,
+            NULL::TEXT,
+            @height,
+            NULL::INT,
+            s.id,
+            @txid
+        FROM UNNEST($stream_ids, $allow_zeros) AS t(stream_id, allow_z)
+        JOIN data_providers dp ON dp.address = $data_provider
+        JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id
+        WHERE COALESCE(t.allow_z, FALSE) = TRUE;
+    }
 
     record_transaction_event(
         1,

--- a/internal/migrations/001-common-actions.sql
+++ b/internal/migrations/001-common-actions.sql
@@ -397,7 +397,16 @@ CREATE OR REPLACE ACTION insert_metadata(
     if !is_stream_owner($data_provider, $stream_id, $lower_caller) {
         ERROR('Only stream owner can insert metadata');
     }
-    
+
+    -- Reserved keys: allow_zeros has a dedicated mutator (set_allow_zeros)
+    -- that handles the disable-then-insert sequence atomically. Routing
+    -- writes through the generic insert_metadata path would let two
+    -- concurrent rows coexist and break the "latest non-disabled wins"
+    -- semantics that insert_records / helper_enqueue_prune_days rely on.
+    if LOWER($key) = 'allow_zeros' {
+        ERROR('use set_allow_zeros to modify allow_zeros');
+    }
+
     -- Set the appropriate value based on type
     if $val_type = 'int' {
         $value_i := $value::INT;
@@ -503,7 +512,15 @@ CREATE OR REPLACE ACTION disable_metadata(
     if $found = false {
         ERROR('Metadata record not found');
     }
-    
+
+    -- Reserved keys: allow_zeros has a dedicated mutator (set_allow_zeros)
+    -- that disables-and-reinserts atomically. Letting disable_metadata
+    -- soft-delete this row in isolation would silently flip a stream
+    -- back to default-FALSE without writing the corresponding audit row.
+    if LOWER($metadata_key) = 'allow_zeros' {
+        ERROR('use set_allow_zeros to modify allow_zeros');
+    }
+
     -- In a separate step, check if the key is read-only
     $is_readonly BOOL := false;
     for $readonly_row in SELECT * FROM metadata 

--- a/internal/migrations/001-common-actions.sql
+++ b/internal/migrations/001-common-actions.sql
@@ -37,13 +37,19 @@ CREATE OR REPLACE ACTION create_data_provider(
  * create_stream: Creates a new stream with required metadata.
  * Validates stream_id format, data provider address, and stream type.
  * Sets default metadata including type, owner, visibility, and readonly keys.
+ *
+ * Optional $allow_zeros (default FALSE) controls whether value=0 inserts
+ * are persisted on this stream. Default FALSE preserves the existing
+ * behavior (zeros are silently dropped on insert and excluded from prune
+ * enqueueing). Set TRUE to allow zero-valued records.
  */
 CREATE OR REPLACE ACTION create_stream(
     $stream_id TEXT,
-    $stream_type TEXT
+    $stream_type TEXT,
+    $allow_zeros BOOL DEFAULT FALSE
 ) PUBLIC {
     -- Delegate to batch implementation for single-stream consistency.
-    create_streams( ARRAY[$stream_id], ARRAY[$stream_type] );
+    create_streams( ARRAY[$stream_id], ARRAY[$stream_type], ARRAY[$allow_zeros] );
 };
 
 /**
@@ -52,10 +58,17 @@ CREATE OR REPLACE ACTION create_stream(
  * Exemption: system:network_writer role bypasses fee collection
  * Validates stream_id format, data provider address, and stream type.
  * Sets default metadata including type, owner, visibility, and readonly keys.
+ *
+ * Optional $allow_zeros: per-stream BOOL array (defaults to NULL — every
+ * stream gets the implicit default of FALSE, today's behavior). When
+ * supplied, length must match $stream_ids; only TRUE entries write a
+ * persisted metadata row. FALSE entries leave the row absent so the
+ * default-FALSE join in insert_records continues to drop value=0 inserts.
  */
 CREATE OR REPLACE ACTION create_streams(
     $stream_ids TEXT[],
-    $stream_types TEXT[]
+    $stream_types TEXT[],
+    $allow_zeros BOOL[] DEFAULT NULL
 ) PUBLIC {
     -- ===== FEE COLLECTION WITH ROLE EXEMPTION =====
     $lower_caller TEXT := LOWER(@caller);
@@ -110,6 +123,12 @@ CREATE OR REPLACE ACTION create_streams(
     -- Check if stream_ids and stream_types arrays have the same length
     if array_length($stream_ids) != array_length($stream_types) {
         ERROR('Stream IDs and stream types arrays must have the same length');
+    }
+
+    -- If allow_zeros array was provided, it must have the same length as stream_ids.
+    -- A NULL array means "use default (FALSE) for every stream" — no row written.
+    if $allow_zeros IS NOT NULL AND array_length($allow_zeros) != array_length($stream_ids) {
+        ERROR('allow_zeros array length must match stream_ids');
     }
 
     -- Validate stream IDs
@@ -307,6 +326,41 @@ CREATE OR REPLACE ACTION create_streams(
     FROM UNNEST($stream_ids, $stream_types) AS t(stream_id, stream_type)
     JOIN data_providers dp ON dp.address = $data_provider
     JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id;
+
+    -- Insert allow_zeros metadata only when explicitly set to TRUE.
+    -- FALSE / NULL leaves the row absent so the implicit default of FALSE
+    -- (today's behavior — zeros dropped on insert) is preserved.
+    if $allow_zeros IS NOT NULL {
+        INSERT INTO metadata (
+            row_id,
+            metadata_key,
+            value_i,
+            value_f,
+            value_b,
+            value_s,
+            value_ref,
+            created_at,
+            disabled_at,
+            stream_ref,
+            tx_id
+        )
+        SELECT
+            uuid_generate_v5($base_uuid, 'metadata' || $data_provider || t.stream_id || 'allow_zeros' || '6')::UUID,
+            'allow_zeros'::TEXT,
+            NULL::INT,
+            NULL::NUMERIC(36,18),
+            TRUE,
+            NULL::TEXT,
+            NULL::TEXT,
+            @height,
+            NULL::INT,
+            s.id,
+            @txid
+        FROM UNNEST($stream_ids, $allow_zeros) AS t(stream_id, allow_z)
+        JOIN data_providers dp ON dp.address = $data_provider
+        JOIN streams s ON s.data_provider_id = dp.id AND s.stream_id = t.stream_id
+        WHERE COALESCE(t.allow_z, FALSE) = TRUE;
+    }
 
     record_transaction_event(
         1,

--- a/internal/migrations/003-primitive-insertion.prod.sql
+++ b/internal/migrations/003-primitive-insertion.prod.sql
@@ -110,7 +110,10 @@ CREATE OR REPLACE ACTION insert_records(
     LEFT JOIN (
         -- Latest non-disabled allow_zeros row per stream in this batch.
         -- Deterministic tiebreaker (created_at DESC, row_id DESC) is required
-        -- to keep the action AppHash-stable across nodes.
+        -- to keep the action AppHash-stable across nodes. The inner JOIN
+        -- against UNNEST scopes the metadata scan to the batch's distinct
+        -- stream_refs so insert latency stays bounded by batch size, not
+        -- by the global allow_zeros row count.
         SELECT stream_ref, value_b AS allow_zeros FROM (
             SELECT
                 md.stream_ref,
@@ -120,6 +123,10 @@ CREATE OR REPLACE ACTION insert_records(
                     ORDER BY md.created_at DESC, md.row_id DESC
                 ) AS rn
             FROM metadata md
+            JOIN (SELECT DISTINCT r.stream_ref
+                  FROM UNNEST($stream_refs) AS r(stream_ref)
+                  WHERE r.stream_ref IS NOT NULL) batch
+              ON batch.stream_ref = md.stream_ref
             WHERE md.metadata_key = 'allow_zeros'
               AND md.disabled_at IS NULL
         ) ranked WHERE rn = 1

--- a/internal/migrations/003-primitive-insertion.prod.sql
+++ b/internal/migrations/003-primitive-insertion.prod.sql
@@ -93,7 +93,11 @@ CREATE OR REPLACE ACTION insert_records(
         $stream_refs := $v.stream_refs;
     }
 
-    -- Insert all records using UNNEST to expand arrays efficiently
+    -- Insert all records using UNNEST to expand arrays efficiently.
+    -- The per-stream `allow_zeros` flag (default FALSE — no metadata row)
+    -- gates the value=0 drop. Streams without an explicit `allow_zeros`
+    -- metadata row inherit the default FALSE, preserving today's behavior.
+    -- Streams opted in via `allow_zeros=TRUE` persist value=0 records.
     INSERT INTO primitive_events (event_time, value, created_at, truflation_created_at, stream_ref, tx_id)
     SELECT
         unnested.event_time,
@@ -103,7 +107,26 @@ CREATE OR REPLACE ACTION insert_records(
         unnested.stream_ref,
         @txid
     FROM UNNEST($event_time, $value, $stream_refs) AS unnested(event_time, value, stream_ref)
-    WHERE unnested.value != 0::NUMERIC(36,18)
+    LEFT JOIN (
+        -- Latest non-disabled allow_zeros row per stream in this batch.
+        -- Deterministic tiebreaker (created_at DESC, row_id DESC) is required
+        -- to keep the action AppHash-stable across nodes.
+        SELECT stream_ref, value_b AS allow_zeros FROM (
+            SELECT
+                md.stream_ref,
+                md.value_b,
+                ROW_NUMBER() OVER (
+                    PARTITION BY md.stream_ref
+                    ORDER BY md.created_at DESC, md.row_id DESC
+                ) AS rn
+            FROM metadata md
+            WHERE md.metadata_key = 'allow_zeros'
+              AND md.disabled_at IS NULL
+        ) ranked WHERE rn = 1
+    ) cfg ON cfg.stream_ref = unnested.stream_ref
+    WHERE
+        unnested.value != 0::NUMERIC(36,18)
+        OR COALESCE(cfg.allow_zeros, FALSE) = TRUE
     ORDER BY unnested.stream_ref, unnested.event_time, $current_block;  -- matches (stream_ref, event_time, created_at)
 
     -- Enqueue days for pruning using helper (idempotent, distinct per day)

--- a/internal/migrations/003-primitive-insertion.sql
+++ b/internal/migrations/003-primitive-insertion.sql
@@ -100,7 +100,11 @@ CREATE OR REPLACE ACTION insert_records(
         $stream_refs := $v.stream_refs;
     }
 
-    -- Insert all records using UNNEST to expand arrays efficiently
+    -- Insert all records using UNNEST to expand arrays efficiently.
+    -- The per-stream `allow_zeros` flag (default FALSE — no metadata row)
+    -- gates the value=0 drop. Streams without an explicit `allow_zeros`
+    -- metadata row inherit the default FALSE, preserving today's behavior.
+    -- Streams opted in via `allow_zeros=TRUE` persist value=0 records.
     INSERT INTO primitive_events (event_time, value, created_at, truflation_created_at, stream_ref, tx_id)
     SELECT
         unnested.event_time,
@@ -110,7 +114,26 @@ CREATE OR REPLACE ACTION insert_records(
         unnested.stream_ref,
         @txid
     FROM UNNEST($event_time, $value, $stream_refs) AS unnested(event_time, value, stream_ref)
-    WHERE unnested.value != 0::NUMERIC(36,18)
+    LEFT JOIN (
+        -- Latest non-disabled allow_zeros row per stream in this batch.
+        -- Deterministic tiebreaker (created_at DESC, row_id DESC) is required
+        -- to keep the action AppHash-stable across nodes.
+        SELECT stream_ref, value_b AS allow_zeros FROM (
+            SELECT
+                md.stream_ref,
+                md.value_b,
+                ROW_NUMBER() OVER (
+                    PARTITION BY md.stream_ref
+                    ORDER BY md.created_at DESC, md.row_id DESC
+                ) AS rn
+            FROM metadata md
+            WHERE md.metadata_key = 'allow_zeros'
+              AND md.disabled_at IS NULL
+        ) ranked WHERE rn = 1
+    ) cfg ON cfg.stream_ref = unnested.stream_ref
+    WHERE
+        unnested.value != 0::NUMERIC(36,18)
+        OR COALESCE(cfg.allow_zeros, FALSE) = TRUE
     ORDER BY unnested.stream_ref, unnested.event_time, $current_block;  -- matches (stream_ref, event_time, created_at)
 
     -- Enqueue days for pruning using helper (idempotent, distinct per day)

--- a/internal/migrations/003-primitive-insertion.sql
+++ b/internal/migrations/003-primitive-insertion.sql
@@ -117,7 +117,10 @@ CREATE OR REPLACE ACTION insert_records(
     LEFT JOIN (
         -- Latest non-disabled allow_zeros row per stream in this batch.
         -- Deterministic tiebreaker (created_at DESC, row_id DESC) is required
-        -- to keep the action AppHash-stable across nodes.
+        -- to keep the action AppHash-stable across nodes. The inner JOIN
+        -- against UNNEST scopes the metadata scan to the batch's distinct
+        -- stream_refs so insert latency stays bounded by batch size, not
+        -- by the global allow_zeros row count.
         SELECT stream_ref, value_b AS allow_zeros FROM (
             SELECT
                 md.stream_ref,
@@ -127,6 +130,10 @@ CREATE OR REPLACE ACTION insert_records(
                     ORDER BY md.created_at DESC, md.row_id DESC
                 ) AS rn
             FROM metadata md
+            JOIN (SELECT DISTINCT r.stream_ref
+                  FROM UNNEST($stream_refs) AS r(stream_ref)
+                  WHERE r.stream_ref IS NOT NULL) batch
+              ON batch.stream_ref = md.stream_ref
             WHERE md.metadata_key = 'allow_zeros'
               AND md.disabled_at IS NULL
         ) ranked WHERE rn = 1

--- a/internal/migrations/046-allow-zeros-config.sql
+++ b/internal/migrations/046-allow-zeros-config.sql
@@ -1,0 +1,111 @@
+/**
+ * 046-allow-zeros-config.sql
+ *
+ * Per-stream `allow_zeros` config: lets a stream owner opt into
+ * persisting `value=0` inserts. Default behavior (no metadata row) is
+ * preserved exactly — zeros continue to be dropped on insert and
+ * skipped by the prune-day enqueue helper, just like today.
+ *
+ * Storage: a `metadata` row keyed `allow_zeros` with `value_b=TRUE`
+ * means "this stream persists zeros". Absence of a row means default
+ * FALSE. We deliberately never store FALSE rows so existing streams
+ * need no migration — the default-FALSE LEFT JOIN in `insert_records`
+ * and `helper_enqueue_prune_days` resolves missing rows to FALSE and
+ * reproduces today's filter bit-identically.
+ *
+ * The four touched actions (`create_stream`, `create_streams`,
+ * `insert_records`, `helper_enqueue_prune_days`) are modified directly
+ * in their canonical source files (001-common-actions.sql,
+ * 003-primitive-insertion.sql, 901-utilities.sql). This file only
+ * defines the genuinely new accessor actions: the owner-gated mutator
+ * and a public read.
+ */
+
+/**
+ * set_allow_zeros: Owner-gated mutator for the per-stream allow_zeros flag.
+ *
+ * Disables any prior allow_zeros metadata row for this stream and, when
+ * $value=TRUE, writes a fresh row marking the stream opt-in. When
+ * $value=FALSE, disabling the existing row is sufficient — the implicit
+ * default of FALSE then applies, restoring today's filter behavior.
+ *
+ * The toggle is forward-only: zeros that were dropped before the flip
+ * stay dropped; zeros that arrive after the flip persist.
+ */
+CREATE OR REPLACE ACTION set_allow_zeros(
+    $data_provider TEXT,
+    $stream_id TEXT,
+    $value BOOL
+) PUBLIC {
+    $data_provider := LOWER($data_provider);
+    $lower_caller TEXT := LOWER(@caller);
+
+    if !is_stream_owner($data_provider, $stream_id, $lower_caller) {
+        ERROR('Only stream owner can set allow_zeros');
+    }
+
+    $stream_ref INT := get_stream_id($data_provider, $stream_id);
+    $current_block INT := @height;
+
+    -- Soft-delete prior rows (idempotent — disabling already-disabled is a no-op).
+    UPDATE metadata
+    SET disabled_at = $current_block
+    WHERE stream_ref = $stream_ref
+      AND metadata_key = 'allow_zeros'
+      AND disabled_at IS NULL;
+
+    if $value = TRUE {
+        $row_id UUID := uuid_generate_kwil('allow_zeros' || @txid || $data_provider || $stream_id);
+        INSERT INTO metadata (
+            row_id, metadata_key, value_i, value_f, value_b, value_s, value_ref, created_at, disabled_at, stream_ref, tx_id
+        ) VALUES (
+            $row_id,
+            'allow_zeros',
+            NULL,
+            NULL,
+            TRUE,
+            NULL,
+            NULL,
+            $current_block,
+            NULL,
+            $stream_ref,
+            @txid
+        );
+    }
+};
+
+/**
+ * get_allow_zeros: Public read for the latest allow_zeros flag.
+ *
+ * Returns TRUE only when the stream has an explicit non-disabled
+ * allow_zeros metadata row with value_b=TRUE. Absence (or value_b NULL,
+ * or value_b=FALSE) collapses to FALSE — the default-FALSE semantics.
+ */
+CREATE OR REPLACE ACTION get_allow_zeros(
+    $data_provider TEXT,
+    $stream_id TEXT
+) PUBLIC view returns (allow_zeros BOOL) {
+    $data_provider := LOWER($data_provider);
+    $stream_ref INT := get_stream_id($data_provider, $stream_id);
+
+    IF $stream_ref IS NULL {
+        ERROR('Stream does not exist: data_provider=' || $data_provider || ' stream_id=' || $stream_id);
+    }
+
+    -- Avoid COALESCE inside the FOR loop body (Kuneiform forbids
+    -- function calls in nested queries). Test the raw value_b directly.
+    $result BOOL := FALSE;
+    for $row in SELECT value_b
+        FROM metadata
+        WHERE stream_ref = $stream_ref
+          AND metadata_key = 'allow_zeros'
+          AND disabled_at IS NULL
+        ORDER BY created_at DESC, row_id DESC
+        LIMIT 1 {
+        if $row.value_b = TRUE {
+            $result := TRUE;
+        }
+    }
+
+    RETURN $result;
+};

--- a/internal/migrations/901-utilities.sql
+++ b/internal/migrations/901-utilities.sql
@@ -142,27 +142,49 @@ CREATE OR REPLACE ACTION helper_check_cache(
     RETURN $cache_hit;
 };
 
--- Enqueue pending prune days for a batch of records, filtering out zero values
+-- Enqueue pending prune days for a batch of records.
+-- Zero-valued records are skipped by default (today's behavior) so the
+-- digest pipeline doesn't waste work on days that produced no persisted
+-- rows. Streams opted in via `allow_zeros=TRUE` persist zero values, and
+-- their zero-day rows must be enqueued so digest can see them; the
+-- per-stream allow_zeros lookup below gates that case.
 CREATE OR REPLACE ACTION helper_enqueue_prune_days(
     $stream_refs INT[],
     $event_times INT8[],
     $values NUMERIC(36,18)[]
 ) PRIVATE {
-    IF COALESCE(array_length($event_times), 0) = 0 {  
-         RETURN;  
-     }  
-    IF COALESCE(array_length($stream_refs), 0) != COALESCE(array_length($event_times), 0)  
-       OR COALESCE(array_length($event_times), 0) != COALESCE(array_length($values), 0) {  
-        ERROR('helper_enqueue_prune_days: array lengths mismatch');  
-    } 
+    IF COALESCE(array_length($event_times), 0) = 0 {
+         RETURN;
+     }
+    IF COALESCE(array_length($stream_refs), 0) != COALESCE(array_length($event_times), 0)
+       OR COALESCE(array_length($event_times), 0) != COALESCE(array_length($values), 0) {
+        ERROR('helper_enqueue_prune_days: array lengths mismatch');
+    }
 
     INSERT INTO pending_prune_days (stream_ref, day_index)
     SELECT DISTINCT
         t.stream_ref,
         (t.event_time / 86400)::INT AS day_index
     FROM UNNEST($stream_refs, $event_times, $values) AS t(stream_ref, event_time, value)
+    LEFT JOIN (
+        -- Latest non-disabled allow_zeros row per stream in this batch.
+        -- Deterministic tiebreaker (created_at DESC, row_id DESC) keeps the
+        -- action AppHash-stable across nodes.
+        SELECT stream_ref, value_b AS allow_zeros FROM (
+            SELECT
+                md.stream_ref,
+                md.value_b,
+                ROW_NUMBER() OVER (
+                    PARTITION BY md.stream_ref
+                    ORDER BY md.created_at DESC, md.row_id DESC
+                ) AS rn
+            FROM metadata md
+            WHERE md.metadata_key = 'allow_zeros'
+              AND md.disabled_at IS NULL
+        ) ranked WHERE rn = 1
+    ) cfg ON cfg.stream_ref = t.stream_ref
     WHERE t.stream_ref IS NOT NULL
       AND t.event_time >= 0::INT8
-      AND t.value != 0::NUMERIC(36,18)
+      AND (t.value != 0::NUMERIC(36,18) OR COALESCE(cfg.allow_zeros, FALSE) = TRUE)
     ON CONFLICT (stream_ref, day_index) DO NOTHING;
 };

--- a/internal/migrations/901-utilities.sql
+++ b/internal/migrations/901-utilities.sql
@@ -169,7 +169,9 @@ CREATE OR REPLACE ACTION helper_enqueue_prune_days(
     LEFT JOIN (
         -- Latest non-disabled allow_zeros row per stream in this batch.
         -- Deterministic tiebreaker (created_at DESC, row_id DESC) keeps the
-        -- action AppHash-stable across nodes.
+        -- action AppHash-stable across nodes. The inner JOIN against
+        -- UNNEST scopes the metadata scan to the batch's distinct
+        -- stream_refs so enqueue latency stays bounded by batch size.
         SELECT stream_ref, value_b AS allow_zeros FROM (
             SELECT
                 md.stream_ref,
@@ -179,6 +181,10 @@ CREATE OR REPLACE ACTION helper_enqueue_prune_days(
                     ORDER BY md.created_at DESC, md.row_id DESC
                 ) AS rn
             FROM metadata md
+            JOIN (SELECT DISTINCT r.stream_ref
+                  FROM UNNEST($stream_refs) AS r(stream_ref)
+                  WHERE r.stream_ref IS NOT NULL) batch
+              ON batch.stream_ref = md.stream_ref
             WHERE md.metadata_key = 'allow_zeros'
               AND md.disabled_at IS NULL
         ) ranked WHERE rn = 1

--- a/tests/streams/allow_zeros_test.go
+++ b/tests/streams/allow_zeros_test.go
@@ -1,0 +1,370 @@
+package tests
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/trufnetwork/kwil-db/common"
+	kwilTesting "github.com/trufnetwork/kwil-db/testing"
+	"github.com/trufnetwork/node/internal/migrations"
+	testutils "github.com/trufnetwork/node/tests/streams/utils"
+	"github.com/trufnetwork/node/tests/streams/utils/procedure"
+	"github.com/trufnetwork/node/tests/streams/utils/setup"
+	"github.com/trufnetwork/sdk-go/core/types"
+	"github.com/trufnetwork/sdk-go/core/util"
+)
+
+// TestAllowZerosCombinations exercises the four-cell {filter on, filter off} ×
+// {value=0, value≠0} matrix on the insert path, plus the post-create
+// mutability path (set_allow_zeros) and the matching prune-enqueue gating.
+func TestAllowZerosCombinations(t *testing.T) {
+	testutils.RunSchemaTest(t, kwilTesting.SchemaTest{
+		Name:           "allow_zeros_combinations_test",
+		SeedStatements: migrations.GetSeedScriptStatements(),
+		FunctionTests: []kwilTesting.TestFunc{
+			testAllowZerosFourCombinations(t),
+			testAllowZerosDefaultPreservesBehavior(t),
+			testSetAllowZerosToggleMutability(t),
+			testAllowZerosGatesPruneEnqueue(t),
+			testGetAllowZerosReflectsState(t),
+		},
+	}, testutils.GetTestOptionsWithCache())
+}
+
+// testAllowZerosFourCombinations: in one platform, create two streams —
+// one default (allow_zeros=FALSE), one opted-in (allow_zeros=TRUE) — and
+// for each, insert one zero and one non-zero record. Verify get_record
+// returns the expected subset.
+func testAllowZerosFourCombinations(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x000000000000000000000000000000000000a110")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+		require.NoError(t, setup.CreateDataProvider(ctx, platform, deployer.Address()))
+
+		filterOnLocator := types.StreamLocator{
+			StreamId:     util.GenerateStreamId("allow_zeros_off_stream"),
+			DataProvider: deployer,
+		}
+		filterOffLocator := types.StreamLocator{
+			StreamId:     util.GenerateStreamId("allow_zeros_on_stream"),
+			DataProvider: deployer,
+		}
+
+		// Default-FALSE (filter on): zeros dropped.
+		require.NoError(t, createStreamWithAllowZeros(ctx, platform, filterOnLocator, false))
+		// Opt-in TRUE (filter off): zeros persist.
+		require.NoError(t, createStreamWithAllowZeros(ctx, platform, filterOffLocator, true))
+
+		// Insert {value=0, value=5} into both streams at distinct event_times.
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, filterOnLocator,
+			setup.InsertRecordInput{EventTime: 100, Value: 0}, 1))
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, filterOnLocator,
+			setup.InsertRecordInput{EventTime: 200, Value: 5}, 1))
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, filterOffLocator,
+			setup.InsertRecordInput{EventTime: 100, Value: 0}, 1))
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, filterOffLocator,
+			setup.InsertRecordInput{EventTime: 200, Value: 5}, 1))
+
+		// Filter ON: only non-zero shows up.
+		onRows, err := getRecordsRange(ctx, platform, filterOnLocator, 0, 1000)
+		require.NoError(t, err)
+		require.Equal(t, []rec{{EventTime: 200, Value: "5.000000000000000000"}}, onRows,
+			"filter_on stream: zero must be dropped, non-zero must persist")
+
+		// Filter OFF: both records show up.
+		offRows, err := getRecordsRange(ctx, platform, filterOffLocator, 0, 1000)
+		require.NoError(t, err)
+		require.Equal(t, []rec{
+			{EventTime: 100, Value: "0.000000000000000000"},
+			{EventTime: 200, Value: "5.000000000000000000"},
+		}, offRows, "filter_off stream: both zero and non-zero must persist")
+
+		return nil
+	}
+}
+
+// testAllowZerosDefaultPreservesBehavior: streams created via the
+// 2-arg create_stream() (no allow_zeros parameter — relies on DEFAULT
+// FALSE) must drop zeros exactly like before this feature shipped.
+func testAllowZerosDefaultPreservesBehavior(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x000000000000000000000000000000000000a111")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+		require.NoError(t, setup.CreateDataProvider(ctx, platform, deployer.Address()))
+
+		locator := types.StreamLocator{
+			StreamId:     util.GenerateStreamId("allow_zeros_default_stream"),
+			DataProvider: deployer,
+		}
+		// Use the existing 2-arg helper to confirm DEFAULT FALSE kicks in
+		// for old-shape callers (covers SDK backwards-compat).
+		require.NoError(t, setup.CreateStream(ctx, platform, setup.StreamInfo{
+			Type:    setup.ContractTypePrimitive,
+			Locator: locator,
+		}))
+
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, locator,
+			setup.InsertRecordInput{EventTime: 100, Value: 0}, 1))
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, locator,
+			setup.InsertRecordInput{EventTime: 200, Value: 7}, 1))
+
+		rows, err := getRecordsRange(ctx, platform, locator, 0, 1000)
+		require.NoError(t, err)
+		require.Equal(t, []rec{{EventTime: 200, Value: "7.000000000000000000"}}, rows,
+			"default-shape create_stream must preserve today's zero-drop behavior")
+
+		return nil
+	}
+}
+
+// testSetAllowZerosToggleMutability: create a default-FALSE stream,
+// confirm zeros are dropped, then call set_allow_zeros(TRUE) and confirm
+// subsequent zero inserts persist. Then flip back to FALSE and confirm
+// new zeros are dropped again. Earlier-persisted zero stays put (the
+// flag is forward-only).
+func testSetAllowZerosToggleMutability(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x000000000000000000000000000000000000a112")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+		require.NoError(t, setup.CreateDataProvider(ctx, platform, deployer.Address()))
+
+		locator := types.StreamLocator{
+			StreamId:     util.GenerateStreamId("allow_zeros_toggle_stream"),
+			DataProvider: deployer,
+		}
+		require.NoError(t, createStreamWithAllowZeros(ctx, platform, locator, false))
+
+		// Stage 1: default off — zero dropped.
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, locator,
+			setup.InsertRecordInput{EventTime: 100, Value: 0}, 1))
+		rows, err := getRecordsRange(ctx, platform, locator, 0, 1000)
+		require.NoError(t, err)
+		require.Empty(t, rows, "stage 1: zero with allow_zeros=FALSE must be dropped")
+
+		// Toggle on.
+		require.NoError(t, setAllowZeros(ctx, platform, locator, true))
+
+		// Stage 2: zeros now persist.
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, locator,
+			setup.InsertRecordInput{EventTime: 200, Value: 0}, 2))
+		rows, err = getRecordsRange(ctx, platform, locator, 0, 1000)
+		require.NoError(t, err)
+		require.Equal(t, []rec{{EventTime: 200, Value: "0.000000000000000000"}}, rows,
+			"stage 2: zero after allow_zeros=TRUE flip must persist")
+
+		// Toggle off again.
+		require.NoError(t, setAllowZeros(ctx, platform, locator, false))
+
+		// Stage 3: new zeros are dropped, but the one from stage 2 stays.
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, locator,
+			setup.InsertRecordInput{EventTime: 300, Value: 0}, 3))
+		rows, err = getRecordsRange(ctx, platform, locator, 0, 1000)
+		require.NoError(t, err)
+		require.Equal(t, []rec{{EventTime: 200, Value: "0.000000000000000000"}}, rows,
+			"stage 3: zero after flip-back-to-FALSE must be dropped; earlier zero must remain")
+
+		return nil
+	}
+}
+
+// testAllowZerosGatesPruneEnqueue: with allow_zeros=TRUE, zero-only
+// days must be enqueued in pending_prune_days so digest can see them.
+// With allow_zeros=FALSE, zero-only days must NOT be enqueued (today's
+// behavior, prevents wasted digest cycles for filtered-out values).
+func testAllowZerosGatesPruneEnqueue(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x000000000000000000000000000000000000a113")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+		require.NoError(t, setup.CreateDataProvider(ctx, platform, deployer.Address()))
+
+		offLocator := types.StreamLocator{
+			StreamId:     util.GenerateStreamId("allow_zeros_prune_off_stream"),
+			DataProvider: deployer,
+		}
+		onLocator := types.StreamLocator{
+			StreamId:     util.GenerateStreamId("allow_zeros_prune_on_stream"),
+			DataProvider: deployer,
+		}
+		require.NoError(t, createStreamWithAllowZeros(ctx, platform, offLocator, false))
+		require.NoError(t, createStreamWithAllowZeros(ctx, platform, onLocator, true))
+
+		// Insert only zeros into both streams at day 0 and day 1.
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, offLocator,
+			setup.InsertRecordInput{EventTime: 100, Value: 0}, 1))
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, offLocator,
+			setup.InsertRecordInput{EventTime: 90000, Value: 0}, 2))
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, onLocator,
+			setup.InsertRecordInput{EventTime: 100, Value: 0}, 1))
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, onLocator,
+			setup.InsertRecordInput{EventTime: 90000, Value: 0}, 2))
+
+		offDays, err := getPendingDays(ctx, platform, deployer.Address(), offLocator.StreamId.String())
+		require.NoError(t, err)
+		require.Empty(t, offDays, "allow_zeros=FALSE: zero-only days must not be enqueued")
+
+		onDays, err := getPendingDays(ctx, platform, deployer.Address(), onLocator.StreamId.String())
+		require.NoError(t, err)
+		require.Equal(t, []int{0, 1}, onDays, "allow_zeros=TRUE: zero-only days must be enqueued")
+
+		return nil
+	}
+}
+
+// testGetAllowZerosReflectsState: get_allow_zeros must return FALSE
+// for streams without an explicit row (today's default), TRUE after
+// opt-in via create_stream(_, _, true), and round-trip through
+// set_allow_zeros toggles.
+func testGetAllowZerosReflectsState(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		deployer := util.Unsafe_NewEthereumAddressFromString("0x000000000000000000000000000000000000a114")
+		platform = procedure.WithSigner(platform, deployer.Bytes())
+		require.NoError(t, setup.CreateDataProvider(ctx, platform, deployer.Address()))
+
+		defaultLocator := types.StreamLocator{
+			StreamId:     util.GenerateStreamId("allow_zeros_view_default"),
+			DataProvider: deployer,
+		}
+		optInLocator := types.StreamLocator{
+			StreamId:     util.GenerateStreamId("allow_zeros_view_optin"),
+			DataProvider: deployer,
+		}
+		require.NoError(t, setup.CreateStream(ctx, platform, setup.StreamInfo{
+			Type: setup.ContractTypePrimitive, Locator: defaultLocator,
+		}))
+		require.NoError(t, createStreamWithAllowZeros(ctx, platform, optInLocator, true))
+
+		v, err := getAllowZeros(ctx, platform, defaultLocator)
+		require.NoError(t, err)
+		require.False(t, v, "default-shape create: get_allow_zeros must return FALSE")
+
+		v, err = getAllowZeros(ctx, platform, optInLocator)
+		require.NoError(t, err)
+		require.True(t, v, "opt-in create: get_allow_zeros must return TRUE")
+
+		// Toggle the default stream on, confirm view flips.
+		require.NoError(t, setAllowZeros(ctx, platform, defaultLocator, true))
+		v, err = getAllowZeros(ctx, platform, defaultLocator)
+		require.NoError(t, err)
+		require.True(t, v, "after set_allow_zeros(TRUE): view must return TRUE")
+
+		// Toggle off, confirm view flips back.
+		require.NoError(t, setAllowZeros(ctx, platform, defaultLocator, false))
+		v, err = getAllowZeros(ctx, platform, defaultLocator)
+		require.NoError(t, err)
+		require.False(t, v, "after set_allow_zeros(FALSE): view must return FALSE")
+
+		return nil
+	}
+}
+
+// ----- Helpers ---------------------------------------------------------
+
+type rec struct {
+	EventTime int64
+	Value     string
+}
+
+// createStreamWithAllowZeros calls create_stream with the third
+// allow_zeros argument explicitly. Mirrors setup.UntypedCreateStream
+// but extends the positional args list.
+func createStreamWithAllowZeros(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator, allowZeros bool) error {
+	addr, err := util.NewEthereumAddressFromString(locator.DataProvider.Address())
+	if err != nil {
+		return errors.Wrap(err, "invalid data provider address")
+	}
+
+	engineCtx := setup.NewEngineContext(ctx, platform, addr, 1)
+
+	r, err := platform.Engine.Call(engineCtx, platform.DB, "", "create_stream",
+		[]any{locator.StreamId.String(), string(setup.ContractTypePrimitive), allowZeros},
+		func(row *common.Row) error { return nil },
+	)
+	if err != nil {
+		return errors.Wrap(err, "create_stream call failed")
+	}
+	if r.Error != nil {
+		return errors.Wrap(r.Error, "create_stream action failed")
+	}
+	return nil
+}
+
+func setAllowZeros(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator, value bool) error {
+	addr, err := util.NewEthereumAddressFromString(locator.DataProvider.Address())
+	if err != nil {
+		return errors.Wrap(err, "invalid data provider address")
+	}
+	engineCtx := setup.NewEngineContext(ctx, platform, addr, 1)
+
+	r, err := platform.Engine.Call(engineCtx, platform.DB, "", "set_allow_zeros",
+		[]any{locator.DataProvider.Address(), locator.StreamId.String(), value},
+		func(row *common.Row) error { return nil },
+	)
+	if err != nil {
+		return errors.Wrap(err, "set_allow_zeros call failed")
+	}
+	if r.Error != nil {
+		return errors.Wrap(r.Error, "set_allow_zeros action failed")
+	}
+	return nil
+}
+
+func getAllowZeros(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator) (bool, error) {
+	addr, err := util.NewEthereumAddressFromString(locator.DataProvider.Address())
+	if err != nil {
+		return false, errors.Wrap(err, "invalid data provider address")
+	}
+	engineCtx := setup.NewEngineContext(ctx, platform, addr, 1)
+
+	var got bool
+	r, err := platform.Engine.Call(engineCtx, platform.DB, "", "get_allow_zeros",
+		[]any{locator.DataProvider.Address(), locator.StreamId.String()},
+		func(row *common.Row) error {
+			if len(row.Values) == 0 || row.Values[0] == nil {
+				return nil
+			}
+			b, ok := row.Values[0].(bool)
+			if !ok {
+				return errors.Errorf("get_allow_zeros: expected bool, got %T", row.Values[0])
+			}
+			got = b
+			return nil
+		},
+	)
+	if err != nil {
+		return false, errors.Wrap(err, "get_allow_zeros call failed")
+	}
+	if r.Error != nil {
+		return false, errors.Wrap(r.Error, "get_allow_zeros action failed")
+	}
+	return got, nil
+}
+
+// getRecordsRange wraps procedure.GetRecord with from/to int64 values
+// and returns a typed event_time + decimal-string slice.
+func getRecordsRange(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator, from, to int64) ([]rec, error) {
+	rows, err := procedure.GetRecord(ctx, procedure.GetRecordInput{
+		Platform:      platform,
+		StreamLocator: locator,
+		FromTime:      &from,
+		ToTime:        &to,
+		Height:        10,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]rec, 0, len(rows))
+	for _, row := range rows {
+		if len(row) < 2 {
+			return nil, errors.Errorf("get_record returned row with %d cols", len(row))
+		}
+		ts, err := strconv.ParseInt(row[0], 10, 64)
+		if err != nil {
+			return nil, errors.Wrap(err, "parse event_time")
+		}
+		out = append(out, rec{EventTime: ts, Value: row[1]})
+	}
+	return out, nil
+}

--- a/tests/streams/allow_zeros_test.go
+++ b/tests/streams/allow_zeros_test.go
@@ -30,6 +30,7 @@ func TestAllowZerosCombinations(t *testing.T) {
 			testSetAllowZerosToggleMutability(t),
 			testAllowZerosGatesPruneEnqueue(t),
 			testGetAllowZerosReflectsState(t),
+			testNonOwnerCannotToggleAllowZeros(t),
 		},
 	}, testutils.GetTestOptionsWithCache())
 }
@@ -71,15 +72,15 @@ func testAllowZerosFourCombinations(t *testing.T) func(ctx context.Context, plat
 		// Filter ON: only non-zero shows up.
 		onRows, err := getRecordsRange(ctx, platform, filterOnLocator, 0, 1000)
 		require.NoError(t, err)
-		require.Equal(t, []rec{{EventTime: 200, Value: "5.000000000000000000"}}, onRows,
+		require.Equal(t, []rec{{EventTime: 200, Value: 5}}, onRows,
 			"filter_on stream: zero must be dropped, non-zero must persist")
 
 		// Filter OFF: both records show up.
 		offRows, err := getRecordsRange(ctx, platform, filterOffLocator, 0, 1000)
 		require.NoError(t, err)
 		require.Equal(t, []rec{
-			{EventTime: 100, Value: "0.000000000000000000"},
-			{EventTime: 200, Value: "5.000000000000000000"},
+			{EventTime: 100, Value: 0},
+			{EventTime: 200, Value: 5},
 		}, offRows, "filter_off stream: both zero and non-zero must persist")
 
 		return nil
@@ -113,7 +114,7 @@ func testAllowZerosDefaultPreservesBehavior(t *testing.T) func(ctx context.Conte
 
 		rows, err := getRecordsRange(ctx, platform, locator, 0, 1000)
 		require.NoError(t, err)
-		require.Equal(t, []rec{{EventTime: 200, Value: "7.000000000000000000"}}, rows,
+		require.Equal(t, []rec{{EventTime: 200, Value: 7}}, rows,
 			"default-shape create_stream must preserve today's zero-drop behavior")
 
 		return nil
@@ -152,7 +153,7 @@ func testSetAllowZerosToggleMutability(t *testing.T) func(ctx context.Context, p
 			setup.InsertRecordInput{EventTime: 200, Value: 0}, 2))
 		rows, err = getRecordsRange(ctx, platform, locator, 0, 1000)
 		require.NoError(t, err)
-		require.Equal(t, []rec{{EventTime: 200, Value: "0.000000000000000000"}}, rows,
+		require.Equal(t, []rec{{EventTime: 200, Value: 0}}, rows,
 			"stage 2: zero after allow_zeros=TRUE flip must persist")
 
 		// Toggle off again.
@@ -163,7 +164,7 @@ func testSetAllowZerosToggleMutability(t *testing.T) func(ctx context.Context, p
 			setup.InsertRecordInput{EventTime: 300, Value: 0}, 3))
 		rows, err = getRecordsRange(ctx, platform, locator, 0, 1000)
 		require.NoError(t, err)
-		require.Equal(t, []rec{{EventTime: 200, Value: "0.000000000000000000"}}, rows,
+		require.Equal(t, []rec{{EventTime: 200, Value: 0}}, rows,
 			"stage 3: zero after flip-back-to-FALSE must be dropped; earlier zero must remain")
 
 		return nil
@@ -260,11 +261,50 @@ func testGetAllowZerosReflectsState(t *testing.T) func(ctx context.Context, plat
 	}
 }
 
+// testNonOwnerCannotToggleAllowZeros: a wallet that didn't create the
+// stream must not be able to flip its allow_zeros flag, and a failed
+// attempt must leave the current state unchanged.
+func testNonOwnerCannotToggleAllowZeros(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		owner := util.Unsafe_NewEthereumAddressFromString("0x000000000000000000000000000000000000a115")
+		platform = procedure.WithSigner(platform, owner.Bytes())
+		require.NoError(t, setup.CreateDataProvider(ctx, platform, owner.Address()))
+
+		defaultLocator := types.StreamLocator{
+			StreamId:     util.GenerateStreamId("allow_zeros_authz_stream"),
+			DataProvider: owner,
+		}
+		// Create with the default (FALSE).
+		require.NoError(t, setup.CreateStream(ctx, platform, setup.StreamInfo{
+			Type: setup.ContractTypePrimitive, Locator: defaultLocator,
+		}))
+
+		prev, err := getAllowZeros(ctx, platform, defaultLocator)
+		require.NoError(t, err)
+		require.False(t, prev, "precondition: default-shape stream must report allow_zeros=false")
+
+		stranger := util.Unsafe_NewEthereumAddressFromString("0x00000000000000000000000000000000000ba115")
+		err = setAllowZerosAs(ctx, platform, defaultLocator, true, stranger)
+		require.Error(t, err, "non-owner toggle must be rejected by the action")
+		require.Contains(t, err.Error(), "Only stream owner",
+			"reject reason should come from the is_stream_owner guard")
+
+		after, err := getAllowZeros(ctx, platform, defaultLocator)
+		require.NoError(t, err)
+		require.Equal(t, prev, after, "rejected toggle must not change the stored flag")
+
+		return nil
+	}
+}
+
 // ----- Helpers ---------------------------------------------------------
 
+// rec carries the event_time and a parsed numeric value so assertions
+// stay format-agnostic (e.g., the SDK could reformat 0 as "0",
+// "0.0", or "0.000000000000000000" without breaking the tests).
 type rec struct {
 	EventTime int64
-	Value     string
+	Value     float64
 }
 
 // createStreamWithAllowZeros calls create_stream with the third
@@ -291,12 +331,19 @@ func createStreamWithAllowZeros(ctx context.Context, platform *kwilTesting.Platf
 	return nil
 }
 
+// setAllowZeros calls set_allow_zeros signed by the stream owner.
 func setAllowZeros(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator, value bool) error {
-	addr, err := util.NewEthereumAddressFromString(locator.DataProvider.Address())
+	owner, err := util.NewEthereumAddressFromString(locator.DataProvider.Address())
 	if err != nil {
 		return errors.Wrap(err, "invalid data provider address")
 	}
-	engineCtx := setup.NewEngineContext(ctx, platform, addr, 1)
+	return setAllowZerosAs(ctx, platform, locator, value, owner)
+}
+
+// setAllowZerosAs calls set_allow_zeros signed by an explicit caller —
+// used to assert the owner-only authorization check rejects strangers.
+func setAllowZerosAs(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator, value bool, caller util.EthereumAddress) error {
+	engineCtx := setup.NewEngineContext(ctx, platform, caller, 1)
 
 	r, err := platform.Engine.Call(engineCtx, platform.DB, "", "set_allow_zeros",
 		[]any{locator.DataProvider.Address(), locator.StreamId.String(), value},
@@ -364,7 +411,11 @@ func getRecordsRange(ctx context.Context, platform *kwilTesting.Platform, locato
 		if err != nil {
 			return nil, errors.Wrap(err, "parse event_time")
 		}
-		out = append(out, rec{EventTime: ts, Value: row[1]})
+		v, err := strconv.ParseFloat(row[1], 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse value %q as float", row[1])
+		}
+		out = append(out, rec{EventTime: ts, Value: v})
 	}
 	return out, nil
 }

--- a/tests/streams/allow_zeros_test.go
+++ b/tests/streams/allow_zeros_test.go
@@ -45,43 +45,43 @@ func testAllowZerosFourCombinations(t *testing.T) func(ctx context.Context, plat
 		platform = procedure.WithSigner(platform, deployer.Bytes())
 		require.NoError(t, setup.CreateDataProvider(ctx, platform, deployer.Address()))
 
-		filterOnLocator := types.StreamLocator{
+		allowZerosOffLocator := types.StreamLocator{
 			StreamId:     util.GenerateStreamId("allow_zeros_off_stream"),
 			DataProvider: deployer,
 		}
-		filterOffLocator := types.StreamLocator{
+		allowZerosOnLocator := types.StreamLocator{
 			StreamId:     util.GenerateStreamId("allow_zeros_on_stream"),
 			DataProvider: deployer,
 		}
 
-		// Default-FALSE (filter on): zeros dropped.
-		require.NoError(t, createStreamWithAllowZeros(ctx, platform, filterOnLocator, false))
-		// Opt-in TRUE (filter off): zeros persist.
-		require.NoError(t, createStreamWithAllowZeros(ctx, platform, filterOffLocator, true))
+		// allow_zeros=false: zeros dropped on insert (today's behavior).
+		require.NoError(t, createStreamWithAllowZeros(ctx, platform, allowZerosOffLocator, false))
+		// allow_zeros=true: zeros persist alongside non-zero values.
+		require.NoError(t, createStreamWithAllowZeros(ctx, platform, allowZerosOnLocator, true))
 
 		// Insert {value=0, value=5} into both streams at distinct event_times.
-		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, filterOnLocator,
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, allowZerosOffLocator,
 			setup.InsertRecordInput{EventTime: 100, Value: 0}, 1))
-		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, filterOnLocator,
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, allowZerosOffLocator,
 			setup.InsertRecordInput{EventTime: 200, Value: 5}, 1))
-		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, filterOffLocator,
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, allowZerosOnLocator,
 			setup.InsertRecordInput{EventTime: 100, Value: 0}, 1))
-		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, filterOffLocator,
+		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, allowZerosOnLocator,
 			setup.InsertRecordInput{EventTime: 200, Value: 5}, 1))
 
-		// Filter ON: only non-zero shows up.
-		onRows, err := getRecordsRange(ctx, platform, filterOnLocator, 0, 1000)
+		// allow_zeros=false: only non-zero shows up.
+		offRows, err := getRecordsRange(ctx, platform, allowZerosOffLocator, 0, 1000, 10)
 		require.NoError(t, err)
-		require.Equal(t, []rec{{EventTime: 200, Value: 5}}, onRows,
-			"filter_on stream: zero must be dropped, non-zero must persist")
+		require.Equal(t, []rec{{EventTime: 200, Value: 5}}, offRows,
+			"allow_zeros=false: zero must be dropped, non-zero must persist")
 
-		// Filter OFF: both records show up.
-		offRows, err := getRecordsRange(ctx, platform, filterOffLocator, 0, 1000)
+		// allow_zeros=true: both records show up.
+		onRows, err := getRecordsRange(ctx, platform, allowZerosOnLocator, 0, 1000, 10)
 		require.NoError(t, err)
 		require.Equal(t, []rec{
 			{EventTime: 100, Value: 0},
 			{EventTime: 200, Value: 5},
-		}, offRows, "filter_off stream: both zero and non-zero must persist")
+		}, onRows, "allow_zeros=true: both zero and non-zero must persist")
 
 		return nil
 	}
@@ -112,7 +112,7 @@ func testAllowZerosDefaultPreservesBehavior(t *testing.T) func(ctx context.Conte
 		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, locator,
 			setup.InsertRecordInput{EventTime: 200, Value: 7}, 1))
 
-		rows, err := getRecordsRange(ctx, platform, locator, 0, 1000)
+		rows, err := getRecordsRange(ctx, platform, locator, 0, 1000, 5)
 		require.NoError(t, err)
 		require.Equal(t, []rec{{EventTime: 200, Value: 7}}, rows,
 			"default-shape create_stream must preserve today's zero-drop behavior")
@@ -138,10 +138,15 @@ func testSetAllowZerosToggleMutability(t *testing.T) func(ctx context.Context, p
 		}
 		require.NoError(t, createStreamWithAllowZeros(ctx, platform, locator, false))
 
+		// Each stage reads at insert_height+1 so the just-written row is
+		// visible. The pattern is more verbose than a global magic
+		// height but spells out the read-after-write timing per stage.
+
 		// Stage 1: default off — zero dropped.
+		const stage1Insert int64 = 1
 		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, locator,
-			setup.InsertRecordInput{EventTime: 100, Value: 0}, 1))
-		rows, err := getRecordsRange(ctx, platform, locator, 0, 1000)
+			setup.InsertRecordInput{EventTime: 100, Value: 0}, stage1Insert))
+		rows, err := getRecordsRange(ctx, platform, locator, 0, 1000, stage1Insert+1)
 		require.NoError(t, err)
 		require.Empty(t, rows, "stage 1: zero with allow_zeros=FALSE must be dropped")
 
@@ -149,9 +154,10 @@ func testSetAllowZerosToggleMutability(t *testing.T) func(ctx context.Context, p
 		require.NoError(t, setAllowZeros(ctx, platform, locator, true))
 
 		// Stage 2: zeros now persist.
+		const stage2Insert int64 = 2
 		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, locator,
-			setup.InsertRecordInput{EventTime: 200, Value: 0}, 2))
-		rows, err = getRecordsRange(ctx, platform, locator, 0, 1000)
+			setup.InsertRecordInput{EventTime: 200, Value: 0}, stage2Insert))
+		rows, err = getRecordsRange(ctx, platform, locator, 0, 1000, stage2Insert+1)
 		require.NoError(t, err)
 		require.Equal(t, []rec{{EventTime: 200, Value: 0}}, rows,
 			"stage 2: zero after allow_zeros=TRUE flip must persist")
@@ -160,9 +166,10 @@ func testSetAllowZerosToggleMutability(t *testing.T) func(ctx context.Context, p
 		require.NoError(t, setAllowZeros(ctx, platform, locator, false))
 
 		// Stage 3: new zeros are dropped, but the one from stage 2 stays.
+		const stage3Insert int64 = 3
 		require.NoError(t, setup.ExecuteInsertRecord(ctx, platform, locator,
-			setup.InsertRecordInput{EventTime: 300, Value: 0}, 3))
-		rows, err = getRecordsRange(ctx, platform, locator, 0, 1000)
+			setup.InsertRecordInput{EventTime: 300, Value: 0}, stage3Insert))
+		rows, err = getRecordsRange(ctx, platform, locator, 0, 1000, stage3Insert+1)
 		require.NoError(t, err)
 		require.Equal(t, []rec{{EventTime: 200, Value: 0}}, rows,
 			"stage 3: zero after flip-back-to-FALSE must be dropped; earlier zero must remain")
@@ -389,15 +396,18 @@ func getAllowZeros(ctx context.Context, platform *kwilTesting.Platform, locator 
 	return got, nil
 }
 
-// getRecordsRange wraps procedure.GetRecord with from/to int64 values
-// and returns a typed event_time + decimal-string slice.
-func getRecordsRange(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator, from, to int64) ([]rec, error) {
+// getRecordsRange wraps procedure.GetRecord with explicit from/to/height
+// int64 values and returns a typed event_time + numeric-value slice.
+// The height parameter is the chain height the read is performed at —
+// callers should pass a height >= the latest insert height in the test
+// so all writes are visible.
+func getRecordsRange(ctx context.Context, platform *kwilTesting.Platform, locator types.StreamLocator, from, to, height int64) ([]rec, error) {
 	rows, err := procedure.GetRecord(ctx, procedure.GetRecordInput{
 		Platform:      platform,
 		StreamLocator: locator,
 		FromTime:      &from,
 		ToTime:        &to,
-		Height:        10,
+		Height:        height,
 	})
 	if err != nil {
 		return nil, err

--- a/tests/streams/streams_behaviors.md
+++ b/tests/streams/streams_behaviors.md
@@ -40,6 +40,7 @@ This document lists the behaviors that must have automated tests to ensure they 
 - [x] Data records are immutable. They can't be disabled or deleted. (records can't be disabled by design, no need to test)
 - [COMPOSED04] Taxonomy definitions are immutable. But they can be disabled (only the whole version and not a single child definition)
 - [PRIMITIVE04] A base date for a stream can be set by parameters. If not set, the stream will use the first record date as base date.
+- [PRIMITIVE05] Per-stream `allow_zeros` config (default false) controls whether `value=0` inserts persist. Default behavior drops zeros silently on insert; opt-in via `create_stream($allow_zeros=true)` or `set_allow_zeros()` persists them. Toggle is forward-only — historical state is not rewritten. Verified by `tests/streams/allow_zeros_test.go`.
 
 
 ## Composition & Aggregation


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-stream "allow zeros" option to persist zero-valued records (set at creation or updated later); insert/prune behavior respects this flag.
  * New read endpoint to query whether a stream allows zero-valued records.

* **Documentation**
  * Added spec for per-stream zero-value retention and forward-only enablement semantics.

* **Tests**
  * Integration tests covering create/update/query, pruning, backward compatibility, and authorization for the new setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->