### PR TITLE
build: pin pg_repack builder base

### DIFF
--- a/deployments/Dockerfile
+++ b/deployments/Dockerfile
@@ -25,7 +25,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -o /app/.build/kwild /app/cmd/kwild/main.go
 
-FROM postgres:16-alpine AS pg_repack_builder
+# Pin to alpine3.21 to match the final runtime stage below: the floating
+# `postgres:16-alpine` tag has moved to Alpine 3.24, which dropped the clang19/llvm19
+# packages this stage installs (and built a pg_repack against a newer libc than the
+# alpine:3.21 runtime). Keeping both stages on Alpine 3.21 restores the build and the ABI match.
+FROM postgres:16-alpine3.21 AS pg_repack_builder
 
 # build pg_repack against postgres 16 client libraries
 RUN apk add --no-cache build-base clang19 gawk llvm19 curl zlib-dev readline-dev openssl-dev lz4-dev zstd-dev && \


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4070

## What

Pin the `pg_repack_builder` stage in `deployments/Dockerfile` to `postgres:16-alpine3.21` instead of the floating `postgres:16-alpine` tag.

## Why

The floating `postgres:16-alpine` tag has moved to Alpine 3.24, which dropped the `clang19` and `llvm19` packages this stage installs. `apk add … clang19 … llvm19` no longer resolves, so the build fails before producing the node image:

```
#15 [pg_repack_builder 2/2] RUN apk add --no-cache build-base clang19 gawk llvm19 ...
ERROR: unable to select packages:
  clang19 (no such package): required by: world[clang19]
  llvm19 (no such package): required by: world[llvm19]
```

The `clang19`/`llvm19` line landed when `postgres:16-alpine` was Alpine 3.21; the tag has since drifted. The build and runtime stages are already pinned (`golang:1.25.3-alpine3.21`, `alpine:3.21`) — only the pg_repack builder floated, which also meant pg_repack was compiled against a newer libc than the `alpine:3.21` runtime it is copied into.

Pinning to `postgres:16-alpine3.21` restores `clang19`/`llvm19` and aligns the builder's Alpine (3.21.x) with the runtime stage so the copied `pg_repack` binary is ABI-consistent.

## Impact

Anything that builds `deployments/Dockerfile` is currently affected:

- node CI `acceptance-test` (auto-builds the `tn-db` service from this Dockerfile)
- the **Publish Node Image** workflow — so `ghcr.io/trufnetwork/node:latest` can be refreshed past v2.5.2
- downstream repos that build node `main` in CI

## Verification

Built the `pg_repack_builder` target against the pinned base: `clang19`/`llvm19` resolve and pg_repack 1.5.3 compiles and installs (`docker build --target pg_repack_builder` → exit 0).

## Optional follow-up

Consider digest-pinning the runtime `alpine:3.21` base and/or adding a Dependabot/Renovate rule for the base images, so a future Alpine 3.21 EOL surfaces as a PR rather than a silent CI break.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image version for build stage to ensure compatibility and consistency with runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->