### PR TITLE
build: bump kwil-db for crediting bridge deposits when an RPC caps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.37.0
-	github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558
-	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558
+	github.com/trufnetwork/kwil-db v0.10.3-0.20260619090422-c7425a52ca21
+	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260619090422-c7425a52ca21
 	github.com/trufnetwork/sdk-go v0.6.4-0.20260224122406-a741343e2f37
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa

--- a/go.sum
+++ b/go.sum
@@ -1240,10 +1240,10 @@ github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZ
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.9.0 h1:lmyCHtANi8aRUgkckBgoDk1nHCux3n2cgkJLXdQGPDo=
 github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
-github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558 h1:I49YGUiUMvEtaWVso+3dLDw9mvZwmRm+yveDmoV1mjA=
-github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558 h1:m7a9HITFMXJF22QznIKoAdeiH8eZxWPU8IRzgcyNMo8=
-github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
+github.com/trufnetwork/kwil-db v0.10.3-0.20260619090422-c7425a52ca21 h1:u8WKWhP13rZ98Ef14A0lkRGvxT9bVw/9uw6XgOd0lkc=
+github.com/trufnetwork/kwil-db v0.10.3-0.20260619090422-c7425a52ca21/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20260619090422-c7425a52ca21 h1:4IMcFoYZVt+LUeFshEU7zKqJ+BNHcTL7lUjPI8kXBYg=
+github.com/trufnetwork/kwil-db/core v0.4.3-0.20260619090422-c7425a52ca21/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2 h1:DCq8MzbWH0wZmICNmMVsSzUHUPl+2vqRhluEABjxl88=
 github.com/trufnetwork/openzeppelin-merkle-tree-go v0.0.2/go.mod h1:Y0MJpPp9QXU5vC6Gpoilql2NkgmGNcbHm9HYC2v2N8s=
 github.com/trufnetwork/sdk-go v0.6.4-0.20260224122406-a741343e2f37 h1:VD/GWxLTshaXpLukEc1SXbG7QA9HrFzF8JvxJAJ/x7Q=


### PR DESCRIPTION
Bumps `kwil-db` and `kwil-db/core` to `c7425a52`, which makes the EVM bridge listener halve its `eth_getLogs` block range and retry instead of wedging when an RPC caps the request. After a long catch-up gap, bridge deposits keep getting picked up instead of stalling.

Dependency-only change (`go.mod` / `go.sum`); `go build ./...` passes.

- https://github.com/trufnetwork/kwil-db/pull/1713


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->