### PR TITLE
chore: stop tn_vacuum re-running every block on idle nodes

### DIFF
--- a/extensions/tn_vacuum/mechanism_repack.go
+++ b/extensions/tn_vacuum/mechanism_repack.go
@@ -107,18 +107,20 @@ func (m *pgRepackMechanism) Run(ctx context.Context, req RunRequest) (*RunReport
 		m.logger.Warn("pg_repack reported incompatibility", "stderr", stderr.String(), "duration", report.Duration)
 		return report, err
 	}
-	tablesProcessed := strings.Count(output, "INFO: repacking table")
+	tablesProcessed := countRepackedTables(output)
 	report.TablesProcessed = tablesProcessed
 
 	if tablesProcessed == 0 {
-		report.Status = StatusFailed
-		report.Error = "pg_repack completed without processing any tables"
-		m.logger.Warn("pg_repack completed but processed no tables", "stderr", stderr.String())
-		return report, fmt.Errorf("pg_repack processed zero tables")
+		m.logger.Info("pg_repack completed with no eligible tables", "duration", report.Duration)
+		return report, nil
 	}
 
 	m.logger.Info("pg_repack completed", "stdout", stdout.String(), "stderr", stderr.String(), "duration", report.Duration, "tables", tablesProcessed)
 	return report, nil
+}
+
+func countRepackedTables(output string) int {
+	return strings.Count(output, "INFO: repacking table")
 }
 
 func detectPgRepackSoftFailure(stderr string) error {

--- a/extensions/tn_vacuum/mechanism_repack_test.go
+++ b/extensions/tn_vacuum/mechanism_repack_test.go
@@ -2,6 +2,46 @@ package tn_vacuum
 
 import "testing"
 
+func TestCountRepackedTables(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   int
+	}{
+		{
+			name: "no eligible tables",
+			output: "INFO: database \"kwild_test_db\" skipped: pg_repack 1.5.3 is not installed in the database\n" +
+				"INFO: database \"postgres\" skipped: pg_repack 1.5.3 is not installed in the database",
+			want: 0,
+		},
+		{
+			name:   "single table",
+			output: "INFO: repacking table \"main\".\"primitive_events\"",
+			want:   1,
+		},
+		{
+			name: "multiple tables",
+			output: "INFO: repacking table \"main\".\"primitive_events\"\n" +
+				"INFO: repacking table \"main\".\"streams\"\n" +
+				"INFO: repacking table \"main\".\"taxonomies\"",
+			want: 3,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := countRepackedTables(tt.output); got != tt.want {
+				t.Fatalf("countRepackedTables() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDetectPgRepackSoftFailure(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * refactored table repacking operations to recognize when no tables require processing, now returning success instead of  reporting an error.

* **Tests**
  * Added test coverage for table repacking count validation across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/node/pull/1376)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->