### PR TITLE
fix: cannot place orders on USDC prediction markets

### DIFF
--- a/internal/migrations/030-order-book-schema.sql
+++ b/internal/migrations/030-order-book-schema.sql
@@ -25,6 +25,12 @@ CREATE TABLE IF NOT EXISTS ob_queries (
     settled BOOLEAN DEFAULT false NOT NULL,
     winning_outcome BOOLEAN,
     settled_at INT8,
+    -- DEPRECATED: dormant column. Originally intended to gate LP reward
+    -- eligibility per market, but sample_lp_rewards (034-order-book-rewards.sql)
+    -- uses a dynamic spread computed from the market midpoint and never reads
+    -- this value. Kept on the table for backward compatibility with existing
+    -- clients that still write/read it. See:
+    -- PredictionMarketTasks/backlog/max_spread_unused.md
     max_spread INT NOT NULL DEFAULT 5,
     min_order_size INT8 NOT NULL DEFAULT 20,
     created_at INT8 NOT NULL,

--- a/internal/migrations/032-order-book-actions.prod.sql
+++ b/internal/migrations/032-order-book-actions.prod.sql
@@ -27,6 +27,16 @@ CREATE OR REPLACE ACTION validate_bridge($bridge TEXT) PRIVATE {
     RETURN;
 };
 
+CREATE OR REPLACE ACTION get_bridge_units_per_dollar($bridge TEXT)
+    PUBLIC VIEW RETURNS (units_per_dollar NUMERIC(78, 0)) {
+    if $bridge = 'eth_truf' {
+        RETURN '1000000000000000000'::NUMERIC(78, 0);
+    } else if $bridge = 'eth_usdc' {
+        RETURN '1000000'::NUMERIC(78, 0);
+    }
+    ERROR('Unknown bridge: ' || $bridge);
+};
+
 CREATE OR REPLACE ACTION create_market(
     $bridge TEXT,
     $query_components BYTEA,
@@ -73,9 +83,9 @@ CREATE OR REPLACE ACTION create_market(
         ERROR('Settlement time must be in the future');
     }
 
-    -- Validate max_spread (1-50 cents)
+    -- Validate max_spread (1-50 price-points)
     if $max_spread IS NULL OR $max_spread < 1 OR $max_spread > 50 {
-        ERROR('Max spread must be between 1 and 50 cents');
+        ERROR('Max spread must be between 1 and 50 (price-points)');
     }
 
     -- Validate min_order_size (must be positive)
@@ -86,7 +96,7 @@ CREATE OR REPLACE ACTION create_market(
     -- ==========================================================================
     -- FEE COLLECTION
     -- ==========================================================================
-    -- Fee: 2 TRUF (2 * 10^18 wei)
+    -- Fee: 2 TRUF (2 * 10^18 base units of eth_truf)
     -- Market creation fee is ALWAYS paid in TRUF (eth_truf on testnet)
     -- regardless of which bridge the market uses for collateral
     $market_creation_fee NUMERIC(78, 0) := '2000000000000000000'::NUMERIC(78, 0);
@@ -171,9 +181,6 @@ CREATE OR REPLACE ACTION place_buy_order(
     $price INT,
     $amount INT8
 ) PUBLIC {
-    -- Constants
-    $collateral_decimals INT := 18;
-
     -- ==========================================================================
     -- SECTION 1: VALIDATION
     -- ==========================================================================
@@ -238,16 +245,15 @@ CREATE OR REPLACE ACTION place_buy_order(
     -- SECTION 2: CALCULATE COLLATERAL NEEDED
     -- ==========================================================================
 
-    -- For buy order: collateral = amount × price × 10^16
-    -- Example: 10 shares at $0.56 = 10 × 56 × 10^16 = 5.6 × 10^18 wei
+    -- All collateral in bridge token base units. units_per_dollar is sourced
+    -- from get_bridge_units_per_dollar (the single point where per-bridge
+    -- decimals are defined). $price is INT in [1, 99], so we divide by 100.
     --
-    -- Why 10^16?
-    -- - Prices are in cents (1-99)
-    -- - Token has 18 decimals
-    -- - Formula: 10^(18-2) = 10^16
-    -- Note: Kuneiform doesn't have POWER(), so we use hardcoded constant
-    -- Cast INT8 and INT to NUMERIC for multiplication
-    $collateral_needed NUMERIC(78, 0) := ($amount::NUMERIC(78, 0) * $price::NUMERIC(78, 0) * '10000000000000000'::NUMERIC(78, 0));
+    --   collateral = ($amount * $price * units_per_dollar) / 100
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+    $collateral_needed NUMERIC(78, 0) := ($amount::NUMERIC(78, 0) *
+                                           $price::NUMERIC(78, 0) *
+                                           $units_per_dollar) / 100::NUMERIC(78, 0);
 
     -- ==========================================================================
     -- SECTION 3: CHECK BALANCE (bridge-specific)
@@ -259,9 +265,9 @@ CREATE OR REPLACE ACTION place_buy_order(
     } else if $bridge = 'eth_truf' {
         $caller_balance := COALESCE(eth_truf.balance(@caller), 0::NUMERIC(78, 0));
     }if $caller_balance < $collateral_needed {
-        -- Note: Division by 10^18 for display purposes (convert wei to TRUF)
-        ERROR('Insufficient balance. Required: ' || $collateral_needed::TEXT || ' wei (' ||
-              ($collateral_needed / '1000000000000000000'::NUMERIC(78, 0))::TEXT || ' TRUF)');
+        -- Display in token base units AND in dollar form (collateral / units_per_dollar).
+        ERROR('Insufficient balance. Required: ' || $collateral_needed::TEXT || ' base units ($' ||
+              ($collateral_needed / $units_per_dollar)::TEXT || ')');
     }
 
     -- ==========================================================================
@@ -407,16 +413,14 @@ CREATE OR REPLACE ACTION place_split_limit_order(
     -- SECTION 2: CALCULATE COLLATERAL NEEDED
     -- ==========================================================================
 
-    -- For split order: collateral = amount × $1.00 = amount × 10^18
-    -- Example: 100 shares × 10^18 = 100,000,000,000,000,000,000 wei = 100 TRUF
+    -- Each minted share pair requires $1.00 of collateral, expressed in
+    -- bridge token base units. units_per_dollar is sourced from
+    -- get_bridge_units_per_dollar (the single point where per-bridge
+    -- decimals are defined).
     --
-    -- Why 10^18?
-    -- - Minting a share pair (YES + NO) requires $1.00 total collateral
-    -- - Token has 18 decimals
-    -- - Formula: $1.00 × 10^18
-    -- Note: Kuneiform doesn't have POWER(), so we use hardcoded constant
-    -- Cast INT8 to NUMERIC for multiplication
-    $collateral_needed NUMERIC(78, 0) := ($amount::NUMERIC(78, 0) * '1000000000000000000'::NUMERIC(78, 0));
+    --   collateral = $amount * units_per_dollar
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+    $collateral_needed NUMERIC(78, 0) := $amount::NUMERIC(78, 0) * $units_per_dollar;
 
     -- ==========================================================================
     -- SECTION 3: CHECK BALANCE (bridge-specific)
@@ -428,9 +432,9 @@ CREATE OR REPLACE ACTION place_split_limit_order(
     } else if $bridge = 'eth_truf' {
         $caller_balance := COALESCE(eth_truf.balance(@caller), 0::NUMERIC(78, 0));
     }if $caller_balance < $collateral_needed {
-        -- Note: Division by 10^18 for display purposes (convert wei to TRUF)
-        ERROR('Insufficient balance. Required: ' || $collateral_needed::TEXT || ' wei (' ||
-              ($collateral_needed / '1000000000000000000'::NUMERIC(78, 0))::TEXT || ' TRUF)');
+        -- Display in token base units AND in dollar form (collateral / units_per_dollar).
+        ERROR('Insufficient balance. Required: ' || $collateral_needed::TEXT || ' base units ($' ||
+              ($collateral_needed / $units_per_dollar)::TEXT || ')');
     }
 
     -- ==========================================================================
@@ -653,20 +657,21 @@ CREATE OR REPLACE ACTION change_bid(
     -- SECTION 5: CALCULATE COLLATERAL CHANGE
     -- ==========================================================================
 
-    -- Buy order collateral formula: amount × |price| × 10^16 wei
-    -- Example: 100 shares @ $0.54 = 100 × 54 × 10^16 = 5.4 × 10^19 wei (54 TRUF)
-    $multiplier NUMERIC(78, 0) := '10000000000000000'::NUMERIC(78, 0);  -- 10^16
+    -- Buy order collateral in bridge token base units:
+    --   ($amount * |price| * units_per_dollar) / 100
+    -- units_per_dollar comes from get_bridge_units_per_dollar (single source
+    -- of per-bridge decimals). $price is INT in [1, 99].
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+    $old_abs_price INT := -$old_price;
+    $new_abs_price INT := -$new_price;
 
-    $old_abs_price INT := -$old_price;  -- Make positive
-    $new_abs_price INT := -$new_price;  -- Make positive
+    $old_collateral NUMERIC(78, 0) := ($old_amount::NUMERIC(78, 0) *
+                                        $old_abs_price::NUMERIC(78, 0) *
+                                        $units_per_dollar) / 100::NUMERIC(78, 0);
 
-    $old_collateral NUMERIC(78, 0) := $old_amount::NUMERIC(78, 0) *
-                                       $old_abs_price::NUMERIC(78, 0) *
-                                       $multiplier;
-
-    $new_collateral NUMERIC(78, 0) := $new_amount::NUMERIC(78, 0) *
-                                       $new_abs_price::NUMERIC(78, 0) *
-                                       $multiplier;
+    $new_collateral NUMERIC(78, 0) := ($new_amount::NUMERIC(78, 0) *
+                                        $new_abs_price::NUMERIC(78, 0) *
+                                        $units_per_dollar) / 100::NUMERIC(78, 0);
 
     $collateral_delta NUMERIC(78, 0) := $new_collateral - $old_collateral;
     $zero NUMERIC(78, 0) := '0'::NUMERIC(78, 0);

--- a/internal/migrations/032-order-book-actions.sql
+++ b/internal/migrations/032-order-book-actions.sql
@@ -36,6 +36,45 @@ CREATE OR REPLACE ACTION validate_bridge($bridge TEXT) PRIVATE {
 };
 
 -- =============================================================================
+-- get_bridge_units_per_dollar: Bridge token base units per $1.00 of collateral
+-- =============================================================================
+/**
+ * Returns the number of bridge token base units that represent $1.00 of
+ * collateral. This is 10^decimals where decimals is the bridge token's
+ * on-chain decimals.
+ *
+ * Embedded test bridges (hoodi_tt2, sepolia_bridge, ethereum_bridge) are all
+ * 18-decimal TRUF-likes and share the same value. The generated mainnet
+ * override (.prod.sql) replaces the body with eth_truf=10^18 and
+ * eth_usdc=10^6, driven by BRIDGE_DECIMALS in
+ * scripts/generate_prod_migrations.py — the only place real per-bridge
+ * decimals live.
+ *
+ * IMPORTANT: $price in OB actions is INT in [1, 99] — an integer-encoded
+ * probability/price-point, NOT a value with units. To compute collateral
+ * in base units:
+ *
+ *     collateral_base_units = ($amount * $price * units_per_dollar) / 100
+ *
+ * Parameters:
+ * - $bridge: Bridge namespace
+ *
+ * Returns:
+ * - units_per_dollar: Base units representing $1.00
+ */
+CREATE OR REPLACE ACTION get_bridge_units_per_dollar($bridge TEXT)
+    PUBLIC VIEW RETURNS (units_per_dollar NUMERIC(78, 0)) {
+    if $bridge = 'hoodi_tt2' {
+        RETURN '1000000000000000000'::NUMERIC(78, 0);
+    } else if $bridge = 'sepolia_bridge' {
+        RETURN '1000000000000000000'::NUMERIC(78, 0);
+    } else if $bridge = 'ethereum_bridge' {
+        RETURN '1000000000000000000'::NUMERIC(78, 0);
+    }
+    ERROR('Unknown bridge: ' || $bridge);
+};
+
+-- =============================================================================
 -- get_market_bridge: Get the bridge for a market
 -- =============================================================================
 /**
@@ -73,7 +112,7 @@ CREATE OR REPLACE ACTION get_market_bridge($query_id INT) PRIVATE RETURNS (bridg
  * - $bridge: Bridge namespace for collateral (hoodi_tt2, sepolia_bridge, ethereum_bridge)
  * - $query_components: ABI-encoded (address data_provider, bytes32 stream_id, string action_id, bytes args)
  * - $settle_time: Unix timestamp when market can be settled (must be in future)
- * - $max_spread: Maximum spread for LP rewards (1-50 cents)
+ * - $max_spread: Maximum spread for LP rewards (1-50 price-points)
  * - $min_order_size: Minimum order size for LP rewards (must be positive)
  *
  * Returns:
@@ -128,9 +167,9 @@ CREATE OR REPLACE ACTION create_market(
         ERROR('Settlement time must be in the future');
     }
 
-    -- Validate max_spread (1-50 cents)
+    -- Validate max_spread (1-50 price-points)
     if $max_spread IS NULL OR $max_spread < 1 OR $max_spread > 50 {
-        ERROR('Max spread must be between 1 and 50 cents');
+        ERROR('Max spread must be between 1 and 50 (price-points)');
     }
 
     -- Validate min_order_size (must be positive)
@@ -141,7 +180,7 @@ CREATE OR REPLACE ACTION create_market(
     -- ==========================================================================
     -- FEE COLLECTION
     -- ==========================================================================
-    -- Fee: 2 TRUF (2 * 10^18 wei)
+    -- Fee: 2 TRUF (2 * 10^18 base units of eth_truf)
     -- Market creation fee is ALWAYS paid in TRUF (hoodi_tt on testnet)
     -- regardless of which bridge the market uses for collateral
     $market_creation_fee NUMERIC(78, 0) := '2000000000000000000'::NUMERIC(78, 0);
@@ -428,9 +467,9 @@ PUBLIC VIEW RETURNS (market_exists BOOLEAN) {
  * - Example: Buy YES @ $0.52 matches Sell YES @ $0.51
  *   → Seller receives $0.51/share, buyer is refunded $0.01/share
  *
- * Collateral Flow:
- * - Seller receives: match_amount × sell_price × 10^16
- * - Buyer refund (if price improvement): match_amount × (buy_price - sell_price) × 10^16
+ * Collateral Flow (all amounts in bridge token base units):
+ * - Seller receives: (match_amount × sell_price × units_per_dollar) / 100
+ * - Buyer refund (if price improvement): (match_amount × (buy_price - sell_price) × units_per_dollar) / 100
  * - Shares transfer from seller's holdings to buyer's holdings
  *
  * Recursion Behavior:
@@ -531,11 +570,12 @@ CREATE OR REPLACE ACTION match_direct(
     }
     $seller_wallet_address TEXT := '0x' || encode($seller_wallet_bytes, 'hex');
 
-    -- Calculate payment to seller (at sell price)
-    $multiplier NUMERIC(78, 0) := '10000000000000000'::NUMERIC(78, 0);
+    -- Calculate payment to seller (at sell price), in bridge token base units.
+    -- $price is INT in [1, 99]; divide by 100 to convert to dollars.
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
     $seller_payment NUMERIC(78, 0) := ($match_amount::NUMERIC(78, 0) *
                                         $sell_price::NUMERIC(78, 0) *
-                                        $multiplier);
+                                        $units_per_dollar) / 100::NUMERIC(78, 0);
 
     -- Transfer payment from vault to seller
     ob_unlock_collateral($bridge, $seller_wallet_address, $seller_payment);
@@ -558,11 +598,11 @@ CREATE OR REPLACE ACTION match_direct(
     $buyer_wallet_address TEXT := '0x' || encode($buyer_wallet_bytes, 'hex');
 
     if $price_diff > 0 {
-        -- Buyer locked collateral at buy_price but match executes at sell_price
-        -- Refund the difference: match_amount × (buy_price - sell_price) × 10^16
+        -- Buyer locked collateral at buy_price but match executes at sell_price.
+        -- Refund the difference: (match_amount × (buy_price - sell_price) × units_per_dollar) / 100.
         $buyer_refund NUMERIC(78, 0) := ($match_amount::NUMERIC(78, 0) *
                                           $price_diff::NUMERIC(78, 0) *
-                                          $multiplier);
+                                          $units_per_dollar) / 100::NUMERIC(78, 0);
         ob_unlock_collateral($bridge, $buyer_wallet_address, $buyer_refund);
 
         -- Record buy impact with refund
@@ -807,8 +847,8 @@ CREATE OR REPLACE ACTION match_burn(
     $no_price INT,
     $bridge TEXT
 ) PRIVATE {
-    -- Multiplier for collateral calculations
-    $multiplier NUMERIC(78, 0) := '10000000000000000'::NUMERIC(78, 0);
+    -- Bridge token base units per $1.00 of collateral (single source of truth).
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
 
     -- Validate complementary prices (must sum to 100)
     if ($yes_price + $no_price) != 100 {
@@ -898,14 +938,15 @@ CREATE OR REPLACE ACTION match_burn(
     ob_record_order_event($query_id, $yes_participant_id, 'burn_fill', TRUE, $yes_price, $burn_amount, $no_participant_id);
     ob_record_order_event($query_id, $no_participant_id, 'burn_fill', FALSE, $no_price, $burn_amount, $yes_participant_id);
 
-    -- Calculate payouts
+    -- Calculate payouts in bridge token base units.
+    -- $price is INT in [1, 99]; divide by 100 to convert to dollars.
     $yes_payout NUMERIC(78, 0) := ($burn_amount::NUMERIC(78, 0) *
                                     $yes_price::NUMERIC(78, 0) *
-                                    $multiplier);
+                                    $units_per_dollar) / 100::NUMERIC(78, 0);
 
     $no_payout NUMERIC(78, 0) := ($burn_amount::NUMERIC(78, 0) *
                                    $no_price::NUMERIC(78, 0) *
-                                   $multiplier);
+                                   $units_per_dollar) / 100::NUMERIC(78, 0);
 
     -- Unlock collateral
     ob_unlock_collateral($bridge, $yes_wallet_address, $yes_payout);
@@ -1048,15 +1089,17 @@ CREATE OR REPLACE ACTION match_orders(
  * Parameters:
  * - $query_id: Market identifier (from ob_queries.id)
  * - $outcome: TRUE for YES shares, FALSE for NO shares
- * - $price: Price per share in cents (1-99 = $0.01 to $0.99)
+ * - $price: INT in [1, 99] — implied probability × 100 ($0.01 to $0.99)
  * - $amount: Number of shares to buy
  *
- * Collateral locked: amount × price × 10^16
- * Example: 10 shares at $0.56 = 10 × 56 × 10^16 = 5.6 × 10^18 wei (5.6 TRUF)
+ * Collateral locked (in bridge token base units):
+ *   ($amount * $price * units_per_dollar) / 100
+ * Example (eth_truf, units_per_dollar = 10^18):
+ *   10 shares at price 56 → (10 × 56 × 10^18) / 100 = 5.6 × 10^18 base units (5.6 TRUF)
  *
  * Price Convention:
- * - Buy orders stored with NEGATIVE price (e.g., -56 for $0.56 buy)
- * - Sell orders stored with POSITIVE price (e.g., 56 for $0.56 sell)
+ * - Buy orders stored with NEGATIVE price (e.g., -56 for a buy at probability 56)
+ * - Sell orders stored with POSITIVE price (e.g., 56 for a sell at probability 56)
  * - Holdings stored with price = 0 (not listed for sale)
  *
  * Examples:
@@ -1069,9 +1112,6 @@ CREATE OR REPLACE ACTION place_buy_order(
     $price INT,
     $amount INT8
 ) PUBLIC {
-    -- Constants
-    $collateral_decimals INT := 18;
-
     -- ==========================================================================
     -- SECTION 1: VALIDATION
     -- ==========================================================================
@@ -1136,16 +1176,15 @@ CREATE OR REPLACE ACTION place_buy_order(
     -- SECTION 2: CALCULATE COLLATERAL NEEDED
     -- ==========================================================================
 
-    -- For buy order: collateral = amount × price × 10^16
-    -- Example: 10 shares at $0.56 = 10 × 56 × 10^16 = 5.6 × 10^18 wei
+    -- All collateral in bridge token base units. units_per_dollar is sourced
+    -- from get_bridge_units_per_dollar (the single point where per-bridge
+    -- decimals are defined). $price is INT in [1, 99], so we divide by 100.
     --
-    -- Why 10^16?
-    -- - Prices are in cents (1-99)
-    -- - Token has 18 decimals
-    -- - Formula: 10^(18-2) = 10^16
-    -- Note: Kuneiform doesn't have POWER(), so we use hardcoded constant
-    -- Cast INT8 and INT to NUMERIC for multiplication
-    $collateral_needed NUMERIC(78, 0) := ($amount::NUMERIC(78, 0) * $price::NUMERIC(78, 0) * '10000000000000000'::NUMERIC(78, 0));
+    --   collateral = ($amount * $price * units_per_dollar) / 100
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+    $collateral_needed NUMERIC(78, 0) := ($amount::NUMERIC(78, 0) *
+                                           $price::NUMERIC(78, 0) *
+                                           $units_per_dollar) / 100::NUMERIC(78, 0);
 
     -- ==========================================================================
     -- SECTION 3: CHECK BALANCE (bridge-specific)
@@ -1161,9 +1200,9 @@ CREATE OR REPLACE ACTION place_buy_order(
     }
 
     if $caller_balance < $collateral_needed {
-        -- Note: Division by 10^18 for display purposes (convert wei to TRUF)
-        ERROR('Insufficient balance. Required: ' || $collateral_needed::TEXT || ' wei (' ||
-              ($collateral_needed / '1000000000000000000'::NUMERIC(78, 0))::TEXT || ' TRUF)');
+        -- Display in token base units AND in dollar form (collateral / units_per_dollar).
+        ERROR('Insufficient balance. Required: ' || $collateral_needed::TEXT || ' base units ($' ||
+              ($collateral_needed / $units_per_dollar)::TEXT || ')');
     }
 
     -- ==========================================================================
@@ -1261,7 +1300,7 @@ CREATE OR REPLACE ACTION place_buy_order(
  * Parameters:
  * - $query_id: Market identifier (from ob_queries.id)
  * - $outcome: TRUE for YES shares, FALSE for NO shares
- * - $price: Price per share in cents (1-99 = $0.01 to $0.99)
+ * - $price: INT in [1, 99] — implied probability × 100 ($0.01 to $0.99)
  * - $amount: Number of shares to sell
  *
  * Prerequisites: User must own at least $amount shares of $outcome
@@ -1454,19 +1493,21 @@ CREATE OR REPLACE ACTION place_sell_order(
  *
  * Parameters:
  * - $query_id: Market identifier (from ob_queries.id)
- * - $true_price: Price for YES shares in cents (1-99 = $0.01 to $0.99)
+ * - $true_price: INT in [1, 99] — implied probability for YES × 100 ($0.01 to $0.99)
  * - $amount: Number of share PAIRS to mint
  *
- * Collateral locked: amount × $1.00 (amount × 10^18 wei)
- * Example: 100 share pairs = 100 × 10^18 wei = 100 TRUF
+ * Collateral locked (in bridge token base units):
+ *   $amount * units_per_dollar    -- one full $1.00 per minted pair
+ * Example (eth_truf, units_per_dollar = 10^18):
+ *   100 share pairs → 100 × 10^18 base units = 100 TRUF
  *
  * Result:
  * - User holds: $amount YES shares at price=0 (holding, not for sale)
  * - User sells: $amount NO shares at price=(100-true_price) (listed for sale)
  *
  * Price Calculation:
- * - YES price: $true_price (e.g., $0.56 = 56 cents)
- * - NO price: 100 - $true_price (e.g., 100 - 56 = 44 cents = $0.44)
+ * - YES price: $true_price (e.g., 56 ⇒ $0.56)
+ * - NO price: 100 - $true_price (e.g., 100 - 56 = 44 ⇒ $0.44)
  * - Total: Always $1.00 per share pair
  *
  * LP Reward Eligibility:
@@ -1481,10 +1522,10 @@ CREATE OR REPLACE ACTION place_sell_order(
  * but qualification requires BOTH prices to be within the spread. This encourages
  * tight two-sided markets and provides meaningful liquidity for traders.
  *
- * Example with max_spread = 5 cents:
- * - Market midpoint: $0.50
- * - Split @ $0.56/$0.44: Distance = 6¢ → OUTSIDE spread → NOT qualified ❌
- * - Split @ $0.52/$0.48: Distance = 2¢ → WITHIN spread → QUALIFIED ✅
+ * Example with max_spread = 5:
+ * - Market midpoint: 50 (price-points)
+ * - Split @ 56/44: Distance = 6 → OUTSIDE spread → NOT qualified
+ * - Split @ 52/48: Distance = 2 → WITHIN spread → QUALIFIED
  *
  * Examples:
  *   place_split_limit_order(1, 56, 100)  -- Mint 100 pairs: hold YES, sell NO @ $0.44
@@ -1555,16 +1596,14 @@ CREATE OR REPLACE ACTION place_split_limit_order(
     -- SECTION 2: CALCULATE COLLATERAL NEEDED
     -- ==========================================================================
 
-    -- For split order: collateral = amount × $1.00 = amount × 10^18
-    -- Example: 100 shares × 10^18 = 100,000,000,000,000,000,000 wei = 100 TRUF
+    -- Each minted share pair requires $1.00 of collateral, expressed in
+    -- bridge token base units. units_per_dollar is sourced from
+    -- get_bridge_units_per_dollar (the single point where per-bridge
+    -- decimals are defined).
     --
-    -- Why 10^18?
-    -- - Minting a share pair (YES + NO) requires $1.00 total collateral
-    -- - Token has 18 decimals
-    -- - Formula: $1.00 × 10^18
-    -- Note: Kuneiform doesn't have POWER(), so we use hardcoded constant
-    -- Cast INT8 to NUMERIC for multiplication
-    $collateral_needed NUMERIC(78, 0) := ($amount::NUMERIC(78, 0) * '1000000000000000000'::NUMERIC(78, 0));
+    --   collateral = $amount * units_per_dollar
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+    $collateral_needed NUMERIC(78, 0) := $amount::NUMERIC(78, 0) * $units_per_dollar;
 
     -- ==========================================================================
     -- SECTION 3: CHECK BALANCE (bridge-specific)
@@ -1580,9 +1619,9 @@ CREATE OR REPLACE ACTION place_split_limit_order(
     }
 
     if $caller_balance < $collateral_needed {
-        -- Note: Division by 10^18 for display purposes (convert wei to TRUF)
-        ERROR('Insufficient balance. Required: ' || $collateral_needed::TEXT || ' wei (' ||
-              ($collateral_needed / '1000000000000000000'::NUMERIC(78, 0))::TEXT || ' TRUF)');
+        -- Display in token base units AND in dollar form (collateral / units_per_dollar).
+        ERROR('Insufficient balance. Required: ' || $collateral_needed::TEXT || ' base units ($' ||
+              ($collateral_needed / $units_per_dollar)::TEXT || ')');
     }
 
     -- ==========================================================================
@@ -1729,9 +1768,10 @@ CREATE OR REPLACE ACTION place_split_limit_order(
  * - System moves 100 NO shares back to holdings (price=0)
  * - Sell order is deleted from ob_positions
  *
- * Collateral Refund Calculation (Buy Orders):
- * - Formula: amount × |price| × 10^16 wei
- * - Example: 10 shares @ $0.56 = 10 × 56 × 10^16 = 5.6 × 10^18 wei (5.6 TRUF)
+ * Collateral Refund Calculation (Buy Orders), in bridge token base units:
+ * - Formula: ($order_amount * |price| * units_per_dollar) / 100
+ * - Example (eth_truf, units_per_dollar = 10^18):
+ *   10 shares @ price 56 → (10 × 56 × 10^18) / 100 = 5.6 × 10^18 base units (5.6 TRUF)
  *
  * Parameters:
  * - $query_id: Market ID from ob_queries
@@ -1848,17 +1888,14 @@ CREATE OR REPLACE ACTION cancel_order(
 
     -- For buy orders (price < 0): Refund locked collateral to user's wallet
     if $price < 0 {
-        -- Calculate locked collateral
-        -- Formula: amount × |price| × 10^16 wei
-        -- Example: 10 shares @ $0.56 = 10 × 56 × 10^16 = 5.6 × 10^18 wei
-        --
-        -- Why 10^16? Prices are in cents (1-99), we need to convert to 18-decimal wei:
-        -- - Price 56 = $0.56 = 0.56 / 1.00
-        -- - Collateral per share = price / 100 * 10^18 = price * 10^16
-
-        $abs_price INT := -$price;  -- Convert negative price to positive
-        $multiplier NUMERIC(78, 0) := '10000000000000000'::NUMERIC(78, 0);  -- 10^16
-        $refund_amount NUMERIC(78, 0) := $order_amount::NUMERIC(78, 0) * $abs_price::NUMERIC(78, 0) * $multiplier;
+        -- Refund in bridge token base units. units_per_dollar comes from
+        -- get_bridge_units_per_dollar (single source of per-bridge decimals).
+        -- $price is INT in [1, 99]; divide by 100 to convert to dollars.
+        $abs_price INT := -$price;
+        $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+        $refund_amount NUMERIC(78, 0) := ($order_amount::NUMERIC(78, 0) *
+                                            $abs_price::NUMERIC(78, 0) *
+                                            $units_per_dollar) / 100::NUMERIC(78, 0);
 
         -- Unlock collateral back to user using helper from 031-order-book-vault.sql
         -- Passes bridge parameter to unlock from correct bridge
@@ -1939,9 +1976,9 @@ CREATE OR REPLACE ACTION cancel_order(
  * - User calls: change_bid(old=-54, new=-50, new_amount=100)
  * - Result: 100 shares @ $0.50 (upsizing from 70 to 100, locks additional 15 TRUF)
  *
- * Collateral Calculation:
- * - Old collateral: old_amount × |old_price| × 10^16 wei
- * - New collateral: new_amount × |new_price| × 10^16 wei
+ * Collateral Calculation (in bridge token base units):
+ * - Old collateral: ($old_amount * |old_price| * units_per_dollar) / 100
+ * - New collateral: ($new_amount * |new_price| * units_per_dollar) / 100
  * - Delta: new_collateral - old_collateral
  * - If delta > 0: Lock additional collateral (will ERROR if insufficient balance)
  * - If delta < 0: Unlock excess collateral
@@ -2076,20 +2113,21 @@ CREATE OR REPLACE ACTION change_bid(
     -- SECTION 5: CALCULATE COLLATERAL CHANGE
     -- ==========================================================================
 
-    -- Buy order collateral formula: amount × |price| × 10^16 wei
-    -- Example: 100 shares @ $0.54 = 100 × 54 × 10^16 = 5.4 × 10^19 wei (54 TRUF)
-    $multiplier NUMERIC(78, 0) := '10000000000000000'::NUMERIC(78, 0);  -- 10^16
+    -- Buy order collateral in bridge token base units:
+    --   ($amount * |price| * units_per_dollar) / 100
+    -- units_per_dollar comes from get_bridge_units_per_dollar (single source
+    -- of per-bridge decimals). $price is INT in [1, 99].
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+    $old_abs_price INT := -$old_price;
+    $new_abs_price INT := -$new_price;
 
-    $old_abs_price INT := -$old_price;  -- Make positive
-    $new_abs_price INT := -$new_price;  -- Make positive
+    $old_collateral NUMERIC(78, 0) := ($old_amount::NUMERIC(78, 0) *
+                                        $old_abs_price::NUMERIC(78, 0) *
+                                        $units_per_dollar) / 100::NUMERIC(78, 0);
 
-    $old_collateral NUMERIC(78, 0) := $old_amount::NUMERIC(78, 0) *
-                                       $old_abs_price::NUMERIC(78, 0) *
-                                       $multiplier;
-
-    $new_collateral NUMERIC(78, 0) := $new_amount::NUMERIC(78, 0) *
-                                       $new_abs_price::NUMERIC(78, 0) *
-                                       $multiplier;
+    $new_collateral NUMERIC(78, 0) := ($new_amount::NUMERIC(78, 0) *
+                                        $new_abs_price::NUMERIC(78, 0) *
+                                        $units_per_dollar) / 100::NUMERIC(78, 0);
 
     $collateral_delta NUMERIC(78, 0) := $new_collateral - $old_collateral;
     $zero NUMERIC(78, 0) := '0'::NUMERIC(78, 0);
@@ -2535,8 +2573,8 @@ CREATE OR REPLACE ACTION settle_market(
     if $total_true > 0 OR $total_false > 0 {
         if NOT $valid_collateral {
             ERROR('Cannot settle market: Vault collateral mismatch. Expected=' ||
-                  COALESCE($expected_collateral::TEXT, 'NULL') || ' wei, Actual=' || COALESCE($vault_balance::TEXT, 'NULL') ||
-                  ' wei. This indicates missing or excess collateral.');
+                  COALESCE($expected_collateral::TEXT, 'NULL') || ' base units, Actual=' || COALESCE($vault_balance::TEXT, 'NULL') ||
+                  ' base units. This indicates missing or excess collateral.');
         }
     }
 

--- a/internal/migrations/032-order-book-actions.sql
+++ b/internal/migrations/032-order-book-actions.sql
@@ -112,7 +112,11 @@ CREATE OR REPLACE ACTION get_market_bridge($query_id INT) PRIVATE RETURNS (bridg
  * - $bridge: Bridge namespace for collateral (hoodi_tt2, sepolia_bridge, ethereum_bridge)
  * - $query_components: ABI-encoded (address data_provider, bytes32 stream_id, string action_id, bytes args)
  * - $settle_time: Unix timestamp when market can be settled (must be in future)
- * - $max_spread: Maximum spread for LP rewards (1-50 price-points)
+ * - $max_spread: DEPRECATED — accepted, validated, and stored, but no longer
+ *                consumed. LP reward eligibility uses a dynamic spread
+ *                computed in sample_lp_rewards (034). Kept for backward
+ *                compatibility with existing callers. See:
+ *                PredictionMarketTasks/backlog/max_spread_unused.md
  * - $min_order_size: Minimum order size for LP rewards (must be positive)
  *
  * Returns:
@@ -1512,20 +1516,24 @@ CREATE OR REPLACE ACTION place_sell_order(
  *
  * LP Reward Eligibility:
  *
- * To qualify for LP rewards, ALL of the following must be true:
- * 1. BOTH buy and sell prices must be within max_spread of market midpoint (50):
- *    - Effective BUY price (true_price) within spread
- *    - SELL price (false_price = 100 - true_price) within spread
- * 2. Amount must meet min_order_size threshold from ob_queries
+ * Implemented in sample_lp_rewards (034-order-book-rewards.sql) using a
+ * DYNAMIC spread that depends on the current market midpoint, NOT the
+ * per-market max_spread column (which is dormant — see
+ * PredictionMarketTasks/backlog/max_spread_unused.md):
  *
- * Rewards are calculated based on SELL order volume (NO shares listed for sale),
- * but qualification requires BOTH prices to be within the spread. This encourages
- * tight two-sided markets and provides meaningful liquidity for traders.
+ *   spread_base = ABS(midpoint - (100 - midpoint))
+ *     < 30 → eligible band = ±5 price-points around midpoint
+ *     < 60 → eligible band = ±4
+ *     < 80 → eligible band = ±3
+ *     ≥ 80 → market too certain, no rewards
  *
- * Example with max_spread = 5:
- * - Market midpoint: 50 (price-points)
- * - Split @ 56/44: Distance = 6 → OUTSIDE spread → NOT qualified
- * - Split @ 52/48: Distance = 2 → WITHIN spread → QUALIFIED
+ * For an order to score:
+ * 1. BOTH legs of the LP pair (YES + NO) must fall inside the eligible band.
+ * 2. Per-pair score is weighted by ((spread - distance) / spread)² — tighter
+ *    quotes earn more.
+ * 3. Per-participant score is LEAST(TRUE-side sum, FALSE-side sum) — both
+ *    sides of the book must contribute for non-zero rewards.
+ * 4. Amount must meet min_order_size threshold from ob_queries.
  *
  * Examples:
  *   place_split_limit_order(1, 56, 100)  -- Mint 100 pairs: hold YES, sell NO @ $0.44

--- a/internal/migrations/033-order-book-settlement.sql
+++ b/internal/migrations/033-order-book-settlement.sql
@@ -274,6 +274,9 @@ CREATE OR REPLACE ACTION process_settlement(
     $bridge TEXT;
     for $row in SELECT bridge FROM ob_queries WHERE id = $query_id { $bridge := $row.bridge; }
 
+    -- Bridge token base units per $1.00 (single source of per-bridge decimals).
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+
     $pids INT[];
     $wallet_hexes TEXT[];
     $amounts NUMERIC(78, 0)[];
@@ -322,11 +325,14 @@ CREATE OR REPLACE ACTION process_settlement(
                 wallet_address,
                 '0x' || encode(wallet_address, 'hex') as wallet_hex,
                 CASE
-                    WHEN price >= 0 THEN ((amount::NUMERIC(78, 0) * '1000000000000000000'::NUMERIC(78, 0) * 98::NUMERIC(78, 0)) / 100::NUMERIC(78, 0))
-                    ELSE (amount::NUMERIC(78, 0) * (CASE WHEN price < 0 THEN -price ELSE price END)::NUMERIC(78, 0) * '10000000000000000'::NUMERIC(78, 0))
+                    -- Winning share payout: amount × $0.98 (98% of $1.00, in base units).
+                    WHEN price >= 0 THEN ((amount::NUMERIC(78, 0) * $units_per_dollar * 98::NUMERIC(78, 0)) / 100::NUMERIC(78, 0))
+                    -- Open buy refund: amount × |price| × $0.01 (price is INT in [1,99]).
+                    ELSE ((amount::NUMERIC(78, 0) * (CASE WHEN price < 0 THEN -price ELSE price END)::NUMERIC(78, 0) * $units_per_dollar) / 100::NUMERIC(78, 0))
                 END as pay,
                 CASE WHEN price >= 0 THEN $winning_outcome ELSE outcome END as out,
-                CASE WHEN price >= 0 THEN ((amount::NUMERIC(78, 0) * '1000000000000000000'::NUMERIC(78, 0) * 2::NUMERIC(78, 0)) / 100::NUMERIC(78, 0)) ELSE 0::NUMERIC(78, 0) END as fee
+                -- Settlement fee: 2% of $1.00 per winning share.
+                CASE WHEN price >= 0 THEN ((amount::NUMERIC(78, 0) * $units_per_dollar * 2::NUMERIC(78, 0)) / 100::NUMERIC(78, 0)) ELSE 0::NUMERIC(78, 0) END as fee
             FROM target_positions
         )
         SELECT * FROM payout_calculation

--- a/internal/migrations/037-order-book-validation.prod.sql
+++ b/internal/migrations/037-order-book-validation.prod.sql
@@ -48,10 +48,11 @@ PUBLIC VIEW RETURNS (
         $total_false := $row.total;
     }
 
-    -- Step 3: Calculate open buy collateral obligations for THIS market (in cents)
-    -- Buy orders: price is negative (stored in cents: -1 to -99)
-    -- Collateral per buy order = |price| * amount / 100 (converted to dollars)
-    -- We return the value in cents for precision
+    -- Step 3: Sum (|price| * amount) for THIS market's open buy orders.
+    -- $price is INT in [-99, -1] for buy orders (negative). The sum here is
+    -- bridge-decimal-agnostic: multiply by units_per_dollar/100 to convert
+    -- to base units. We expose the raw sum so callers (or this action's
+    -- own collateral check below) can apply the conversion themselves.
     $open_buys_value BIGINT := 0;
     for $row in
         SELECT COALESCE(SUM(ABS(price) * amount)::BIGINT, 0::BIGINT) as total_value
@@ -74,7 +75,7 @@ PUBLIC VIEW RETURNS (
     -- Step 5: Calculate TOTAL expected collateral across ALL unsettled markets using same bridge
     -- This fixes the multi-market validation issue where vault holds collateral for all markets
     $total_shares_all_markets BIGINT := 0;
-    $total_buys_cents_all_markets BIGINT := 0;
+    $total_buys_price_amount BIGINT := 0;  -- SUM(|price| * amount); convert to base units via units_per_dollar/100
 
     -- Sum TRUE shares (holdings + sells) across all unsettled markets with same bridge
     for $row in
@@ -89,7 +90,7 @@ PUBLIC VIEW RETURNS (
         $total_shares_all_markets := $row.total;
     }
 
-    -- Sum open buy orders (in cents) across all unsettled markets with same bridge
+    -- Sum (|price| * amount) for all unsettled markets' open buy orders, same bridge.
     for $row in
         SELECT COALESCE(SUM(ABS(p.price) * p.amount)::BIGINT, 0::BIGINT) as total_value
         FROM ob_positions p
@@ -98,13 +99,17 @@ PUBLIC VIEW RETURNS (
           AND q.bridge = $bridge
           AND p.price < 0
     {
-        $total_buys_cents_all_markets := $row.total_value;
+        $total_buys_price_amount := $row.total_value;
     }
 
-    -- Calculate total expected collateral in wei (18 decimals)
+    -- Calculate total expected collateral in bridge token base units.
+    -- units_per_dollar comes from get_bridge_units_per_dollar — single source
+    -- of per-bridge decimals. Each share is backed by $1.00; each buy order
+    -- locks ($amount * $price * units_per_dollar) / 100.
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
     $expected_collateral NUMERIC(78, 0);
-    $shares_collateral NUMERIC(78, 0) := $total_shares_all_markets::NUMERIC(78, 0) * '1000000000000000000'::NUMERIC(78, 0);
-    $buys_collateral NUMERIC(78, 0) := ($total_buys_cents_all_markets::NUMERIC(78, 0) * '1000000000000000000'::NUMERIC(78, 0)) / 100::NUMERIC(78, 0);
+    $shares_collateral NUMERIC(78, 0) := $total_shares_all_markets::NUMERIC(78, 0) * $units_per_dollar;
+    $buys_collateral NUMERIC(78, 0) := ($total_buys_price_amount::NUMERIC(78, 0) * $units_per_dollar) / 100::NUMERIC(78, 0);
     $expected_collateral := ($shares_collateral + $buys_collateral)::NUMERIC(78, 0);
 
     -- Step 6: Get actual vault balance from bridge

--- a/internal/migrations/037-order-book-validation.sql
+++ b/internal/migrations/037-order-book-validation.sql
@@ -37,8 +37,9 @@
  * - total_true: Count of TRUE shares for THIS market (holdings + open sells)
  * - total_false: Count of FALSE shares for THIS market (holdings + open sells)
  * - vault_balance: Current network ownedBalance from ethereum_bridge
- * - expected_collateral: Total expected collateral across ALL unsettled markets
- * - open_buys_value: Total escrowed buy order collateral for THIS market (in cents)
+ * - expected_collateral: Total expected collateral across ALL unsettled markets (bridge token base units)
+ * - open_buys_value: Sum of (|price| * amount) across THIS market's open buy orders.
+ *                    $price is INT in [1, 99]; multiply by units_per_dollar/100 to convert to base units.
  *
  * Usage:
  *   kwil-cli database call --action validate_market_collateral \
@@ -82,10 +83,11 @@ PUBLIC VIEW RETURNS (
         $total_false := $row.total;
     }
 
-    -- Step 3: Calculate open buy collateral obligations for THIS market (in cents)
-    -- Buy orders: price is negative (stored in cents: -1 to -99)
-    -- Collateral per buy order = |price| * amount / 100 (converted to dollars)
-    -- We return the value in cents for precision
+    -- Step 3: Sum (|price| * amount) for THIS market's open buy orders.
+    -- $price is INT in [-99, -1] for buy orders (negative). The sum here is
+    -- bridge-decimal-agnostic: multiply by units_per_dollar/100 to convert
+    -- to base units. We expose the raw sum so callers (or this action's
+    -- own collateral check below) can apply the conversion themselves.
     $open_buys_value BIGINT := 0;
     for $row in
         SELECT COALESCE(SUM(ABS(price) * amount)::BIGINT, 0::BIGINT) as total_value
@@ -108,7 +110,7 @@ PUBLIC VIEW RETURNS (
     -- Step 5: Calculate TOTAL expected collateral across ALL unsettled markets using same bridge
     -- This fixes the multi-market validation issue where vault holds collateral for all markets
     $total_shares_all_markets BIGINT := 0;
-    $total_buys_cents_all_markets BIGINT := 0;
+    $total_buys_price_amount BIGINT := 0;  -- SUM(|price| * amount); convert to base units via units_per_dollar/100
 
     -- Sum TRUE shares (holdings + sells) across all unsettled markets with same bridge
     for $row in
@@ -123,7 +125,7 @@ PUBLIC VIEW RETURNS (
         $total_shares_all_markets := $row.total;
     }
 
-    -- Sum open buy orders (in cents) across all unsettled markets with same bridge
+    -- Sum (|price| * amount) for all unsettled markets' open buy orders, same bridge.
     for $row in
         SELECT COALESCE(SUM(ABS(p.price) * p.amount)::BIGINT, 0::BIGINT) as total_value
         FROM ob_positions p
@@ -132,13 +134,17 @@ PUBLIC VIEW RETURNS (
           AND q.bridge = $bridge
           AND p.price < 0
     {
-        $total_buys_cents_all_markets := $row.total_value;
+        $total_buys_price_amount := $row.total_value;
     }
 
-    -- Calculate total expected collateral in wei (18 decimals)
+    -- Calculate total expected collateral in bridge token base units.
+    -- units_per_dollar comes from get_bridge_units_per_dollar — single source
+    -- of per-bridge decimals. Each share is backed by $1.00; each buy order
+    -- locks ($amount * $price * units_per_dollar) / 100.
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
     $expected_collateral NUMERIC(78, 0);
-    $shares_collateral NUMERIC(78, 0) := $total_shares_all_markets::NUMERIC(78, 0) * '1000000000000000000'::NUMERIC(78, 0);
-    $buys_collateral NUMERIC(78, 0) := ($total_buys_cents_all_markets::NUMERIC(78, 0) * '1000000000000000000'::NUMERIC(78, 0)) / 100::NUMERIC(78, 0);
+    $shares_collateral NUMERIC(78, 0) := $total_shares_all_markets::NUMERIC(78, 0) * $units_per_dollar;
+    $buys_collateral NUMERIC(78, 0) := ($total_buys_price_amount::NUMERIC(78, 0) * $units_per_dollar) / 100::NUMERIC(78, 0);
     $expected_collateral := ($shares_collateral + $buys_collateral)::NUMERIC(78, 0);
 
     -- Step 6: Get actual vault balance from bridge

--- a/internal/migrations/038-order-book-queries.prod.sql
+++ b/internal/migrations/038-order-book-queries.prod.sql
@@ -57,6 +57,13 @@ PUBLIC VIEW RETURNS (
 
     -- Shares value (holdings + open sells), valued at $1.00 per share, in
     -- bridge token base units. Restricted to markets that use $bridge.
+    --
+    -- KNOWN ISSUE: this currently sums YES + NO unconditionally, so a paired
+    -- holding (e.g. 100 YES + 100 NO from a split mint) reports 200 × $1
+    -- instead of the 100 × $1 collateral that actually backs it. Correct
+    -- per-market netting needs MAX(net_yes, net_no), but changing it shifts
+    -- the returned values that off-chain consumers depend on — defer to a
+    -- separate, coordinated change.
     $shares_value NUMERIC(78, 0);
     for $row in
         SELECT COALESCE(SUM(p.amount)::NUMERIC(78, 0), 0::NUMERIC(78, 0)) as amount_sum

--- a/internal/migrations/038-order-book-queries.prod.sql
+++ b/internal/migrations/038-order-book-queries.prod.sql
@@ -1,0 +1,76 @@
+-- =============================================================================
+-- GENERATED FILE — DO NOT EDIT BY HAND
+-- =============================================================================
+-- Source : internal/migrations/038-order-book-queries.sql
+-- Script : scripts/generate_prod_migrations.py
+--
+-- Manual-apply mainnet override. The embedded migration loader skips
+-- *.prod.sql, so apply via:
+--
+--     kwil-cli exec-sql --file <this file> --sync \
+--         --private-key $PRIVATE_KEY --provider $PROVIDER
+--
+-- Prerequisite: erc20-bridge/000-extension.prod.sql must be applied
+-- FIRST so the eth_truf and eth_usdc bridge instances exist.
+-- =============================================================================
+
+CREATE OR REPLACE ACTION get_user_collateral($bridge TEXT DEFAULT 'eth_truf')
+PUBLIC VIEW RETURNS (
+    total_locked NUMERIC(78, 0),
+    buy_orders_locked NUMERIC(78, 0),
+    shares_value NUMERIC(78, 0)
+) {
+    -- Bridge token base units per $1.00 (single source of per-bridge decimals).
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+
+    -- Get caller's wallet address
+    $caller_bytes BYTEA := decode(substring(LOWER(@caller), 3, 40), 'hex');
+
+    -- Lookup participant ID
+    $participant_id INT;
+    for $row in SELECT id FROM ob_participants WHERE wallet_address = $caller_bytes {
+        $participant_id := $row.id;
+    }
+
+    -- Return zeros if participant doesn't exist
+    if $participant_id IS NULL {
+        RETURN 0::NUMERIC(78, 0), 0::NUMERIC(78, 0), 0::NUMERIC(78, 0);
+    }
+
+    -- Buy order collateral, in bridge token base units:
+    --   ($amount * |price| * units_per_dollar) / 100
+    -- Restricted to markets that use $bridge.
+    $buy_locked NUMERIC(78, 0);
+    for $row in
+        SELECT COALESCE(
+            SUM(abs(p.price)::NUMERIC(78, 0) * p.amount::NUMERIC(78, 0))::NUMERIC(78, 0),
+            0::NUMERIC(78, 0)
+        ) as price_amount_sum
+        FROM ob_positions p
+        JOIN ob_queries q ON p.query_id = q.id
+        WHERE p.participant_id = $participant_id
+          AND p.price < 0
+          AND q.bridge = $bridge
+    {
+        $buy_locked := ($row.price_amount_sum * $units_per_dollar) / 100::NUMERIC(78, 0);
+    }
+
+    -- Shares value (holdings + open sells), valued at $1.00 per share, in
+    -- bridge token base units. Restricted to markets that use $bridge.
+    $shares_value NUMERIC(78, 0);
+    for $row in
+        SELECT COALESCE(SUM(p.amount)::NUMERIC(78, 0), 0::NUMERIC(78, 0)) as amount_sum
+        FROM ob_positions p
+        JOIN ob_queries q ON p.query_id = q.id
+        WHERE p.participant_id = $participant_id
+          AND p.price >= 0
+          AND q.bridge = $bridge
+    {
+        $shares_value := $row.amount_sum * $units_per_dollar;
+    }
+
+    -- Total locked collateral
+    $total_locked NUMERIC(78, 0) := $buy_locked + $shares_value;
+
+    RETURN $total_locked, $buy_locked, $shares_value;
+};

--- a/internal/migrations/038-order-book-queries.sql
+++ b/internal/migrations/038-order-book-queries.sql
@@ -353,6 +353,13 @@ PUBLIC VIEW RETURNS (
 
     -- Shares value (holdings + open sells), valued at $1.00 per share, in
     -- bridge token base units. Restricted to markets that use $bridge.
+    --
+    -- KNOWN ISSUE: this currently sums YES + NO unconditionally, so a paired
+    -- holding (e.g. 100 YES + 100 NO from a split mint) reports 200 × $1
+    -- instead of the 100 × $1 collateral that actually backs it. Correct
+    -- per-market netting needs MAX(net_yes, net_no), but changing it shifts
+    -- the returned values that off-chain consumers depend on — defer to a
+    -- separate, coordinated change.
     $shares_value NUMERIC(78, 0);
     for $row in
         SELECT COALESCE(SUM(p.amount)::NUMERIC(78, 0), 0::NUMERIC(78, 0)) as amount_sum

--- a/internal/migrations/038-order-book-queries.sql
+++ b/internal/migrations/038-order-book-queries.sql
@@ -284,32 +284,41 @@ CREATE OR REPLACE ACTION get_best_prices(
 };
 
 /**
- * get_user_collateral()
+ * get_user_collateral($bridge)
  *
- * Show caller's total collateral locked across all markets.
- * Useful for user dashboards showing "total value locked in prediction markets".
+ * Show caller's total collateral locked across all markets that use the
+ * given bridge. Different bridges have different on-chain decimals
+ * (e.g. eth_truf=18, eth_usdc=6) — summing across mixed-bridge positions
+ * would produce a meaningless quantity, so this action is per-bridge.
  *
- * Returns:
- * - total_locked: Total collateral (shares value + buy orders locked)
+ * Parameters:
+ * - $bridge: Bridge namespace. Defaults to ethereum_bridge in dev /
+ *            eth_truf in prod (the legacy 18-decimal default), so existing
+ *            parameterless callers keep working unchanged.
+ *
+ * Returns (all values in $bridge's token base units):
+ * - total_locked: shares_value + buy_orders_locked
  * - buy_orders_locked: Collateral locked in open buy orders
  * - shares_value: Value of shares held (holdings + open sells, at $1.00 per share)
  *
- * All values in wei (18 decimals).
- *
  * Usage:
- *   kwil-cli database call --action get_user_collateral
+ *   kwil-cli call-action get_user_collateral
+ *   kwil-cli call-action get_user_collateral text:eth_usdc
  *
- * Example Output:
+ * Example Output (ethereum_bridge, 18-decimal):
  *   total_locked               | buy_orders_locked          | shares_value
  *   2500000000000000000000     | 500000000000000000000      | 2000000000000000000000
  *   (2500 tokens)              | (500 tokens)               | (2000 tokens)
  */
-CREATE OR REPLACE ACTION get_user_collateral()
+CREATE OR REPLACE ACTION get_user_collateral($bridge TEXT DEFAULT 'ethereum_bridge')
 PUBLIC VIEW RETURNS (
     total_locked NUMERIC(78, 0),
     buy_orders_locked NUMERIC(78, 0),
     shares_value NUMERIC(78, 0)
 ) {
+    -- Bridge token base units per $1.00 (single source of per-bridge decimals).
+    $units_per_dollar NUMERIC(78, 0) := get_bridge_units_per_dollar($bridge);
+
     -- Get caller's wallet address
     $caller_bytes BYTEA := decode(substring(LOWER(@caller), 3, 40), 'hex');
 
@@ -324,29 +333,36 @@ PUBLIC VIEW RETURNS (
         RETURN 0::NUMERIC(78, 0), 0::NUMERIC(78, 0), 0::NUMERIC(78, 0);
     }
 
-    -- Calculate locked collateral from buy orders
-    -- Buy order collateral = |price| * amount * 0.01 (price in cents)
-    -- Convert to wei: multiply by 10^18, divide by 100
+    -- Buy order collateral, in bridge token base units:
+    --   ($amount * |price| * units_per_dollar) / 100
+    -- Restricted to markets that use $bridge.
     $buy_locked NUMERIC(78, 0);
     for $row in
-        SELECT COALESCE(SUM(abs(price)::NUMERIC(78, 0) * amount::NUMERIC(78, 0) * '10000000000000000'::NUMERIC(78, 0))::NUMERIC(78, 0), 0::NUMERIC(78, 0)) as total
-        FROM ob_positions
-        WHERE participant_id = $participant_id
-          AND price < 0
+        SELECT COALESCE(
+            SUM(abs(p.price)::NUMERIC(78, 0) * p.amount::NUMERIC(78, 0))::NUMERIC(78, 0),
+            0::NUMERIC(78, 0)
+        ) as price_amount_sum
+        FROM ob_positions p
+        JOIN ob_queries q ON p.query_id = q.id
+        WHERE p.participant_id = $participant_id
+          AND p.price < 0
+          AND q.bridge = $bridge
     {
-        $buy_locked := $row.total;
+        $buy_locked := ($row.price_amount_sum * $units_per_dollar) / 100::NUMERIC(78, 0);
     }
 
-    -- Calculate value of shares held (holdings + open sells)
-    -- Each share = $1.00 = 10^18 wei
+    -- Shares value (holdings + open sells), valued at $1.00 per share, in
+    -- bridge token base units. Restricted to markets that use $bridge.
     $shares_value NUMERIC(78, 0);
     for $row in
-        SELECT COALESCE(SUM(amount::NUMERIC(78, 0) * '1000000000000000000'::NUMERIC(78, 0))::NUMERIC(78, 0), 0::NUMERIC(78, 0)) as total
-        FROM ob_positions
-        WHERE participant_id = $participant_id
-          AND price >= 0
+        SELECT COALESCE(SUM(p.amount)::NUMERIC(78, 0), 0::NUMERIC(78, 0)) as amount_sum
+        FROM ob_positions p
+        JOIN ob_queries q ON p.query_id = q.id
+        WHERE p.participant_id = $participant_id
+          AND p.price >= 0
+          AND q.bridge = $bridge
     {
-        $shares_value := $row.total;
+        $shares_value := $row.amount_sum * $units_per_dollar;
     }
 
     -- Total locked collateral

--- a/scripts/generate_prod_migrations.py
+++ b/scripts/generate_prod_migrations.py
@@ -178,9 +178,12 @@ def substitute_tokens(text: str) -> str:
 
 
 # After substitute_tokens, the only mainnet collateral bridges we want to
-# keep in dispatch chains are eth_usdc and eth_truf. Anything else
-# (sepolia_bridge, future testnet aliases) gets dropped.
-MAINNET_BRIDGES = ("eth_usdc", "eth_truf")
+# keep in dispatch chains are the ones declared in BRIDGE_DECIMALS. Anything
+# else (sepolia_bridge, future testnet aliases) gets dropped.
+# Used as a membership test only (`name in MAINNET_BRIDGES`); order is not
+# load-bearing since the displayed branch order in collapse_dispatch comes
+# from the source SQL, not from this tuple.
+MAINNET_BRIDGES = tuple(BRIDGE_DECIMALS)
 
 _BRANCH_HEADER_RE = re.compile(
     r"(?:if|else\s+if)\s+\$bridge\s*=\s*'(?P<name>\w+)'\s*\{",

--- a/scripts/generate_prod_migrations.py
+++ b/scripts/generate_prod_migrations.py
@@ -420,14 +420,20 @@ def transform_core(source_sql: str) -> tuple[str, list[str]]:
     parts: list[str] = []
     names: list[str] = []
     for name, raw in split_actions(source_sql):
+        # `get_bridge_units_per_dollar` is regenerated regardless of whether
+        # the dev source still mentions any bridge alias — its prod body
+        # comes from BRIDGE_DECIMALS, not from textual substitution. Keep
+        # this above the bridge-mention filter so a future refactor that
+        # drops the alias from the helper body doesn't silently strip it
+        # from the prod override.
+        if name == "get_bridge_units_per_dollar":
+            parts.append(regenerate_units_per_dollar())
+            names.append(name)
+            continue
         # Emit any action that references a bridge alias we substitute,
         # so e.g. `$bridge TEXT DEFAULT 'ethereum_bridge'` in get_user_collateral
         # becomes `'eth_truf'` in the prod override.
         if "hoodi_tt" not in raw and "ethereum_bridge" not in raw:
-            continue
-        if name == "get_bridge_units_per_dollar":
-            parts.append(regenerate_units_per_dollar())
-            names.append(name)
             continue
         substituted = substitute_tokens(raw)
         substituted = collapse_validate_and_chain(substituted)

--- a/scripts/generate_prod_migrations.py
+++ b/scripts/generate_prod_migrations.py
@@ -47,12 +47,25 @@ from typing import Iterable
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MIGRATIONS_DIR = REPO_ROOT / "internal" / "migrations"
 
+# Per-bridge on-chain decimals. The ONLY place real decimals live for the
+# mainnet override. The dev `.sql` migrations carry stub values appropriate
+# for the embedded test bridges (all 18-decimal); on prod-generation we
+# regenerate `get_bridge_units_per_dollar` entirely from this map so each
+# bridge gets units_per_dollar = 10^decimals. To add a new bridge, add an
+# entry here and ensure substitute_tokens maps a hoodi alias to its name
+# (or extend substitute_tokens / MAINNET_BRIDGES).
+BRIDGE_DECIMALS: dict[str, int] = {
+    "eth_truf": 18,
+    "eth_usdc": 6,
+}
+
 # (source_relpath, output_relpath, mode)
 TARGETS: list[tuple[str, str, str]] = [
     ("031-order-book-vault.sql", "031-order-book-vault.prod.sql", "core"),
     ("032-order-book-actions.sql", "032-order-book-actions.prod.sql", "core"),
     ("033-order-book-settlement.sql", "033-order-book-settlement.prod.sql", "core"),
     ("037-order-book-validation.sql", "037-order-book-validation.prod.sql", "core"),
+    ("038-order-book-queries.sql", "038-order-book-queries.prod.sql", "core"),
     (
         "erc20-bridge/001-actions.sql",
         "erc20-bridge/001-actions.prod.sql",
@@ -369,14 +382,52 @@ def collapse_validate_and_chain(text: str) -> str:
     return text
 
 
+def regenerate_units_per_dollar() -> str:
+    """Build the prod body of `get_bridge_units_per_dollar` from
+    BRIDGE_DECIMALS. Replaces whatever the dev source contained — the
+    dev branches are stubs that all return 10^18, but each prod bridge
+    needs its own units_per_dollar = 10^decimals.
+
+    Returns the full action text including the CREATE OR REPLACE header
+    and trailing semicolon, ending with a single newline.
+    """
+    branches: list[str] = []
+    for idx, (bridge, decimals) in enumerate(BRIDGE_DECIMALS.items()):
+        units = "1" + "0" * decimals
+        prefix = "if" if idx == 0 else "} else if"
+        branches.append(
+            f"    {prefix} $bridge = '{bridge}' {{\n"
+            f"        RETURN '{units}'::NUMERIC(78, 0);"
+        )
+    body = "\n".join(branches) + "\n    }\n    ERROR('Unknown bridge: ' || $bridge);"
+    return (
+        "CREATE OR REPLACE ACTION get_bridge_units_per_dollar($bridge TEXT)\n"
+        "    PUBLIC VIEW RETURNS (units_per_dollar NUMERIC(78, 0)) {\n"
+        f"{body}\n"
+        "};\n"
+    )
+
+
 def transform_core(source_sql: str) -> tuple[str, list[str]]:
     """Mode A. Emit each action whose body references `eth_truf`/`eth_usdc`
     after substitution, with dispatch chains collapsed.
+
+    Special case: `get_bridge_units_per_dollar` is regenerated from
+    BRIDGE_DECIMALS rather than rewritten via substitution — the dev
+    branches are 18-decimal stubs but each prod bridge needs its actual
+    decimals (eth_truf=18, eth_usdc=6). See regenerate_units_per_dollar.
     """
     parts: list[str] = []
     names: list[str] = []
     for name, raw in split_actions(source_sql):
-        if "hoodi_tt" not in raw:
+        # Emit any action that references a bridge alias we substitute,
+        # so e.g. `$bridge TEXT DEFAULT 'ethereum_bridge'` in get_user_collateral
+        # becomes `'eth_truf'` in the prod override.
+        if "hoodi_tt" not in raw and "ethereum_bridge" not in raw:
+            continue
+        if name == "get_bridge_units_per_dollar":
+            parts.append(regenerate_units_per_dollar())
+            names.append(name)
             continue
         substituted = substitute_tokens(raw)
         substituted = collapse_validate_and_chain(substituted)

--- a/tests/streams/order_book/queries_test.go
+++ b/tests/streams/order_book/queries_test.go
@@ -956,7 +956,7 @@ func callGetBestPrices(ctx context.Context, platform *kwilTesting.Platform, sign
 }
 
 func callGetUserCollateral(ctx context.Context, platform *kwilTesting.Platform, signer *util.EthereumAddress, resultFn func(*common.Row) error) error {
-	return callActionQueries(ctx, platform, signer, "get_user_collateral", []any{}, resultFn)
+	return callActionQueries(ctx, platform, signer, "get_user_collateral", []any{testExtensionNameQueries}, resultFn)
 }
 
 func callPlaceBuyOrderQueries(ctx context.Context, platform *kwilTesting.Platform, signer *util.EthereumAddress, queryID int, outcome bool, price, amount int, resultFn func(*common.Row) error) error {


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `get_user_collateral()` action to query a user's locked collateral and shares value for a specific bridge.

* **Bug Fixes**
  * Improved collateral calculations to properly scale across different bridges using bridge-specific decimal conventions.
  * Enhanced error messaging in order placement to report both token units and dollar-equivalents for insufficient-balance scenarios.

* **Updates**
  * Refined market creation validation error terminology for clarity.
  * Optimized settlement fee and order matching computations for multi-bridge support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->