### PR TITLE
chore: name the bridge a transfer charged its fee in

### DIFF
--- a/internal/migrations/erc20-bridge/002-public-transfer-actions.prod.sql
+++ b/internal/migrations/erc20-bridge/002-public-transfer-actions.prod.sql
@@ -15,6 +15,11 @@
 -- fee is paid in the SAME bridge as the transfer (not always in TRUF).
 -- This avoids forcing USDC senders to also hold TRUF.
 --
+-- Because of that, and because transaction_events carries no token column, both
+-- actions record the bridge in the ledger event's metadata. Without it the two
+-- fees are indistinguishable in the ledger and a reader has to infer the token
+-- from the amount, which only works while the two fees stay different constants.
+--
 -- Manual-apply mainnet override. The embedded migration loader skips
 -- *.prod.sql, so apply via:
 --
@@ -58,11 +63,14 @@ CREATE OR REPLACE ACTION eth_truf_transfer($to_address TEXT, $amount TEXT) PUBLI
   -- Execute transfer using the bridge extension
   eth_truf.transfer($to_address, $amount::NUMERIC(78, 0));
 
+  -- The fee is paid in the bridge that moved, not always in $TRUF, and
+  -- transaction_events has no token column. Naming the bridge here is what lets
+  -- a reader tell this row's 1 TRUF from eth_usdc_transfer's 1 USDC.
   record_transaction_event(
     4,
     $fee,
     '0x' || $leader_hex,
-    NULL
+    '{"bridge":"eth_truf"}'
   );
 };
 
@@ -100,10 +108,12 @@ CREATE OR REPLACE ACTION eth_usdc_transfer($to_address TEXT, $amount TEXT) PUBLI
   -- Execute transfer using the bridge extension
   eth_usdc.transfer($to_address, $amount::NUMERIC(78, 0));
 
+  -- See eth_truf_transfer above: without this the 6-decimal fee is
+  -- indistinguishable from an 18-decimal one in the ledger.
   record_transaction_event(
     4,
     $fee,
     '0x' || $leader_hex,
-    NULL
+    '{"bridge":"eth_usdc"}'
   );
 };

--- a/internal/migrations/erc20-bridge/002-public-transfer-actions.sql
+++ b/internal/migrations/erc20-bridge/002-public-transfer-actions.sql
@@ -37,7 +37,7 @@ CREATE OR REPLACE ACTION sepolia_transfer($to_address TEXT, $amount TEXT) PUBLIC
     4,
     $fee,
     '0x' || $leader_hex,
-    NULL
+    '{"bridge":"sepolia_bridge"}'
   );
 };
 
@@ -78,7 +78,7 @@ CREATE OR REPLACE ACTION ethereum_transfer($to_address TEXT, $amount TEXT) PUBLI
     4,
     $fee,
     '0x' || $leader_hex,
-    NULL
+    '{"bridge":"ethereum_bridge"}'
   );
 };
 
@@ -119,7 +119,7 @@ CREATE OR REPLACE ACTION hoodi_tt_transfer($to_address TEXT, $amount TEXT) PUBLI
     4,
     $fee,
     '0x' || $leader_hex,
-    NULL
+    '{"bridge":"hoodi_tt"}'
   );
 };
 
@@ -160,6 +160,6 @@ CREATE OR REPLACE ACTION hoodi_tt2_transfer($to_address TEXT, $amount TEXT) PUBL
     4,
     $fee,
     '0x' || $leader_hex,
-    NULL
+    '{"bridge":"hoodi_tt2"}'
   );
 };

--- a/tests/streams/transaction_events_ledger_test.go
+++ b/tests/streams/transaction_events_ledger_test.go
@@ -204,6 +204,19 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 		require.NoError(t, err)
 		height++
 
