### PR TITLE
chore: add system:fee_required role for phased write-fee rollout

### DIFF
--- a/internal/migrations/047-fee-required-role.sql
+++ b/internal/migrations/047-fee-required-role.sql
@@ -1,0 +1,25 @@
+/*
+    FEE-REQUIRED ROLE BOOTSTRAP
+
+    Creates the `system:fee_required` role used to gate per-tx write-fee
+    collection in create_streams / insert_records / insert_taxonomy.
+
+    Phased rollout per truflation/website#3805: only wallets enrolled in
+    this role are charged the flat 1 TRUF/tx. Empty role = no caller is
+    charged. Wallets are enrolled one at a time as their TRUF funding
+    lands. Once every active write wallet is enrolled, the gating
+    `IF $fee_required` blocks in 001/003/004 can be deleted in a
+    follow-up migration so universal charging resumes.
+
+    Manager: network_writers_manager (same admin who already grants
+    write capability — keeps fee-enrollment ops on a privilege the
+    network already provisions).
+*/
+
+INSERT INTO roles (owner, role_name, display_name, role_type, created_at) VALUES
+    ('system', 'fee_required', 'Fee Required', 'system', 0)
+ON CONFLICT (owner, role_name) DO NOTHING;
+
+UPDATE roles
+SET manager_owner = 'system', manager_role_name = 'network_writers_manager'
+WHERE owner = 'system' AND role_name = 'fee_required';


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Write operations now charge a transaction fee only for enrolled accounts; unenrolled accounts can perform these writes at no charge.

* **Chores**
  * Added system configuration to manage fee-enrollment and enable phased rollout of fees.

* **Tests**
  * Test suite updated to cover both enrolled (fee-applied) and unenrolled (free) scenarios for stream, record, and taxonomy writes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trufnetwork/node/pull/1382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->