### PR TITLE
chore: charge the taxonomy write fee per child stream

### DIFF
--- a/internal/migrations/004-composed-taxonomy.prod.sql
+++ b/internal/migrations/004-composed-taxonomy.prod.sql
@@ -56,10 +56,13 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     }
 
     -- ===== FEE COLLECTION =====
-    -- Flat 1 TRUF per transaction (write-fee policy per issue #3805).
-    -- Charged universally — no role gate. Every caller pays the flat
-    -- per-tx fee regardless of role membership.
-    $total_fee := 1000000000000000000::NUMERIC(78, 0); -- 1 TRUF with 18 decimals
+    -- Per-child write fee per issue #3972. Charged universally — no role gate.
+    -- Each child adds a permanent taxonomies row that every composed read walks,
+    -- so per-child pricing keeps the cost proportional to what the caller
+    -- actually attaches. A flat per-tx fee let one caller attach an arbitrary
+    -- number of children for the price of one.
+    $per_child_fee NUMERIC(78, 0) := '10000000000000000000'::NUMERIC(78, 0); -- 10 TRUF (10^19)
+    $total_fee NUMERIC(78, 0) := $per_child_fee * $num_children::NUMERIC(78, 0);
 
     IF @leader_sender IS NULL {
         ERROR('Leader address not available for fee transfer');
@@ -69,7 +72,7 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     $caller_balance := eth_truf.balance(@caller);
 
     IF $caller_balance < $total_fee {
-        ERROR('Insufficient balance for taxonomies creation. Required: 1 TRUF');
+        ERROR('Insufficient balance for taxonomies creation. Required: 10 TRUF per child stream');
     }
 
     eth_truf.transfer($leader_hex, $total_fee);

--- a/internal/migrations/004-composed-taxonomy.sql
+++ b/internal/migrations/004-composed-taxonomy.sql
@@ -1,5 +1,9 @@
 /**
  * insert_taxonomy: Creates a new taxonomy group_sequence for a composed stream.
+ * Fee: 10 TRUF per child stream (issue #3972). Charged on every caller —
+ * no role exemption. The total transferred is
+ * 10 TRUF × array_length($child_stream_ids), bounded only by the caller's
+ * TRUF balance and the transaction size limit.
  * Validates input arrays, increments group_sequence, and inserts child stream relationships.
  */
 CREATE OR REPLACE ACTION insert_taxonomy(
@@ -44,10 +48,13 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     }
 
     -- ===== FEE COLLECTION =====
-    -- Flat 1 TRUF per transaction (write-fee policy per issue #3805).
-    -- Charged universally — no role gate. Every caller pays the flat
-    -- per-tx fee regardless of role membership.
-    $total_fee := 1000000000000000000::NUMERIC(78, 0); -- 1 TRUF with 18 decimals
+    -- Per-child write fee per issue #3972. Charged universally — no role gate.
+    -- Each child adds a permanent taxonomies row that every composed read walks,
+    -- so per-child pricing keeps the cost proportional to what the caller
+    -- actually attaches. A flat per-tx fee let one caller attach an arbitrary
+    -- number of children for the price of one.
+    $per_child_fee NUMERIC(78, 0) := '10000000000000000000'::NUMERIC(78, 0); -- 10 TRUF (10^19)
+    $total_fee NUMERIC(78, 0) := $per_child_fee * $num_children::NUMERIC(78, 0);
 
     IF @leader_sender IS NULL {
         ERROR('Leader address not available for fee transfer');
@@ -57,7 +64,7 @@ CREATE OR REPLACE ACTION insert_taxonomy(
     $caller_balance := hoodi_tt.balance(@caller);
 
     IF $caller_balance < $total_fee {
-        ERROR('Insufficient balance for taxonomies creation. Required: 1 TRUF');
+        ERROR('Insufficient balance for taxonomies creation. Required: 10 TRUF per child stream');
     }
 
     hoodi_tt.transfer($leader_hex, $total_fee);

--- a/tests/streams/taxonomy_fee_test.go
+++ b/tests/streams/taxonomy_fee_test.go
@@ -16,19 +16,20 @@ import (
 	kwilTesting "github.com/trufnetwork/kwil-db/testing"
 	"github.com/trufnetwork/node/internal/migrations"
 	testutils "github.com/trufnetwork/node/tests/streams/utils"
+	"github.com/trufnetwork/node/tests/streams/utils/feefund"
 	"github.com/trufnetwork/node/tests/streams/utils/setup"
 	"github.com/trufnetwork/sdk-go/core/util"
 )
 
-// Test constants for taxonomy fees
-const (
-	// Flat 1 TRUF per insert_taxonomy transaction (issue #3805): child count
-	// no longer multiplies the fee.
-	taxonomyFeeAmount = "1000000000000000000" // 1 TRUF with 18 decimals per tx
-)
-
 var (
-	oneTRUFTaxonomy = mustParseBigInt(taxonomyFeeAmount) // 1 TRUF as big.Int, using shared helper from stream_creation_fee_test.go
+	// taxonomyFeePerChild is parsed from feefund.TaxonomyFeePerChildWei — the
+	// same shared constant the test helpers fund from, so the migration's fee
+	// and the tests' expectations cannot drift apart. Per issue #3972 the fee
+	// is 10 TRUF per child stream, not a flat amount per transaction.
+	taxonomyFeePerChild = mustParseBigInt(feefund.TaxonomyFeePerChildWei) // 10 TRUF as big.Int, using shared helper from stream_creation_fee_test.go
+
+	// threeChildTaxonomyFee is what a 3-child taxonomy costs: 3 × 10 TRUF.
+	threeChildTaxonomyFee = new(big.Int).Mul(taxonomyFeePerChild, big.NewInt(3))
 )
 
 // TestTaxonomyFees is the main test suite for insert_taxonomy transaction fees
@@ -41,8 +42,9 @@ func TestTaxonomyFees(t *testing.T) {
 			testTaxonomyWriterRolePaysFee(t),
 			testTaxonomyNonExemptWalletPaysFee(t),
 			testTaxonomyInsufficientBalance(t),
-			testTaxonomyMultipleChildrenChargesFlatFee(t),
+			testTaxonomyMultipleChildrenChargesPerChildFee(t),
 			testTaxonomyUnenrolledWalletStillPaysFee(t),
+			testTaxonomyPartialBalanceRejectsExtraChild(t),
 		},
 	}, testutils.GetTestOptionsWithCache())
 }
@@ -71,7 +73,7 @@ func setupTaxonomyTestEnvironment(t *testing.T) func(ctx context.Context, platfo
 }
 
 // Test 1: Wallet with network_writer role still pays insert_taxonomy fees.
-// 300 TRUF in → 100 (composed) + 100 (child) + 1 (1-child taxonomy) = 201 TRUF spent.
+// 300 TRUF in → 100 (composed) + 100 (child) + 10 (1-child taxonomy) = 210 TRUF spent.
 func testTaxonomyWriterRolePaysFee(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		writerAddrVal := util.Unsafe_NewEthereumAddressFromString("0x2111111111111111111111111111111111111111")
@@ -107,18 +109,18 @@ func testTaxonomyWriterRolePaysFee(t *testing.T) func(ctx context.Context, platf
 		finalBalance, err := getBalance(ctx, platform, writerAddr.Address())
 		require.NoError(t, err, "failed to get final balance")
 
-		// 100 (composed create) + 100 (child create) + 1 (taxonomy w/ 1 child) = 201 TRUF.
-		totalFee := mustParseBigInt("201000000000000000000")
+		// 100 (composed create) + 100 (child create) + 10 (taxonomy w/ 1 child) = 210 TRUF.
+		totalFee := mustParseBigInt("210000000000000000000")
 		expectedBalance := new(big.Int).Sub(initialBalance, totalFee)
 		require.Equal(t, 0, expectedBalance.Cmp(finalBalance),
-			"network_writer should pay 201 TRUF total, expected %s but got %s", expectedBalance, finalBalance)
+			"network_writer should pay 210 TRUF total, expected %s but got %s", expectedBalance, finalBalance)
 
 		return nil
 	}
 }
 
-// Test 2: Non-exempt wallet (without network_writer role) pays a flat 1 TRUF
-// per insert_taxonomy tx. Fund exactly 201 TRUF: 100 (composed) + 100 (child) + 1 (taxonomy).
+// Test 2: Non-exempt wallet (without network_writer role) pays 10 TRUF per
+// child stream. Fund exactly 210 TRUF: 100 (composed) + 100 (child) + 10 (1-child taxonomy).
 func testTaxonomyNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		nonExemptAddrVal := util.Unsafe_NewEthereumAddressFromString("0x3222222222222222222222222222222222222222")
@@ -128,14 +130,14 @@ func testTaxonomyNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, 
 		err := setup.CreateDataProviderWithoutRole(ctx, platform, nonExemptAddr.Address())
 		require.NoError(t, err, "failed to create data provider without role")
 
-		// Give exactly 201 TRUF: 100 (composed) + 100 (child) + 1 (taxonomy)
-		exactFund := mustParseBigInt("201000000000000000000") // 201 TRUF
+		// Give exactly 210 TRUF: 100 (composed) + 100 (child) + 10 (1-child taxonomy)
+		exactFund := mustParseBigInt("210000000000000000000") // 210 TRUF
 		err = giveBalance(ctx, platform, nonExemptAddr.Address(), exactFund.String())
 		require.NoError(t, err, "failed to give balance")
 
 		initialBalance, err := getBalance(ctx, platform, nonExemptAddr.Address())
 		require.NoError(t, err, "failed to get initial balance")
-		require.Equal(t, exactFund, initialBalance, "Initial balance should be 201 TRUF")
+		require.Equal(t, exactFund, initialBalance, "Initial balance should be 210 TRUF")
 
 		composedStreamId := util.GenerateStreamId("taxonomy_nonexempt_composed")
 		childStreamId := util.GenerateStreamId("taxonomy_nonexempt_child")
@@ -148,12 +150,12 @@ func testTaxonomyNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, 
 		err = createStream(ctx, platform, nonExemptAddr, childStreamId.String(), "primitive")
 		require.NoError(t, err, "failed to create child stream")
 
-		// Balance after stream creation should be 1 TRUF (201 - 100 - 100)
+		// Balance after stream creation should be 10 TRUF (210 - 100 - 100)
 		balanceAfterStreams, err := getBalance(ctx, platform, nonExemptAddr.Address())
 		require.NoError(t, err, "failed to get balance after stream creation")
-		require.Equal(t, oneTRUFTaxonomy, balanceAfterStreams, "Balance should be 1 TRUF after creating streams")
+		require.Equal(t, taxonomyFeePerChild, balanceAfterStreams, "Balance should be 10 TRUF after creating streams")
 
-		// Insert taxonomy (1 child, flat 1 TRUF fee)
+		// Insert taxonomy (1 child → 1 × 10 TRUF)
 		err = insertTaxonomy(ctx, platform, nonExemptAddr,
 			nonExemptAddr.Address(), composedStreamId.String(),
 			[]string{nonExemptAddr.Address()},
@@ -162,7 +164,7 @@ func testTaxonomyNonExemptWalletPaysFee(t *testing.T) func(ctx context.Context, 
 			nil)
 		require.NoError(t, err, "taxonomy insertion should succeed")
 
-		// Verify balance is now 0 (1 TRUF taxonomy fee charged)
+		// Verify balance is now 0 (10 TRUF taxonomy fee charged)
 		finalBalance, err := getBalance(ctx, platform, nonExemptAddr.Address())
 		require.NoError(t, err, "failed to get final balance")
 
@@ -183,7 +185,7 @@ func testTaxonomyInsufficientBalance(t *testing.T) func(ctx context.Context, pla
 		require.NoError(t, err, "failed to create data provider without role")
 
 		// Give exactly 200 TRUF: enough for two create_stream calls (100 + 100)
-		// but nothing left over for the 1 TRUF taxonomy fee.
+		// but nothing left over for the 10 TRUF taxonomy fee.
 		twoHundredTRUF := mustParseBigInt("200000000000000000000")
 		err = giveBalance(ctx, platform, insufficientAddr.Address(), twoHundredTRUF.String())
 		require.NoError(t, err, "failed to give balance")
@@ -198,7 +200,7 @@ func testTaxonomyInsufficientBalance(t *testing.T) func(ctx context.Context, pla
 		err = createStream(ctx, platform, insufficientAddr, childStreamId.String(), "primitive")
 		require.NoError(t, err, "failed to create child stream")
 
-		// Should have 0 TRUF left (200 - 100 - 100 = 0), not enough for the 1 TRUF taxonomy fee
+		// Should have 0 TRUF left (200 - 100 - 100 = 0), not enough for the 10 TRUF taxonomy fee
 		remainingBalance, err := getBalance(ctx, platform, insufficientAddr.Address())
 		require.NoError(t, err, "failed to get remaining balance")
 		require.Equal(t, big.NewInt(0), remainingBalance, "Should have 0 TRUF left after creating streams")
@@ -213,15 +215,15 @@ func testTaxonomyInsufficientBalance(t *testing.T) func(ctx context.Context, pla
 
 		require.Error(t, err, "taxonomy insertion should fail with insufficient balance")
 		require.Contains(t, err.Error(), "Insufficient balance for taxonomies creation", "Error should mention insufficient balance")
-		require.Contains(t, err.Error(), "Required: 1 TRUF", "Error should mention 1 TRUF requirement")
+		require.Contains(t, err.Error(), "Required: 10 TRUF per child stream", "Error should mention the per-child requirement")
 
 		return nil
 	}
 }
 
-// Test 4: Multi-child taxonomy charges a flat 1 TRUF regardless of child count.
-// This is the key invariant of issue #3805 — pricing is per-tx, not per-child.
-func testTaxonomyMultipleChildrenChargesFlatFee(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+// Test 4: Multi-child taxonomy charges 10 TRUF × child count.
+// This is the key invariant of issue #3972 — pricing is per-child, not per-tx.
+func testTaxonomyMultipleChildrenChargesPerChildFee(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		multiAddrVal := util.Unsafe_NewEthereumAddressFromString("0x5444444444444444444444444444444444444444")
 		multiAddr := &multiAddrVal
@@ -230,16 +232,16 @@ func testTaxonomyMultipleChildrenChargesFlatFee(t *testing.T) func(ctx context.C
 		err := setup.CreateDataProviderWithoutRole(ctx, platform, multiAddr.Address())
 		require.NoError(t, err, "failed to create data provider without role")
 
-		// Give exactly 401 TRUF: 100 (composed) + 300 (3 children) + 1 (taxonomy, flat).
-		// If the migration were still per-child, the 3-child taxonomy would
-		// cost 3 TRUF and this test would fail with insufficient balance.
-		exactFund := mustParseBigInt("401000000000000000000")
+		// Give exactly 430 TRUF: 100 (composed) + 300 (3 children) + 30 (3-child taxonomy).
+		// If the migration were still flat per-tx, the taxonomy would cost 1 TRUF
+		// and this test would end with 29 TRUF left instead of 0.
+		exactFund := mustParseBigInt("430000000000000000000")
 		err = giveBalance(ctx, platform, multiAddr.Address(), exactFund.String())
 		require.NoError(t, err, "failed to give balance")
 
 		initialBalance, err := getBalance(ctx, platform, multiAddr.Address())
 		require.NoError(t, err, "failed to get initial balance")
-		require.Equal(t, exactFund, initialBalance, "Initial balance should be 401 TRUF")
+		require.Equal(t, exactFund, initialBalance, "Initial balance should be 430 TRUF")
 
 		// Create streams (costs 100 + 300 = 400 TRUF total)
 		composedStreamId := util.GenerateStreamId("taxonomy_multi_composed")
@@ -257,12 +259,12 @@ func testTaxonomyMultipleChildrenChargesFlatFee(t *testing.T) func(ctx context.C
 			require.NoError(t, err, "failed to create child stream")
 		}
 
-		// Balance after stream creation should be 1 TRUF (401 - 400)
+		// Balance after stream creation should be 30 TRUF (430 - 400)
 		balanceAfterStreams, err := getBalance(ctx, platform, multiAddr.Address())
 		require.NoError(t, err, "failed to get balance after stream creation")
-		require.Equal(t, oneTRUFTaxonomy, balanceAfterStreams, "Balance should be 1 TRUF after creating streams")
+		require.Equal(t, threeChildTaxonomyFee, balanceAfterStreams, "Balance should be 30 TRUF after creating streams")
 
-		// Insert taxonomy with 3 children — must still charge exactly 1 TRUF.
+		// Insert taxonomy with 3 children — must charge exactly 3 × 10 = 30 TRUF.
 		err = insertTaxonomy(ctx, platform, multiAddr,
 			multiAddr.Address(), composedStreamId.String(),
 			[]string{multiAddr.Address(), multiAddr.Address(), multiAddr.Address()},
@@ -271,11 +273,11 @@ func testTaxonomyMultipleChildrenChargesFlatFee(t *testing.T) func(ctx context.C
 			nil)
 		require.NoError(t, err, "taxonomy insertion should succeed")
 
-		// Verify balance is now 0 — 3-child taxonomy charged only 1 TRUF (flat).
+		// Verify balance is now 0 — the 3-child taxonomy charged 30 TRUF.
 		finalBalance, err := getBalance(ctx, platform, multiAddr.Address())
 		require.NoError(t, err, "failed to get final balance")
 
-		require.Equal(t, big.NewInt(0), finalBalance, "Final balance should be 0 — taxonomy fee is flat 1 TRUF regardless of child count")
+		require.Equal(t, big.NewInt(0), finalBalance, "Final balance should be 0 — taxonomy fee is 10 TRUF per child, so 3 children cost 30 TRUF")
 
 		return nil
 	}
@@ -284,7 +286,7 @@ func testTaxonomyMultipleChildrenChargesFlatFee(t *testing.T) func(ctx context.C
 // Test 5: A wallet with no fee-related role membership still pays the
 // insert_taxonomy fee. Regression check that the phased-rollout exemption
 // has been removed (issue #3805 universal charging) — after two 100-TRUF
-// stream creates, the 1-TRUF taxonomy fee is charged like everybody else.
+// stream creates, the 10-TRUF per-child taxonomy fee is charged like everybody else.
 func testTaxonomyUnenrolledWalletStillPaysFee(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
 	return func(ctx context.Context, platform *kwilTesting.Platform) error {
 		userAddrVal := util.Unsafe_NewEthereumAddressFromString("0x6555555555555555555555555555555555555555")
@@ -293,9 +295,9 @@ func testTaxonomyUnenrolledWalletStillPaysFee(t *testing.T) func(ctx context.Con
 		err := setup.CreateDataProviderWithoutRole(ctx, platform, userAddr.Address())
 		require.NoError(t, err, "failed to create data provider without role")
 
-		// Fund exactly 201 TRUF: 100 (composed) + 100 (child) + 1 (taxonomy).
+		// Fund exactly 210 TRUF: 100 (composed) + 100 (child) + 10 (1-child taxonomy).
 		// No fee-related role membership — the taxonomy fee applies anyway.
-		err = giveBalance(ctx, platform, userAddr.Address(), "201000000000000000000")
+		err = giveBalance(ctx, platform, userAddr.Address(), "210000000000000000000")
 		require.NoError(t, err, "failed to give balance")
 
 		composedStreamId := util.GenerateStreamId("taxonomy_unenrolled_composed")
@@ -307,12 +309,12 @@ func testTaxonomyUnenrolledWalletStillPaysFee(t *testing.T) func(ctx context.Con
 		err = createStream(ctx, platform, userAddr, childStreamId.String(), "primitive")
 		require.NoError(t, err, "failed to create child stream")
 
-		// After 2 stream creations (200 TRUF spent), balance should be 1 TRUF.
+		// After 2 stream creations (200 TRUF spent), balance should be 10 TRUF.
 		balanceAfterStreams, err := getBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err, "failed to get balance after stream creation")
-		require.Equal(t, oneTRUFTaxonomy, balanceAfterStreams, "Balance should be 1 TRUF after creating streams")
+		require.Equal(t, taxonomyFeePerChild, balanceAfterStreams, "Balance should be 10 TRUF after creating streams")
 
-		// Taxonomy insertion is charged the universal 1 TRUF — no exemption.
+		// Taxonomy insertion is charged the universal per-child fee — no exemption.
 		err = insertTaxonomy(ctx, platform, userAddr,
 			userAddr.Address(), composedStreamId.String(),
 			[]string{userAddr.Address()},
@@ -323,7 +325,61 @@ func testTaxonomyUnenrolledWalletStillPaysFee(t *testing.T) func(ctx context.Con
 
 		finalBalance, err := getBalance(ctx, platform, userAddr.Address())
 		require.NoError(t, err, "failed to get final balance")
-		require.Equal(t, big.NewInt(0), finalBalance, "un-enrolled wallet must pay the 1 TRUF taxonomy fee — exemption removed")
+		require.Equal(t, big.NewInt(0), finalBalance, "un-enrolled wallet must pay the 10 TRUF taxonomy fee — exemption removed")
+
+		return nil
+	}
+}
+
+// Test 6: A wallet funded for a 1-child taxonomy cannot afford a 2-child one.
+// The balance is non-zero, so this exercises the partial-funding rejection path
+// rather than the zero-balance one in Test 3 — and it fails only if the fee
+// actually multiplies by child count. Under a flat per-tx fee the insert would
+// succeed.
+func testTaxonomyPartialBalanceRejectsExtraChild(t *testing.T) func(ctx context.Context, platform *kwilTesting.Platform) error {
+	return func(ctx context.Context, platform *kwilTesting.Platform) error {
+		partialAddrVal := util.Unsafe_NewEthereumAddressFromString("0x7666666666666666666666666666666666666666")
+		partialAddr := &partialAddrVal
+
+		err := setup.CreateDataProviderWithoutRole(ctx, platform, partialAddr.Address())
+		require.NoError(t, err, "failed to create data provider without role")
+
+		// Fund 310 TRUF: 300 for three stream creates, then exactly 10 left —
+		// enough for one child, not the two the taxonomy attaches.
+		err = giveBalance(ctx, platform, partialAddr.Address(), "310000000000000000000")
+		require.NoError(t, err, "failed to give balance")
+
+		composedStreamId := util.GenerateStreamId("taxonomy_partial_composed")
+		child1StreamId := util.GenerateStreamId("taxonomy_partial_child1")
+		child2StreamId := util.GenerateStreamId("taxonomy_partial_child2")
+
+		err = createStream(ctx, platform, partialAddr, composedStreamId.String(), "composed")
+		require.NoError(t, err, "failed to create composed stream")
+
+		for _, childId := range []util.StreamId{child1StreamId, child2StreamId} {
+			err = createStream(ctx, platform, partialAddr, childId.String(), "primitive")
+			require.NoError(t, err, "failed to create child stream")
+		}
+
+		balanceAfterStreams, err := getBalance(ctx, platform, partialAddr.Address())
+		require.NoError(t, err, "failed to get balance after stream creation")
+		require.Equal(t, taxonomyFeePerChild, balanceAfterStreams, "Balance should be 10 TRUF after creating streams")
+
+		// 2 children → 20 TRUF required, only 10 held.
+		err = insertTaxonomy(ctx, platform, partialAddr,
+			partialAddr.Address(), composedStreamId.String(),
+			[]string{partialAddr.Address(), partialAddr.Address()},
+			[]string{child1StreamId.String(), child2StreamId.String()},
+			[]string{"0.5", "0.5"},
+			nil)
+
+		require.Error(t, err, "a 2-child taxonomy must be rejected when only one child's fee is held")
+		require.Contains(t, err.Error(), "Insufficient balance for taxonomies creation", "Error should mention insufficient balance")
+
+		// The rejected call must not have taken the caller's TRUF.
+		finalBalance, err := getBalance(ctx, platform, partialAddr.Address())
+		require.NoError(t, err, "failed to get final balance")
+		require.Equal(t, taxonomyFeePerChild, finalBalance, "a rejected taxonomy must leave the balance untouched")
 
 		return nil
 	}

--- a/tests/streams/transaction_events_ledger_test.go
+++ b/tests/streams/transaction_events_ledger_test.go
@@ -38,8 +38,11 @@ const (
 	ledgerERC20          = "0x2222222222222222222222222222222222222222"
 	ledgerExtensionAlias = "sepolia_bridge"
 
-	feeHalfTRUF  = "500000000000000000"
-	feeOneTRUF   = "1000000000000000000"
+	feeHalfTRUF = "500000000000000000"
+	feeOneTRUF  = "1000000000000000000"
+	// feeTenTRUF mirrors insert_taxonomy charging 10 TRUF × N children
+	// (issue #3972); this test sets a taxonomy with 1 child → 10 TRUF.
+	feeTenTRUF   = "10000000000000000000"
 	feeFortyTRUF = "40000000000000000000"
 	// feeTwoHundredTRUF mirrors create_streams charging 100 TRUF × N streams
 	// (issue #3971); this test creates 2 streams in one tx → 200 TRUF.
@@ -95,15 +98,16 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 		// The write-fee actions (create_streams / insert_records /
 		// insert_taxonomy / request_attestation) charge against `hoodi_tt`,
 		// not `sepolia_bridge`. create_streams is now 100 TRUF per stream
-		// (#3971); this test creates 2 streams, inserts 1 record, sets a
-		// taxonomy, and requests an attestation. Fund 500 TRUF to cover
-		// 200 + 1 + 1 + 40 with headroom for future ledger assertions.
+		// (#3971) and insert_taxonomy 10 TRUF per child (#3972); this test
+		// creates 2 streams, inserts 1 record, sets a 1-child taxonomy, and
+		// requests an attestation. Fund 500 TRUF to cover 200 + 1 + 10 + 40
+		// with headroom for future ledger assertions.
 		require.NoError(t, feefund.EnsureWalletFunded(ctx, platform, actor.Address(), "500000000000000000000"),
 			"fund actor on hoodi_tt for write fees")
-		// create_streams (100 TRUF/stream, #3971), insert_records and
-		// insert_taxonomy (flat 1 TRUF/tx, #3805) all charge every caller
-		// universally now — no role enrollment needed for the ledger test's
-		// fee rows to fire.
+		// create_streams (100 TRUF/stream, #3971), insert_records (flat
+		// 1 TRUF/tx, #3805) and insert_taxonomy (10 TRUF/child, #3972) all
+		// charge every caller universally now — no role enrollment needed for
+		// the ledger test's fee rows to fire.
 
 		receiverVal := util.Unsafe_NewEthereumAddressFromString("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
 		receiver := &receiverVal
@@ -284,10 +288,10 @@ func runTransactionEventsLedgerScenario(t *testing.T) func(ctx context.Context, 
 			},
 			taxTx: {
 				method:       "setTaxonomies",
-				fee:          feeOneTRUF, // flat 1 TRUF regardless of child count
+				fee:          feeTenTRUF, // 10 TRUF × 1 child (#3972)
 				feeRecipient: taxLeaderAddr,
 				feeDistributions: []string{
-					buildDistribution(taxLeaderAddr, feeOneTRUF),
+					buildDistribution(taxLeaderAddr, feeTenTRUF),
 				},
 				assertMetadata: assertNoMetadata,
 			},
@@ -781,8 +785,9 @@ func runTransactionIDTrackingScenario(t *testing.T) func(ctx context.Context, pl
 		require.NoError(t, setup.CreateDataProviderWithoutRole(ctx, platform, actor.Address()))
 		require.NoError(t, ledgerGiveBalance(ctx, platform, actor.Address(), initialUserFunds))
 		// Write-fee actions charge against `hoodi_tt`; fund that bridge too.
-		// create_streams is now 100 TRUF per stream (#3971) — this test
-		// creates 2 streams + inserts records. 300 TRUF gives headroom.
+		// create_streams is 100 TRUF per stream (#3971) and insert_taxonomy
+		// 10 TRUF per child (#3972) — this test creates 2 streams, inserts
+		// records, and sets a 1-child taxonomy. 300 TRUF gives headroom.
 		require.NoError(t, feefund.EnsureWalletFunded(ctx, platform, actor.Address(), "300000000000000000000"),
 			"fund actor on hoodi_tt for write fees")
 

--- a/tests/streams/utils/feefund/feefund_default.go
+++ b/tests/streams/utils/feefund/feefund_default.go
@@ -14,9 +14,10 @@ import (
 
 // Constants kept identical to feefund_kwiltest.go so callers compile uniformly.
 const (
-	WriteFeeWei          = "1000000000000000000"   // 1 TRUF (flat per-tx write fee on insert_records / insert_taxonomy)
-	StreamCreationFeeWei = "100000000000000000000" // 100 TRUF per stream (create_streams; issue #3971)
-	AttestationFeeWei    = "40000000000000000000"  // 40 TRUF
+	WriteFeeWei            = "1000000000000000000"   // 1 TRUF (flat per-tx write fee on insert_records)
+	StreamCreationFeeWei   = "100000000000000000000" // 100 TRUF per stream (create_streams; issue #3971)
+	TaxonomyFeePerChildWei = "10000000000000000000"  // 10 TRUF per child stream (insert_taxonomy; issue #3972)
+	AttestationFeeWei      = "40000000000000000000"  // 40 TRUF
 )
 
 // EnsureWalletFunded is a no-op outside the kwiltest build. Non-kwiltest callers

--- a/tests/streams/utils/feefund/feefund_kwiltest.go
+++ b/tests/streams/utils/feefund/feefund_kwiltest.go
@@ -24,9 +24,8 @@ import (
 // in sync with on-chain charges. If a migration changes its fee, update here.
 const (
 	// WriteFeeWei mirrors the flat per-transaction write fee charged by
-	// 003-primitive-insertion.sql `insert_records` and
-	// 004-composed-taxonomy.sql `insert_taxonomy` — independent of batch
-	// size (1 TRUF regardless of records/children).
+	// 003-primitive-insertion.sql `insert_records` — independent of batch
+	// size (1 TRUF regardless of how many records are in the batch).
 	WriteFeeWei = "1000000000000000000" // 1 TRUF
 
 	// StreamCreationFeeWei mirrors the per-stream fee charged by
@@ -34,6 +33,13 @@ const (
 	// scales with array_length($stream_ids): a batch of N streams costs
 	// N × StreamCreationFeeWei. No role exemption — every caller pays.
 	StreamCreationFeeWei = "100000000000000000000" // 100 TRUF per stream
+
+	// TaxonomyFeePerChildWei mirrors the per-child fee charged by
+	// 004-composed-taxonomy.sql `insert_taxonomy`. Per issue #3972 the fee
+	// scales with array_length($child_stream_ids): a taxonomy attaching N
+	// children costs N × TaxonomyFeePerChildWei, not a flat per-tx fee.
+	// No role exemption — every caller pays.
+	TaxonomyFeePerChildWei = "10000000000000000000" // 10 TRUF per child stream
 
 	// AttestationFeeWei mirrors the flat fee in 024-attestation-actions.sql.
 	AttestationFeeWei = "40000000000000000000" // 40 TRUF

--- a/tests/streams/utils/procedure/execute.go
+++ b/tests/streams/utils/procedure/execute.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -434,9 +435,12 @@ func SetTaxonomy(ctx context.Context, input SetTaxonomyInput) error {
 		weightDecimals = append(weightDecimals, valueDecimal)
 	}
 
-	// insert_taxonomy charges a flat 1 TRUF per call regardless of child
-	// count, so fund a single feefund.WriteFeeWei before invoking it.
-	if err := feefund.EnsureWalletFunded(ctx, input.Platform, deployer.Address(), feefund.WriteFeeWei); err != nil {
+	// insert_taxonomy charges 10 TRUF per child stream (004-composed-taxonomy.sql,
+	// issue #3972), so fund N × per-child fee before invoking it.
+	totalTaxonomyFee := new(big.Int)
+	totalTaxonomyFee.SetString(feefund.TaxonomyFeePerChildWei, 10)
+	totalTaxonomyFee.Mul(totalTaxonomyFee, big.NewInt(int64(len(primitiveStreamStrings))))
+	if err := feefund.EnsureWalletFunded(ctx, input.Platform, deployer.Address(), totalTaxonomyFee.String()); err != nil {
 		return errors.Wrap(err, "fund deployer for insert_taxonomy fee")
 	}
 


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3972

## What changes

`insert_taxonomy` (004) now charges **10 TRUF per child stream** instead of a flat 1 TRUF per transaction. Per-transaction pricing let one caller attach an arbitrary number of children for the price of one, so the cost of a taxonomy no longer tracks what it actually adds — each child is a permanent `taxonomies` row that every composed read walks.

```sql
$per_child_fee NUMERIC(78, 0) := '10000000000000000000'::NUMERIC(78, 0); -- 10 TRUF (10^19)
$total_fee NUMERIC(78, 0) := $per_child_fee * $num_children::NUMERIC(78, 0);
```

This restores the multiplier shape that `create_streams` (001) already uses for its per-stream fee, at the 10 TRUF figure agreed on the issue. The literal is quoted because 10^19 exceeds int64 — the same reason `001` quotes its 10^20.

The insufficient-balance message changes from `Required: 1 TRUF` to `Required: 10 TRUF per child stream`, matching `001`'s `Required: 100 TRUF per stream`.

The dev `*.sql` source was edited and the mainnet override regenerated with `scripts/generate_prod_migrations.py` (`hoodi_tt` → `eth_truf`); the other 13 generator targets regenerate byte-identically, so only `004-composed-taxonomy.prod.sql` changes. Both files pass `kwil-cli utils parse`.

No cap on `$num_children` is added. Pricing bounds the abuse on its own — `max_req_size` already caps a transaction near 40,000 children, which is 400,000 TRUF at this rate — and picking a cap value would reject legitimate large taxonomies with no migration path.

## Tests

`feefund.TaxonomyFeePerChildWei` is the single source of the fee for the test tree, and every expectation derives from it, so the migration and the tests cannot drift apart.

- `taxonomy_fee_test.go`: all five existing cases re-costed; `testTaxonomyMultipleChildrenChargesFlatFee` becomes `...ChargesPerChildFee` and now funds exactly `100 + 300 + 30` so a regression back to a flat fee leaves 29 TRUF and fails.
- New `testTaxonomyPartialBalanceRejectsExtraChild`: a wallet holding exactly one child's fee attaches two children. This is the rejection path with a **non-zero** balance, which the existing insufficient-balance case (which drains to zero) does not exercise, and it asserts the rejected call left the balance untouched.
- `transaction_events_ledger_test.go`: the `setTaxonomies` ledger row and its fee distribution now assert 10 TRUF for a 1-child taxonomy.
- `utils/procedure/execute.go`: `SetTaxonomy` — the shared helper ~40 tests fund through — now credits N × per-child instead of a flat 1 TRUF.

Suites run and passing: `TestTaxonomyFees`, the three transaction-ledger suites, the composed/taxonomy consumers (`TestComposed`, `TestTaxonomyQueryActions`, `TestMultiLevelComposedStreams`, `TestGamefiIndex`, `TestTruflationComposedFrozen`, `TestComprehensivePathIndependenceWithSharedPrimitive`), plus the full `aggregation` and `auth` packages.

## Rollout notes (consensus-critical)

1. Apply the regenerated `004-composed-taxonomy.prod.sql` via `kwil-cli exec-sql` (after `erc20-bridge/000-extension.prod.sql`, so `eth_truf` exists). It is a `CREATE OR REPLACE ACTION` on that one action — no fleet upgrade, no restart.
2. Impact on current traffic is small: mainnet has 9 `setTaxonomies` events in total, 3 of them fee-bearing, and the largest taxonomy group is 30 children — so the worst single call becomes 300 TRUF. No refill-bot threshold needs changing.
3. `insert_taxonomy` has no internal on-chain callers and no SDK hardcodes the fee, so only external data providers setting taxonomies are affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Taxonomy creation fees now scale at 10 TRUF per child stream instead of a flat 1 TRUF fee.
  * Insufficient-balance errors now report the required per-child fee.
  * Taxonomy creation rejects partial funding without deducting funds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->