### PR TITLE
chore: give tn-node healthcheck room for long maintenance

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -59,6 +59,7 @@ services:
       interval: 1m
       timeout: 10s
       retries: 10
+      start_period: 5m
     deploy:
       resources:
         limits:


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended database service startup grace period to improve initialization reliability during container startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/node/pull/1379)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->