### PR TITLE
chore: adjust data provision fee to 6

### DIFF
--- a/internal/migrations/001-common-actions.prod.sql
+++ b/internal/migrations/001-common-actions.prod.sql
@@ -37,9 +37,9 @@ CREATE OR REPLACE ACTION create_streams(
         }
     }
 
-    -- Collect fee only from non-exempt wallets (2 TRUF per stream)
+    -- Collect fee only from non-exempt wallets (6 TRUF per stream)
     IF NOT $is_exempt {
-        $fee_per_stream := 2000000000000000000::NUMERIC(78, 0); -- 2 TRUF with 18 decimals
+        $fee_per_stream := 6000000000000000000::NUMERIC(78, 0); -- 6 TRUF with 18 decimals
         $total_fee := $fee_per_stream * $num_streams::NUMERIC(78, 0);
 
         IF @leader_sender IS NULL {

--- a/internal/migrations/001-common-actions.sql
+++ b/internal/migrations/001-common-actions.sql
@@ -54,7 +54,7 @@ CREATE OR REPLACE ACTION create_stream(
 
 /**
  * create_streams: Creates multiple streams at once.
- * Fee: 2 TRUF per stream created
+ * Fee: 6 TRUF per stream created
  * Exemption: system:network_writer role bypasses fee collection
  * Validates stream_id format, data provider address, and stream type.
  * Sets default metadata including type, owner, visibility, and readonly keys.
@@ -88,9 +88,9 @@ CREATE OR REPLACE ACTION create_streams(
         }
     }
 
-    -- Collect fee only from non-exempt wallets (2 TRUF per stream)
+    -- Collect fee only from non-exempt wallets (6 TRUF per stream)
     IF NOT $is_exempt {
-        $fee_per_stream := 2000000000000000000::NUMERIC(78, 0); -- 2 TRUF with 18 decimals
+        $fee_per_stream := 6000000000000000000::NUMERIC(78, 0); -- 6 TRUF with 18 decimals
         $total_fee := $fee_per_stream * $num_streams::NUMERIC(78, 0);
 
         IF @leader_sender IS NULL {

--- a/internal/migrations/003-primitive-insertion.prod.sql
+++ b/internal/migrations/003-primitive-insertion.prod.sql
@@ -47,9 +47,9 @@ CREATE OR REPLACE ACTION insert_records(
         }
     }
 
-    -- Collect fee only from non-exempt wallets (2 TRUF per record)
+    -- Collect fee only from non-exempt wallets (6 TRUF per record)
     IF NOT $is_exempt {
-        $fee_per_record := 2000000000000000000::NUMERIC(78, 0); -- 2 TRUF with 18 decimals
+        $fee_per_record := 6000000000000000000::NUMERIC(78, 0); -- 6 TRUF with 18 decimals
         $total_fee := $fee_per_record * $num_records::NUMERIC(78, 0);
 
         IF @leader_sender IS NULL {

--- a/internal/migrations/003-primitive-insertion.sql
+++ b/internal/migrations/003-primitive-insertion.sql
@@ -54,9 +54,9 @@ CREATE OR REPLACE ACTION insert_records(
         }
     }
 
-    -- Collect fee only from non-exempt wallets (2 TRUF per record)
+    -- Collect fee only from non-exempt wallets (6 TRUF per record)
     IF NOT $is_exempt {
-        $fee_per_record := 2000000000000000000::NUMERIC(78, 0); -- 2 TRUF with 18 decimals
+        $fee_per_record := 6000000000000000000::NUMERIC(78, 0); -- 6 TRUF with 18 decimals
         $total_fee := $fee_per_record * $num_records::NUMERIC(78, 0);
 
         IF @leader_sender IS NULL {

--- a/internal/migrations/004-composed-taxonomy.prod.sql
+++ b/internal/migrations/004-composed-taxonomy.prod.sql
@@ -66,9 +66,9 @@ CREATE OR REPLACE ACTION insert_taxonomy(
         }
     }
 
-    -- Collect fee only from non-exempt wallets (2 TRUF per stream)
+    -- Collect fee only from non-exempt wallets (6 TRUF per stream)
     IF NOT $is_exempt {
-        $fee_per_stream := 2000000000000000000::NUMERIC(78, 0); -- 2 TRUF with 18 decimals
+        $fee_per_stream := 6000000000000000000::NUMERIC(78, 0); -- 6 TRUF with 18 decimals
         $total_fee := $fee_per_stream * $num_children::NUMERIC(78, 0);
 
         IF @leader_sender IS NULL {

--- a/internal/migrations/004-composed-taxonomy.sql
+++ b/internal/migrations/004-composed-taxonomy.sql
@@ -54,9 +54,9 @@ CREATE OR REPLACE ACTION insert_taxonomy(
         }
     }
 
-    -- Collect fee only from non-exempt wallets (2 TRUF per stream)
+    -- Collect fee only from non-exempt wallets (6 TRUF per stream)
     IF NOT $is_exempt {
-        $fee_per_stream := 2000000000000000000::NUMERIC(78, 0); -- 2 TRUF with 18 decimals
+        $fee_per_stream := 6000000000000000000::NUMERIC(78, 0); -- 6 TRUF with 18 decimals
         $total_fee := $fee_per_stream * $num_children::NUMERIC(78, 0);
 
         IF @leader_sender IS NULL {

--- a/tests/streams/insert_records_fee_test.go
+++ b/tests/streams/insert_records_fee_test.go
@@ -29,11 +29,11 @@ const (
 	testInsertEscrow        = "0x502430eD0BbE0f230215870c9C2853e126eE5Ae3"
 	testInsertERC20         = "0x2222222222222222222222222222222222222222"
 	testInsertExtensionName = "sepolia_bridge"
-	insertFeeAmount         = "2000000000000000000" // 2 TRUF with 18 decimals per record
+	insertFeeAmount         = "6000000000000000000" // 6 TRUF with 18 decimals per record
 )
 
 var (
-	twoTRUFInsert            = mustParseInsertBigInt(insertFeeAmount) // 2 TRUF as big.Int
+	sixTRUFInsert            = mustParseInsertBigInt(insertFeeAmount) // 6 TRUF as big.Int
 	insertPointCounter int64 = 1000                                   // Start from 1000, increment for each balance injection
 )
 
@@ -181,7 +181,7 @@ func testInsertExemptWalletNoFee(t *testing.T) func(ctx context.Context, platfor
 	}
 }
 
-// Test 2: Non-exempt wallet pays 2 TRUF fee per record
+// Test 2: Non-exempt wallet pays 6 TRUF fee per record
 func testInsertNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		// Get systemAdmin who owns the stream
@@ -225,13 +225,13 @@ func testInsertNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, pl
 		err = insertRecord(ctx, platform, userAddr, systemAdmin.Address(), streamID, 1000, "10.5")
 		require.NoError(t, err, "insert should succeed")
 
-		// Verify balance decreased by 2 TRUF
+		// Verify balance decreased by 6 TRUF
 		finalBalance, err := getInsertBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err, "failed to get final balance")
 
-		expectedBalance := new(big.Int).Sub(initialBalance, twoTRUFInsert)
+		expectedBalance := new(big.Int).Sub(initialBalance, sixTRUFInsert)
 		require.Equal(t, 0, expectedBalance.Cmp(finalBalance),
-			"Balance should decrease by 2 TRUF, expected %s but got %s", expectedBalance, finalBalance)
+			"Balance should decrease by 6 TRUF, expected %s but got %s", expectedBalance, finalBalance)
 
 		return nil
 	}
@@ -269,7 +269,7 @@ func testInsertInsufficientBalance(t *testing.T) func(ctx context.Context, platf
 		err = grantStreamWriteAccess(ctx, platform, systemAdmin.Address(), streamID, userAddr.Address())
 		require.NoError(t, err, "failed to grant write access")
 
-		// Give user only 1 TRUF (insufficient for 2 TRUF fee)
+		// Give user only 1 TRUF (insufficient for 6 TRUF fee)
 		err = giveInsertBalance(ctx, platform, userAddr.Address(), "1000000000000000000")
 		require.NoError(t, err, "failed to give balance")
 
@@ -329,8 +329,8 @@ func testInsertRoleChangeAffectsFee(t *testing.T) func(ctx context.Context, plat
 		balanceAfterFirst, err := getInsertBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err)
 
-		expectedAfterFirst := new(big.Int).Sub(initialBalance, twoTRUFInsert)
-		require.Equal(t, 0, expectedAfterFirst.Cmp(balanceAfterFirst), "First insert should charge 2 TRUF fee")
+		expectedAfterFirst := new(big.Int).Sub(initialBalance, sixTRUFInsert)
+		require.Equal(t, 0, expectedAfterFirst.Cmp(balanceAfterFirst), "First insert should charge 6 TRUF fee")
 
 		// Grant network_writer role to make user exempt
 		err = setup.AddMemberToRoleBypass(ctx, platform, "system", "network_writer", userAddr.Address())
@@ -355,7 +355,7 @@ func testInsertRoleChangeAffectsFee(t *testing.T) func(ctx context.Context, plat
 		balanceAfterThird, err := getInsertBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err)
 
-		expectedAfterThird := new(big.Int).Sub(balanceAfterSecond, twoTRUFInsert)
+		expectedAfterThird := new(big.Int).Sub(balanceAfterSecond, sixTRUFInsert)
 		require.Equal(t, 0, expectedAfterThird.Cmp(balanceAfterThird), "Third insert should charge fee (role revoked)")
 
 		return nil
@@ -407,14 +407,14 @@ func testInsertBatchChargesPerRecord(t *testing.T) func(ctx context.Context, pla
 		err = insertMultipleRecords(ctx, platform, userAddr, systemAdmin.Address(), streamID, 2000, numRecords)
 		require.NoError(t, err, "batch insert should succeed")
 
-		// Verify balance decreased by 10 TRUF (5 records × 2 TRUF)
+		// Verify balance decreased by 30 TRUF (5 records × 6 TRUF)
 		finalBalance, err := getInsertBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err)
 
-		feeForFiveRecords := new(big.Int).Mul(twoTRUFInsert, big.NewInt(int64(numRecords)))
+		feeForFiveRecords := new(big.Int).Mul(sixTRUFInsert, big.NewInt(int64(numRecords)))
 		expectedBalance := new(big.Int).Sub(initialBalance, feeForFiveRecords)
 		require.Equal(t, 0, expectedBalance.Cmp(finalBalance),
-			"Balance should decrease by 10 TRUF (5 records × 2 TRUF), expected %s but got %s", expectedBalance, finalBalance)
+			"Balance should decrease by 30 TRUF (5 records × 6 TRUF), expected %s but got %s", expectedBalance, finalBalance)
 
 		return nil
 	}
@@ -477,13 +477,13 @@ func testInsertLeaderReceivesFees(t *testing.T) func(ctx context.Context, platfo
 		err = insertRecordWithLeader(ctx, platform, userAddr, pub, systemAdmin.Address(), streamID, 3000, "15.5")
 		require.NoError(t, err, "insert with leader should succeed")
 
-		// Verify leader balance increased by 2 TRUF
+		// Verify leader balance increased by 6 TRUF
 		finalLeaderBalance, err := getInsertBalance(ctx, platform, leaderAddr)
 		require.NoError(t, err, "failed to get final leader balance")
 
-		expectedLeaderBalance := new(big.Int).Add(initialLeaderBalance, twoTRUFInsert)
+		expectedLeaderBalance := new(big.Int).Add(initialLeaderBalance, sixTRUFInsert)
 		require.Equal(t, 0, expectedLeaderBalance.Cmp(finalLeaderBalance),
-			"Leader should receive 2 TRUF fee, expected %s but got %s", expectedLeaderBalance, finalLeaderBalance)
+			"Leader should receive 6 TRUF fee, expected %s but got %s", expectedLeaderBalance, finalLeaderBalance)
 
 		return nil
 	}

--- a/tests/streams/stream_creation_fee_test.go
+++ b/tests/streams/stream_creation_fee_test.go
@@ -26,11 +26,11 @@ const (
 	testEscrow        = "0x502430eD0BbE0f230215870c9C2853e126eE5Ae3" // From erc20-bridge/000-extension.sql
 	testERC20         = "0x2222222222222222222222222222222222222222"
 	testExtensionName = "sepolia_bridge"
-	feeAmount         = "2000000000000000000" // 2 TRUF with 18 decimals
+	feeAmount         = "6000000000000000000" // 6 TRUF with 18 decimals
 )
 
 var (
-	twoTRUF            = mustParseBigInt(feeAmount) // 2 TRUF as big.Int
+	sixTRUF            = mustParseBigInt(feeAmount) // 6 TRUF as big.Int
 	pointCounter int64 = 10                         // Start from 10, increment for each balance injection
 )
 
@@ -119,7 +119,7 @@ func testExemptWalletNoFee(t *testing.T) func(ctx context.Context, platform *kwi
 	}
 }
 
-// Test 2: Non-exempt wallet pays 2 TRUF fee
+// Test 2: Non-exempt wallet pays 6 TRUF fee
 func testNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		userAddrVal := util.Unsafe_NewEthereumAddressFromString("0x3333333333333333333333333333333333333333")
@@ -141,13 +141,13 @@ func testNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, platform
 		err = createStream(ctx, platform, userAddr, "st000000000000000000000000000002", "primitive")
 		require.NoError(t, err, "stream creation should succeed")
 
-		// Verify balance decreased by 2 TRUF
+		// Verify balance decreased by 6 TRUF
 		finalBalance, err := getBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err, "failed to get final balance")
 
-		expectedBalance := new(big.Int).Sub(initialBalance, twoTRUF)
+		expectedBalance := new(big.Int).Sub(initialBalance, sixTRUF)
 		require.Equal(t, 0, expectedBalance.Cmp(finalBalance),
-			"Balance should decrease by 2 TRUF, expected %s but got %s", expectedBalance, finalBalance)
+			"Balance should decrease by 6 TRUF, expected %s but got %s", expectedBalance, finalBalance)
 
 		return nil
 	}
@@ -201,8 +201,8 @@ func testRoleChangeAffectsFee(t *testing.T) func(ctx context.Context, platform *
 		balanceAfterFirst, err := getBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err)
 
-		expectedAfterFirst := new(big.Int).Sub(initialBalance, twoTRUF)
-		require.Equal(t, 0, expectedAfterFirst.Cmp(balanceAfterFirst), "First call should charge 2 TRUF fee")
+		expectedAfterFirst := new(big.Int).Sub(initialBalance, sixTRUF)
+		require.Equal(t, 0, expectedAfterFirst.Cmp(balanceAfterFirst), "First call should charge 6 TRUF fee")
 
 		// Grant role
 		err = setup.AddMemberToRoleBypass(ctx, platform, "system", "network_writer", userAddr.Address())
@@ -227,7 +227,7 @@ func testRoleChangeAffectsFee(t *testing.T) func(ctx context.Context, platform *
 		balanceAfterThird, err := getBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err)
 
-		expectedAfterThird := new(big.Int).Sub(balanceAfterSecond, twoTRUF)
+		expectedAfterThird := new(big.Int).Sub(balanceAfterSecond, sixTRUF)
 		require.Equal(t, 0, expectedAfterThird.Cmp(balanceAfterThird), "Third call should charge fee (role revoked)")
 
 		return nil
@@ -263,15 +263,15 @@ func testBatchCreationPerStreamFee(t *testing.T) func(ctx context.Context, platf
 		err = createStreams(ctx, platform, userAddr, streamIds, streamTypes)
 		require.NoError(t, err, "batch stream creation should succeed")
 
-		// Verify balance decreased by 6 TRUF (2 TRUF × 3 streams)
+		// Verify balance decreased by 18 TRUF (6 TRUF × 3 streams)
 		finalBalance, err := getBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err)
 
 		numStreams := int64(len(streamIds)) // 3 streams
-		expectedFee := new(big.Int).Mul(twoTRUF, big.NewInt(numStreams))
+		expectedFee := new(big.Int).Mul(sixTRUF, big.NewInt(numStreams))
 		expectedBalance := new(big.Int).Sub(initialBalance, expectedFee)
 		require.Equal(t, 0, expectedBalance.Cmp(finalBalance),
-			"Batch should charge 2 TRUF per stream (3 streams = 6 TRUF), expected %s but got %s", expectedBalance, finalBalance)
+			"Batch should charge 6 TRUF per stream (3 streams = 18 TRUF), expected %s but got %s", expectedBalance, finalBalance)
 
 		return nil
 	}
@@ -310,13 +310,13 @@ func testLeaderReceivesFees(t *testing.T) func(ctx context.Context, platform *kw
 		err = createStreamWithLeader(ctx, platform, userAddr, pub, "st00000000000000000000000000000a", "primitive")
 		require.NoError(t, err, "stream creation with leader should succeed")
 
-		// Verify leader balance increased by 2 TRUF
+		// Verify leader balance increased by 6 TRUF
 		finalLeaderBalance, err := getBalance(ctx, platform, leaderAddr)
 		require.NoError(t, err, "failed to get final leader balance")
 
-		expectedLeaderBalance := new(big.Int).Add(initialLeaderBalance, twoTRUF)
+		expectedLeaderBalance := new(big.Int).Add(initialLeaderBalance, sixTRUF)
 		require.Equal(t, 0, expectedLeaderBalance.Cmp(finalLeaderBalance),
-			"Leader should receive 2 TRUF fee, expected %s but got %s", expectedLeaderBalance, finalLeaderBalance)
+			"Leader should receive 6 TRUF fee, expected %s but got %s", expectedLeaderBalance, finalLeaderBalance)
 
 		return nil
 	}

--- a/tests/streams/taxonomy_fee_test.go
+++ b/tests/streams/taxonomy_fee_test.go
@@ -22,11 +22,11 @@ import (
 
 // Test constants for taxonomy fees
 const (
-	taxonomyFeeAmount = "2000000000000000000" // 2 TRUF with 18 decimals per child stream
+	taxonomyFeeAmount = "6000000000000000000" // 6 TRUF with 18 decimals per child stream
 )
 
 var (
-	twoTRUFTaxonomy = mustParseBigInt(taxonomyFeeAmount) // 2 TRUF as big.Int, using shared helper from stream_creation_fee_test.go
+	sixTRUFTaxonomy = mustParseBigInt(taxonomyFeeAmount) // 6 TRUF as big.Int, using shared helper from stream_creation_fee_test.go
 )
 
 // TestTaxonomyFees is the main test suite for insert_taxonomy transaction fees
@@ -97,7 +97,7 @@ func testTaxonomyExemptWalletNoFee(t *testing.T) func(ctx context.Context, platf
 		err = createStream(ctx, platform, exemptAddr, childStreamId.String(), "primitive")
 		require.NoError(t, err, "failed to create child stream")
 
-		// Insert taxonomy (1 child = 2 TRUF fee, but should be exempt)
+		// Insert taxonomy (1 child = 6 TRUF fee, but should be exempt)
 		err = insertTaxonomy(ctx, platform, exemptAddr,
 			exemptAddr.Address(), composedStreamId.String(),
 			[]string{exemptAddr.Address()},
@@ -115,7 +115,7 @@ func testTaxonomyExemptWalletNoFee(t *testing.T) func(ctx context.Context, platf
 	}
 }
 
-// Test 2: Non-exempt wallet (without network_writer role) pays 2 TRUF per child stream
+// Test 2: Non-exempt wallet (without network_writer role) pays 6 TRUF per child stream
 func testTaxonomyNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		nonExemptAddrVal := util.Unsafe_NewEthereumAddressFromString("0x3222222222222222222222222222222222222222")
@@ -125,34 +125,34 @@ func testTaxonomyNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, 
 		err := setup.CreateDataProviderWithoutRole(ctx, platform, nonExemptAddr.Address())
 		require.NoError(t, err, "failed to create data provider without role")
 
-		// Give 6 TRUF: 2 TRUF (composed stream fee) + 2 TRUF (child stream fee) + 2 TRUF (taxonomy fee)
-		sixTRUF := mustParseBigInt("6000000000000000000") // 6 TRUF
-		err = giveBalance(ctx, platform, nonExemptAddr.Address(), sixTRUF.String())
+		// Give 18 TRUF: 6 TRUF (composed stream fee) + 6 TRUF (child stream fee) + 6 TRUF (taxonomy fee)
+		eighteenTRUF := mustParseBigInt("18000000000000000000") // 18 TRUF
+		err = giveBalance(ctx, platform, nonExemptAddr.Address(), eighteenTRUF.String())
 		require.NoError(t, err, "failed to give balance")
 
 		// Get initial balance
 		initialBalance, err := getBalance(ctx, platform, nonExemptAddr.Address())
 		require.NoError(t, err, "failed to get initial balance")
-		require.Equal(t, sixTRUF, initialBalance, "Initial balance should be 6 TRUF")
+		require.Equal(t, eighteenTRUF, initialBalance, "Initial balance should be 18 TRUF")
 
-		// Create streams using direct engine calls (each costs 2 TRUF)
+		// Create streams using direct engine calls (each costs 6 TRUF)
 		composedStreamId := util.GenerateStreamId("taxonomy_nonexempt_composed")
 		childStreamId := util.GenerateStreamId("taxonomy_nonexempt_child")
 
-		// Create composed stream (costs 2 TRUF)
+		// Create composed stream (costs 6 TRUF)
 		err = createStream(ctx, platform, nonExemptAddr, composedStreamId.String(), "composed")
 		require.NoError(t, err, "failed to create composed stream")
 
-		// Create child stream (costs 2 TRUF)
+		// Create child stream (costs 6 TRUF)
 		err = createStream(ctx, platform, nonExemptAddr, childStreamId.String(), "primitive")
 		require.NoError(t, err, "failed to create child stream")
 
-		// Balance after stream creation should be 2 TRUF (6 - 2 - 2)
+		// Balance after stream creation should be 6 TRUF (18 - 6 - 6)
 		balanceAfterStreams, err := getBalance(ctx, platform, nonExemptAddr.Address())
 		require.NoError(t, err, "failed to get balance after stream creation")
-		require.Equal(t, twoTRUFTaxonomy, balanceAfterStreams, "Balance should be 2 TRUF after creating streams")
+		require.Equal(t, sixTRUFTaxonomy, balanceAfterStreams, "Balance should be 6 TRUF after creating streams")
 
-		// Insert taxonomy (1 child = 2 TRUF fee)
+		// Insert taxonomy (1 child = 6 TRUF fee)
 		err = insertTaxonomy(ctx, platform, nonExemptAddr,
 			nonExemptAddr.Address(), composedStreamId.String(),
 			[]string{nonExemptAddr.Address()},
@@ -161,7 +161,7 @@ func testTaxonomyNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, 
 			nil)
 		require.NoError(t, err, "taxonomy insertion should succeed")
 
-		// Verify balance is now 0 (2 TRUF taxonomy fee charged)
+		// Verify balance is now 0 (6 TRUF taxonomy fee charged)
 		finalBalance, err := getBalance(ctx, platform, nonExemptAddr.Address())
 		require.NoError(t, err, "failed to get final balance")
 
@@ -181,12 +181,12 @@ func testTaxonomyInsufficientBalance(t *testing.T) func(ctx context.Context, pla
 		err := setup.CreateDataProviderWithoutRole(ctx, platform, insufficientAddr.Address())
 		require.NoError(t, err, "failed to create data provider without role")
 
-		// Give 5 TRUF: Enough for streams (2+2=4) but not enough for taxonomy fee (need 2 more)
-		fiveTRUF := mustParseBigInt("5000000000000000000") // 5 TRUF
-		err = giveBalance(ctx, platform, insufficientAddr.Address(), fiveTRUF.String())
+		// Give 13 TRUF: Enough for streams (6+6=12) but not enough for taxonomy fee (need 6 more)
+		thirteenTRUF := mustParseBigInt("13000000000000000000") // 13 TRUF
+		err = giveBalance(ctx, platform, insufficientAddr.Address(), thirteenTRUF.String())
 		require.NoError(t, err, "failed to give balance")
 
-		// Create streams (costs 4 TRUF total, leaving 1 TRUF)
+		// Create streams (costs 12 TRUF total, leaving 1 TRUF)
 		composedStreamId := util.GenerateStreamId("taxonomy_insufficient_composed")
 		childStreamId := util.GenerateStreamId("taxonomy_insufficient_child")
 
@@ -196,7 +196,7 @@ func testTaxonomyInsufficientBalance(t *testing.T) func(ctx context.Context, pla
 		err = createStream(ctx, platform, insufficientAddr, childStreamId.String(), "primitive")
 		require.NoError(t, err, "failed to create child stream")
 
-		// Should have 1 TRUF left (5 - 2 - 2 = 1), not enough for 2 TRUF taxonomy fee
+		// Should have 1 TRUF left (13 - 6 - 6 = 1), not enough for 6 TRUF taxonomy fee
 		remainingBalance, err := getBalance(ctx, platform, insufficientAddr.Address())
 		require.NoError(t, err, "failed to get remaining balance")
 		oneTRUF := mustParseBigInt("1000000000000000000")
@@ -212,13 +212,13 @@ func testTaxonomyInsufficientBalance(t *testing.T) func(ctx context.Context, pla
 
 		require.Error(t, err, "taxonomy insertion should fail with insufficient balance")
 		require.Contains(t, err.Error(), "Insufficient balance for taxonomies creation", "Error should mention insufficient balance")
-		require.Contains(t, err.Error(), "Required: 2 TRUF", "Error should mention 2 TRUF requirement")
+		require.Contains(t, err.Error(), "Required: 6 TRUF", "Error should mention 6 TRUF requirement")
 
 		return nil
 	}
 }
 
-// Test 4: Multiple children - fee should be 2 TRUF per child
+// Test 4: Multiple children - fee should be 6 TRUF per child
 func testTaxonomyMultipleChildrenFee(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		multiAddrVal := util.Unsafe_NewEthereumAddressFromString("0x5444444444444444444444444444444444444444")
@@ -228,39 +228,39 @@ func testTaxonomyMultipleChildrenFee(t *testing.T) func(ctx context.Context, pla
 		err := setup.CreateDataProviderWithoutRole(ctx, platform, multiAddr.Address())
 		require.NoError(t, err, "failed to create data provider without role")
 
-		// Give 14 TRUF: 2 (composed) + 6 (3 children streams) + 6 (taxonomy fee for 3 children)
-		fourteenTRUF := mustParseBigInt("14000000000000000000") // 14 TRUF
-		err = giveBalance(ctx, platform, multiAddr.Address(), fourteenTRUF.String())
+		// Give 42 TRUF: 6 (composed) + 18 (3 children streams) + 18 (taxonomy fee for 3 children)
+		fortyTwoTRUF := mustParseBigInt("42000000000000000000") // 42 TRUF
+		err = giveBalance(ctx, platform, multiAddr.Address(), fortyTwoTRUF.String())
 		require.NoError(t, err, "failed to give balance")
 
 		// Get initial balance
 		initialBalance, err := getBalance(ctx, platform, multiAddr.Address())
 		require.NoError(t, err, "failed to get initial balance")
-		require.Equal(t, fourteenTRUF, initialBalance, "Initial balance should be 14 TRUF")
+		require.Equal(t, fortyTwoTRUF, initialBalance, "Initial balance should be 42 TRUF")
 
-		// Create streams (costs 2 + 6 = 8 TRUF total)
+		// Create streams (costs 6 + 18 = 24 TRUF total)
 		composedStreamId := util.GenerateStreamId("taxonomy_multi_composed")
 		child1StreamId := util.GenerateStreamId("taxonomy_multi_child1")
 		child2StreamId := util.GenerateStreamId("taxonomy_multi_child2")
 		child3StreamId := util.GenerateStreamId("taxonomy_multi_child3")
 
-		// Create composed stream (costs 2 TRUF)
+		// Create composed stream (costs 6 TRUF)
 		err = createStream(ctx, platform, multiAddr, composedStreamId.String(), "composed")
 		require.NoError(t, err, "failed to create composed stream")
 
-		// Create 3 child streams (costs 6 TRUF total)
+		// Create 3 child streams (costs 18 TRUF total)
 		for _, childId := range []util.StreamId{child1StreamId, child2StreamId, child3StreamId} {
 			err = createStream(ctx, platform, multiAddr, childId.String(), "primitive")
 			require.NoError(t, err, "failed to create child stream")
 		}
 
-		// Balance after stream creation should be 6 TRUF (14 - 8)
+		// Balance after stream creation should be 18 TRUF (42 - 24)
 		balanceAfterStreams, err := getBalance(ctx, platform, multiAddr.Address())
 		require.NoError(t, err, "failed to get balance after stream creation")
-		sixTRUF := mustParseBigInt("6000000000000000000")
-		require.Equal(t, sixTRUF, balanceAfterStreams, "Balance should be 6 TRUF after creating streams")
+		eighteenTRUF := mustParseBigInt("18000000000000000000")
+		require.Equal(t, eighteenTRUF, balanceAfterStreams, "Balance should be 18 TRUF after creating streams")
 
-		// Insert taxonomy with 3 children (should charge 6 TRUF total)
+		// Insert taxonomy with 3 children (should charge 18 TRUF total)
 		err = insertTaxonomy(ctx, platform, multiAddr,
 			multiAddr.Address(), composedStreamId.String(),
 			[]string{multiAddr.Address(), multiAddr.Address(), multiAddr.Address()},
@@ -269,7 +269,7 @@ func testTaxonomyMultipleChildrenFee(t *testing.T) func(ctx context.Context, pla
 			nil)
 		require.NoError(t, err, "taxonomy insertion should succeed")
 
-		// Verify balance is now 0 (6 TRUF taxonomy fee charged)
+		// Verify balance is now 0 (18 TRUF taxonomy fee charged)
 		finalBalance, err := getBalance(ctx, platform, multiAddr.Address())
 		require.NoError(t, err, "failed to get final balance")
 

--- a/tests/streams/transaction_events_ledger_test.go
+++ b/tests/streams/transaction_events_ledger_test.go
@@ -32,8 +32,9 @@ const (
 	ledgerExtensionAlias = "sepolia_bridge"
 
 	feeOneTRUF       = "1000000000000000000"
-	feeTwoTRUF       = "2000000000000000000"
-	feeFourTRUF      = "4000000000000000000"
+	feeThreeTRUF     = "3000000000000000000"
+	feeSixTRUF       = "6000000000000000000"
+	feeTwelveTRUF    = "12000000000000000000"
 	feeFortyTRUF     = "40000000000000000000"
 	transferAmount   = "5000000000000000000"
 	withdrawAmount   = "10000000000000000000"
@@ -142,7 +143,7 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 			 WHERE tx_id = $2 AND sequence = 1`, schemaName)
 		_, err = platform.DB.Execute(ctx,
 			updateSQL,
-			feeOneTRUF,
+			feeThreeTRUF,
 			insertTx,
 		)
 		require.NoError(t, err)
@@ -155,7 +156,7 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 			insertTx,
 			2,
 			bonusRecipientLower,
-			feeOneTRUF,
+			feeThreeTRUF,
 		)
 		require.NoError(t, err)
 
@@ -218,29 +219,29 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 		expected := map[string]ledgerExpectation{
 			createTx: {
 				method:       "deployStream",
-				fee:          feeFourTRUF,
+				fee:          feeTwelveTRUF,
 				feeRecipient: createLeaderAddr,
 				feeDistributions: []string{
-					buildDistribution(createLeaderAddr, feeFourTRUF),
+					buildDistribution(createLeaderAddr, feeTwelveTRUF),
 				},
 				assertMetadata: assertNoMetadata,
 			},
 			insertTx: {
 				method:       "insertRecords",
-				fee:          feeTwoTRUF,
+				fee:          feeSixTRUF,
 				feeRecipient: insertLeaderAddr,
 				feeDistributions: []string{
-					buildDistribution(insertLeaderAddr, feeOneTRUF),
-					buildDistribution(bonusRecipientLower, feeOneTRUF),
+					buildDistribution(insertLeaderAddr, feeThreeTRUF),
+					buildDistribution(bonusRecipientLower, feeThreeTRUF),
 				},
 				assertMetadata: assertNoMetadata,
 			},
 			taxTx: {
 				method:       "setTaxonomies",
-				fee:          feeTwoTRUF,
+				fee:          feeSixTRUF,
 				feeRecipient: taxLeaderAddr,
 				feeDistributions: []string{
-					buildDistribution(taxLeaderAddr, feeTwoTRUF),
+					buildDistribution(taxLeaderAddr, feeSixTRUF),
 				},
 				assertMetadata: assertNoMetadata,
 			},
@@ -340,7 +341,7 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 		require.Equal(t, insertTx, insertLeaderReceivedRows[0].TxID)
 		require.Equal(t, insertLeaderAddr, insertLeaderReceivedRows[0].FeeRecipient)
 		require.Equal(t, insertLeaderAddr, insertLeaderReceivedRows[0].DistributionRecipient)
-		require.Equal(t, feeOneTRUF, insertLeaderReceivedRows[0].DistributionAmount)
+		require.Equal(t, feeThreeTRUF, insertLeaderReceivedRows[0].DistributionAmount)
 
 		bonusReceivedRows, err := fetchTransactionFees(ctx, platform, actor.Address(), bonusRecipientLower, "received")
 		require.NoError(t, err)
@@ -348,7 +349,7 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 		require.Equal(t, insertTx, bonusReceivedRows[0].TxID)
 		require.Equal(t, insertLeaderAddr, bonusReceivedRows[0].FeeRecipient)
 		require.Equal(t, bonusRecipientLower, bonusReceivedRows[0].DistributionRecipient)
-		require.Equal(t, feeOneTRUF, bonusReceivedRows[0].DistributionAmount)
+		require.Equal(t, feeThreeTRUF, bonusReceivedRows[0].DistributionAmount)
 
 		lastTxRows, err := fetchLastTransactions(ctx, platform, actor.Address(), userLower, int64(len(expected)))
 		require.NoError(t, err)
@@ -366,7 +367,7 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 		for _, row := range bonusHistoryRows {
 			if row.DistributionRecipient == bonusRecipientLower {
 				require.Equal(t, insertTx, row.TxID)
-				require.Equal(t, feeOneTRUF, row.DistributionAmount)
+				require.Equal(t, feeThreeTRUF, row.DistributionAmount)
 				foundBonus = true
 				break
 			}


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3805

applied to Live Mainnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stream creation fee increased from 2 TRUF to 6 TRUF.
  * Record insertion fee increased from 2 TRUF to 6 TRUF.
  * Taxonomy insertion fee increased from 2 TRUF to 6 TRUF per child stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->