+		// A second transfer on a different bridge. Two transfer actions booking
+		// two different bridges under the same method is the whole point of
+		// recording one: the amount alone cannot tell them apart once a bridge
+		// with different decimals exists. The actor is already funded on
+		// hoodi_tt for the write fees above, so this needs no extra setup.
+		ttTransferLeaderPub, ttTransferLeaderAddr := newLeader(t)
+		ttTransferTx, err := callActionWithLeader(ctx, platform, actor, ttTransferLeaderPub, height, "hoodi_tt_transfer", []any{
+			receiver.Address(),
+			transferAmount,
+		})
+		require.NoError(t, err)
+		height++
+
 		withdrawLeaderPub, withdrawLeaderAddr := newLeader(t)
 		withdrawTx, err := callActionWithLeader(ctx, platform, actor, withdrawLeaderPub, height, "sepolia_bridge_tokens", []any{
 			actor.Address(),
@@ -236,6 +249,17 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 
 		assertNoMetadata := func(meta metadataMap) {
 			require.Empty(t, meta, "expected no metadata for ledger event")
+		}
+
+		// A transfer is the one method that does not always charge its fee in
+		// $TRUF: it charges in the bridge it moves. The ledger has no token
+		// column, so unless each action names its own bridge a reader cannot
+		// tell a 1 TRUF fee from a 1 USDC one, and the two differ by 1e12.
+		assertBridge := func(want string) func(meta metadataMap) {
+			return func(meta metadataMap) {
+				require.Equal(t, want, meta.String("bridge"),
+					"a transfer must name the bridge its fee was charged in")
+			}
 		}
 
 		expected := map[string]ledgerExpectation{
@@ -274,7 +298,16 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 				feeDistributions: []string{
 					buildDistribution(transferLeaderAddr, feeOneTRUF),
 				},
-				assertMetadata: assertNoMetadata,
+				assertMetadata: assertBridge("sepolia_bridge"),
+			},
+			ttTransferTx: {
+				method:       "transferTN",
+				fee:          feeOneTRUF,
+				feeRecipient: ttTransferLeaderAddr,
+				feeDistributions: []string{
+					buildDistribution(ttTransferLeaderAddr, feeOneTRUF),
+				},
+				assertMetadata: assertBridge("hoodi_tt"),
 			},
 			withdrawTx: {
 				method:       "withdrawTN",


### PR DESCRIPTION
A peer-to-peer transfer records which bridge it charged its fee in, so the fee ledger describes its own token instead of leaving a reader to infer it.

## Why

`transaction_events` carries no token column, and a transfer is the one method whose fee is not charged in $TRUF: it charges in the bridge it moves. `eth_truf_transfer` takes 1 TRUF at 1e18, `eth_usdc_transfer` takes 1 USDC at 1e6, and both are booked under the same `method_id = 4`. The mainnet migration already documents this — *"fee is paid in the SAME bridge as the transfer (not always in TRUF)"* — but nothing recorded which one.

A reader with only the ledger has to infer the token from the amount. That works while the two fees stay different constants and stops working the moment they do not, or a third bridge appears. One base unit differs between the two tokens by a factor of 1e12, so an inference that goes wrong is not a rounding matter.

## What changes

`record_transaction_event` already takes a `metadata` argument, and every call site in the repo passes `NULL`. The transfer actions now pass the bridge instead:

- `eth_truf_transfer` → `'{"bridge":"eth_truf"}'`
- `eth_usdc_transfer` → `'{"bridge":"eth_usdc"}'`

`metadata` is TEXT holding a JSON object — `026-transaction-schemas.sql` notes it would be JSONB if the engine supported it, and the ledger test helper already parses it as JSON — so the bridge is one key inside it rather than the whole value. It is empty on all 3,985,000+ existing mainnet rows, so nothing is displaced.

The four dev transfer actions get the same treatment for parity. Note these reach no deployed network on their own: `scripts/migrate.sh` globs `./internal/migrations/*.sql` non-recursively, and the `internal/migrations` embed is imported only by tests, so `erc20-bridge/*.sql` is applied by hand exactly as the `.prod.sql` header describes.

## Test

`TestTransactionEventsLedger` asserted a transfer carries no metadata, which is the behaviour being changed. It now asserts the bridge, so the stamp cannot be dropped silently.

## Scope

No schema change, no new method id, no new migration file, and no change to any fee amount or recipient. Rolling back is re-applying the previous revision of the action.

Worth knowing for review: `.prod.sql` is excluded from the `//go:embed` and from `go test`, so no automated check parses or executes those two literals. They were verified by reading them back out of `info.actions` on the mainnet leader after the migration was applied.

## Related

- resolves: https://github.com/trufnetwork/trufscan/issues/143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ledger transfer records by identifying the originating bridge.
  * Ensured bridge-specific fees can be correctly attributed across supported token transfer actions.

* **Tests**
  * Updated ledger event validation to confirm bridge metadata is included and correctly identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->